### PR TITLE
Update build.cmd to make it work for WS2019

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -208,6 +208,7 @@ for %%F in (%extension_src_path%\*.cmd) do (
 xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
 
 echo ======= copy e2e test project to Package folder
+echo xcopy /Y /S /C /Q %out_dir%\e2etest\ %out_package_dir%\e2etest\
 xcopy /Y /S /C /Q %out_dir%\e2etest\ %out_package_dir%\e2etest\
 
 echo ======= run binskim command

--- a/build.cmd
+++ b/build.cmd
@@ -39,7 +39,7 @@ if not exist "%out_path%" (md "%out_path%")
 if not exist "%out_dir%" (md "%out_dir%")
 
 echo ======= Prepare out-package folder structure
-SET out_package_dir="%out_dir%"\package
+SET out_package_dir=%out_dir%\package
 if not exist "%out_package_dir%" (md "%out_package_dir%")
 SET out_package_proxyagent_dir="%out_package_dir%"\ProxyAgent
 if not exist "%out_package_proxyagent_dir%" (md "%out_package_proxyagent_dir%")
@@ -197,7 +197,7 @@ xcopy /Y %out_dir%\GuestProxyAgent.json %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\EbpfApi.dll %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\EbpfApi.pdb %out_package_proxyagent_dir%\
 
-SET out_package_proxyagent_extension_dir="%out_package_dir%"\ProxyAgent_Extension
+SET out_package_proxyagent_extension_dir=%out_package_dir%\ProxyAgent_Extension
 if not exist "%out_package_proxyagent_extension_dir%" (md "%out_package_proxyagent_extension_dir%")
 echo ======= copy ProxyAgent Extension files
 xcopy /Y %extension_src_path%\HandlerManifest.json %out_package_proxyagent_extension_dir%\

--- a/build.cmd
+++ b/build.cmd
@@ -178,13 +178,14 @@ if  %ERRORLEVEL% NEQ 0 (
 )
 
 echo ======= build e2e test project
-echo call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_dir%\e2etest
-call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_dir%\e2etest
+SET out_e2etest_dir=%out_dir%\e2etest
+echo call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_e2etest_dir%
+call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_e2etest_dir%
 if  %ERRORLEVEL% NEQ 0 (
     echo call dotnet.exe build failed with exit-code: %errorlevel%
     exit /b %errorlevel%
 )
-dir /S /B %out_dir%\e2etest\
+dir /S /B %out_e2etest_dir%\
 
 echo ======= copy setup tool to Package folder
 xcopy /Y %out_dir%\proxy_agent_setup.exe %out_package_dir%\
@@ -208,8 +209,9 @@ for %%F in (%extension_src_path%\*.cmd) do (
 xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
 
 echo ======= copy e2e test project to Package folder
-echo xcopy /Y /S /C /Q %out_dir%\e2etest\ %out_package_dir%\e2etest\
-xcopy /Y /S /C /Q %out_dir%\e2etest\ %out_package_dir%\e2etest\
+SET out_package_e2etest_dir=%out_package_dir%\e2etest
+echo xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
+xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
 
 echo ======= run binskim command
 call %bin_skim_path%\BinSkim.exe analyze %out_package_proxyagent_dir%\GuestProxyAgent.exe --output %out_package_proxyagent_dir%\GuestProxyAgent.exe.binskim.json --rich-return-code=true --force

--- a/build.cmd
+++ b/build.cmd
@@ -210,8 +210,7 @@ xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
 
 echo ======= copy e2e test project to Package folder
 SET out_package_e2etest_dir=%out_package_dir%\e2etest
-if not exist "%out_package_e2etest_dir%" (md "%out_package_e2etest_dir%")
-echo xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
+echo xcopy /Y /S /C /Q %out_e2etest_dir% %out_package_e2etest_dir%\
 xcopy /Y /S /C /Q %out_e2etest_dir% %out_package_e2etest_dir%\
 
 echo ======= run binskim command

--- a/build.cmd
+++ b/build.cmd
@@ -184,6 +184,7 @@ if  %ERRORLEVEL% NEQ 0 (
     echo call dotnet.exe build failed with exit-code: %errorlevel%
     exit /b %errorlevel%
 )
+dir /S /B %out_dir%\e2etest\
 
 echo ======= copy setup tool to Package folder
 xcopy /Y %out_dir%\proxy_agent_setup.exe %out_package_dir%\
@@ -198,7 +199,7 @@ xcopy /Y %out_dir%\EbpfApi.pdb %out_package_proxyagent_dir%\
 
 SET out_package_proxyagent_extension_dir="%out_package_dir%"\ProxyAgent_Extension
 if not exist "%out_package_proxyagent_extension_dir%" (md "%out_package_proxyagent_extension_dir%")
-echo ======= copy cmd files
+echo ======= copy ProxyAgent Extension files
 xcopy /Y %extension_src_path%\HandlerManifest.json %out_package_proxyagent_extension_dir%\
 for %%F in (%extension_src_path%\*.cmd) do (
     echo Found file: %%F

--- a/build.cmd
+++ b/build.cmd
@@ -210,6 +210,7 @@ xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
 
 echo ======= copy e2e test project to Package folder
 SET out_package_e2etest_dir=%out_package_dir%\e2etest
+if not exist "%out_package_e2etest_dir%" (md "%out_package_e2etest_dir%")
 echo xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
 xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
 

--- a/build.cmd
+++ b/build.cmd
@@ -3,6 +3,7 @@ SET root_path=%~dp0
 SET out_path=%root_path%out
 set Configuration=%1
 set CleanBuild=%2
+set ContinueAtConvertBpfToNative=%3
 if "%Configuration%"=="" (SET Configuration=debug)
 echo Configuration=%Configuration%
 echo out_path=%out_path%
@@ -63,7 +64,10 @@ echo call powershell.exe %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -Ou
 call powershell.exe %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir %out_dir% -FileName redirect.bpf.o -IncludeDir %eBPF_for_Windows_inc_path%
 if  %ERRORLEVEL% NEQ 0 (
     echo call Convert-BpfToNative.ps1 failed with exit-code: %errorlevel%
-    exit /b %errorlevel%
+    if "%ContinueAtConvertBpfToNative%"=="" (
+        exit /b %errorlevel%
+    )
+    echo Skip the error and continue to build other projects
 )
 REM copy redirect.bpf.sys
 xcopy /Y %out_dir%\redirect.bpf.sys %out_package_proxyagent_dir%\

--- a/build.cmd
+++ b/build.cmd
@@ -16,7 +16,7 @@ SET rustup_version=1.69.0
 
 
 if "%CleanBuild%"=="clean" (
-    REM delete old files
+    echo ======= delete old files
     echo RD /S /Q %out_dir%
     RD /S /Q %out_dir%
 
@@ -24,30 +24,30 @@ if "%CleanBuild%"=="clean" (
     RD /S /Q %root_path%packages
 )
 
-REM nuget restore
+echo ======= nuget restore
 call nuget restore
 if  %ERRORLEVEL% NEQ 0 (
     echo call nuget restore with exit-code: %errorlevel%
     exit /b %errorlevel%
 )
 
-REM rustup update to a particular version
+echo ======= rustup update to a particular version
 call rustup update %rustup_version%
 
-REM create out path folder and subfolder
+echo ======= create out path folder and subfolder
 if not exist "%out_path%" (md "%out_path%")
 if not exist "%out_dir%" (md "%out_dir%")
 
-REM Prepare out-package folder structure
+echo ======= Prepare out-package folder structure
 SET out_package_dir="%out_dir%"\package
 if not exist "%out_package_dir%" (md "%out_package_dir%")
 SET out_package_proxyagent_dir="%out_package_dir%"\ProxyAgent
 if not exist "%out_package_proxyagent_dir%" (md "%out_package_proxyagent_dir%")
 
-REM copy VB Scripts to Package folder
+echo ======= copy VB Scripts to Package folder
 xcopy /Y %root_path%\Setup\Windows\*.* %out_package_dir%\
 
-REM build ebpf program
+echo ======= build ebpf program
 SET ebpf_path=%root_path%\ebpf
 echo call clang -target bpf -Werror -O2 -c %ebpf_path%\redirect.bpf.c -o %out_dir%\redirect.bpf.o
 call clang -target bpf -Werror -O2 -c %ebpf_path%\redirect.bpf.c -o %out_dir%\redirect.bpf.o
@@ -55,9 +55,9 @@ if  %ERRORLEVEL% NEQ 0 (
     echo call clang failed with exit-code: %errorlevel%
     exit /b %errorlevel%
 )
-REM copy redirect.bpf.o
+echo ======= copy redirect.bpf.o
 xcopy /Y %out_dir%\redirect.bpf.o %out_package_proxyagent_dir%\
-REM convert redirect.bpf.o to redirect.bpf.sys
+echo ======= convert redirect.bpf.o to redirect.bpf.sys
 call %eBPF_for_Windows_bin_path%\export_program_info.exe --clear
 call %eBPF_for_Windows_bin_path%\export_program_info.exe
 echo call powershell.exe %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir %out_dir% -FileName redirect.bpf.o -IncludeDir %eBPF_for_Windows_bin_path%
@@ -69,11 +69,11 @@ if  %ERRORLEVEL% NEQ 0 (
     )
     echo Skip the error and continue to build other projects
 )
-REM copy redirect.bpf.sys
+echo ======= copy redirect.bpf.sys
 xcopy /Y %out_dir%\redirect.bpf.sys %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\redirect.bpf.pdb %out_package_proxyagent_dir%\
 
-REM build proxy_agent_shared
+echo ======= build proxy_agent_shared
 set cargo_toml=%root_path%proxy_agent_shared\Cargo.toml
 SET release_flag=
 if "%Configuration%"=="release" (SET release_flag=--release)
@@ -85,13 +85,13 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM copy files for run/debug proxy_agent_shared Unit test in VS Code
+echo ======= copy files for run/debug proxy_agent_shared Unit test in VS Code
 echo xcopy /Y /C /Q %out_dir% %out_dir%\deps\
 xcopy /Y /C /Q %out_dir% %out_dir%\deps\
 echo xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_shared\target\%Configuration%\
 xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_shared\target\%Configuration%\
 
-REM run rust proxy_agent_shared tests
+echo ======= run rust proxy_agent_shared tests
 echo call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 if  %ERRORLEVEL% NEQ 0 (
@@ -99,11 +99,11 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM copy config file for windows platform
-REM Adding a wildcard (*) to the end of the destination will suppress this prompt and default to copying as a file:
+echo ======= copy config file for windows platform
+echo ======= Adding a wildcard (*) to the end of the destination will suppress this prompt and default to copying as a file:
 xcopy /Y %root_path%proxy_agent\config\GuestProxyAgent.windows.json %out_dir%\GuestProxyAgent.json*
 
-REM build proxy_agent
+echo ======= build proxy_agent
 set cargo_toml=%root_path%proxy_agent\Cargo.toml
 SET release_flag=
 if "%Configuration%"=="release" (SET release_flag=--release)
@@ -115,7 +115,7 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM copy files for run/debug proxy_agent Unit test
+echo ======= copy files for run/debug proxy_agent Unit test
 echo xcopy /Y /C /Q %eBPF_for_Windows_bin_path%\EbpfApi.* %out_dir%\
 xcopy /Y /C /Q %eBPF_for_Windows_bin_path%\EbpfApi.* %out_dir%\
 echo xcopy /Y /C /Q %out_dir% %out_dir%\deps\
@@ -123,7 +123,7 @@ xcopy /Y /C /Q %out_dir% %out_dir%\deps\
 echo xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent\target\%Configuration%\
 xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent\target\%Configuration%\
 
-REM run rust proxy_agent tests
+echo ======= run rust proxy_agent tests
 echo call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 if  %ERRORLEVEL% NEQ 0 (
@@ -131,7 +131,7 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM build proxy_agent_extension
+echo ======= build proxy_agent_extension
 SET extension_root_path=%root_path%proxy_agent_extension
 SET extension_src_path=%root_path%proxy_agent_extension\src\windows
 set cargo_toml=%extension_root_path%\Cargo.toml
@@ -143,13 +143,13 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM copy files for run/debug proxy_agent_extension Unit test
+echo ======= copy files for run/debug proxy_agent_extension Unit test
 echo xcopy /Y /C /Q %out_dir% %out_dir%\deps\
 xcopy /Y /C /Q %out_dir% %out_dir%\deps\
 echo xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_extension\target\%Configuration%\
 xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_extension\target\%Configuration%\
 
-REM run rust proxy_agent_extension tests
+echo ======= run rust proxy_agent_extension tests
 echo call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 call cargo +%rustup_version% test  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% -- --test-threads=1
 if  %ERRORLEVEL% NEQ 0 (
@@ -157,7 +157,7 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM build proxy_agent_setup
+echo ======= build proxy_agent_setup
 set cargo_toml=%root_path%proxy_agent_setup\Cargo.toml
 SET release_flag=
 if "%Configuration%"=="release" (SET release_flag=--release)
@@ -169,7 +169,7 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM restore e2e test project dependencies
+echo ======= restore e2e test project dependencies
 echo call dotnet.exe restore %root_path%\e2etest\GuestProxyAgentTest.sln
 call dotnet.exe restore %root_path%\e2etest\GuestProxyAgentTest.sln
 if  %ERRORLEVEL% NEQ 0 (
@@ -177,7 +177,7 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM build e2e test project
+echo ======= build e2e test project
 echo call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_dir%\e2etest
 call dotnet.exe build %root_path%\e2etest\GuestProxyAgentTest.sln --no-restore --configuration %Configuration% -o %out_dir%\e2etest
 if  %ERRORLEVEL% NEQ 0 (
@@ -185,11 +185,11 @@ if  %ERRORLEVEL% NEQ 0 (
     exit /b %errorlevel%
 )
 
-REM copy setup tool to Package folder
+echo ======= copy setup tool to Package folder
 xcopy /Y %out_dir%\proxy_agent_setup.exe %out_package_dir%\
 xcopy /Y %out_dir%\proxy_agent_setup.pdb %out_package_dir%\
 
-REM copy to ProxyAgent folder
+echo ======= copy to ProxyAgent folder
 xcopy /Y %out_dir%\GuestProxyAgent.exe %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\GuestProxyAgent.pdb %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\GuestProxyAgent.json %out_package_proxyagent_dir%\
@@ -198,7 +198,7 @@ xcopy /Y %out_dir%\EbpfApi.pdb %out_package_proxyagent_dir%\
 
 SET out_package_proxyagent_extension_dir="%out_package_dir%"\ProxyAgent_Extension
 if not exist "%out_package_proxyagent_extension_dir%" (md "%out_package_proxyagent_extension_dir%")
-REM copy cmd files
+echo ======= copy cmd files
 xcopy /Y %extension_src_path%\HandlerManifest.json %out_package_proxyagent_extension_dir%\
 for %%F in (%extension_src_path%\*.cmd) do (
     echo Found file: %%F
@@ -206,11 +206,11 @@ for %%F in (%extension_src_path%\*.cmd) do (
 )
 xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
 
-REM copy e2e test project to Package folder
+echo ======= copy e2e test project to Package folder
 xcopy /Y /S /C /Q %out_dir%\e2etest\ %out_package_dir%\e2etest\
 
-REM run binskim command
+echo ======= run binskim command
 call %bin_skim_path%\BinSkim.exe analyze %out_package_proxyagent_dir%\GuestProxyAgent.exe --output %out_package_proxyagent_dir%\GuestProxyAgent.exe.binskim.json --rich-return-code=true --force
 
-REM Generate build-configuration.zip file
+echo ======= Generate build-configuration.zip file
 call powershell.exe Compress-Archive -Path "%out_package_dir%" -DestinationPath "%out_dir%"\build-%Configuration%-windows-amd64.zip" -Force

--- a/build.cmd
+++ b/build.cmd
@@ -212,7 +212,7 @@ echo ======= copy e2e test project to Package folder
 SET out_package_e2etest_dir=%out_package_dir%\e2etest
 if not exist "%out_package_e2etest_dir%" (md "%out_package_e2etest_dir%")
 echo xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
-xcopy /Y /S /C /Q %out_e2etest_dir%\ %out_package_e2etest_dir%\
+xcopy /Y /S /C /Q %out_e2etest_dir% %out_package_e2etest_dir%\
 
 echo ======= run binskim command
 call %bin_skim_path%\BinSkim.exe analyze %out_package_proxyagent_dir%\GuestProxyAgent.exe --output %out_package_proxyagent_dir%\GuestProxyAgent.exe.binskim.json --rich-return-code=true --force


### PR DESCRIPTION
- add additional parameter ContinueAtConvertBpfToNative to skip sys file generation failure.
- switch REM to echo for more build loggings
- fix xcopy command issue (source folder cannot be end with '\\') at WS2019