### PR TITLE
Init data_vessel model and move key_keeper Key

### DIFF
--- a/proxy_agent/src/data_vessel.rs
+++ b/proxy_agent/src/data_vessel.rs
@@ -15,60 +15,79 @@ pub enum DataAction {
     },
 }
 
-pub fn start_receiver_async() -> Sender<DataAction> {
-    let (sender, receiver) = std::sync::mpsc::channel::<DataAction>();
+#[derive(Clone, Debug)]
+pub struct DataVessel {
+    sender: Sender<DataAction>,
+}
+impl DataVessel {
+    pub fn start_new_async() -> Self {
+        let (sender, receiver) = std::sync::mpsc::channel::<DataAction>();
 
-    std::thread::spawn(move || {
-        // chached data are defined here
-        let mut cached_key: Key = Key::empty();
+        std::thread::spawn(move || {
+            // chached data are defined here
+            let mut cached_key: Key = Key::empty();
 
-        while let Ok(action) = receiver.recv() {
-            match action {
-                DataAction::Stop => {
-                    break;
-                }
-                DataAction::KeyKeeperSetKey { key, response } => {
-                    // Set the key from the key keeper
-                    cached_key = key.clone();
-                    let _ = response.send(true);
-                }
-                DataAction::KeyKeeperGetKeyValue { response } => {
-                    // Get the key from the key keeper
-                    let _ = response.send(cached_key.clone());
+            while let Ok(action) = receiver.recv() {
+                match action {
+                    DataAction::Stop => {
+                        break;
+                    }
+                    DataAction::KeyKeeperSetKey { key, response } => {
+                        // Set the key from the key keeper
+                        cached_key = key.clone();
+                        _ = response.send(true);
+                    }
+                    DataAction::KeyKeeperGetKeyValue { response } => {
+                        // Get the key from the key keeper
+                        _ = response.send(cached_key.clone());
+                    }
                 }
             }
-        }
-    });
+        });
 
-    sender
+        DataVessel { sender }
+    }
+
+    pub fn stop(&self) {
+        let _ = self.sender.send(DataAction::Stop);
+    }
 }
 
-pub mod key_keeper {
-    use crate::data_vessel::DataAction;
-    use crate::key_keeper::key::Key;
-    use std::sync::mpsc::Sender;
-
-    pub fn update_current_key(sender: Sender<DataAction>, key: Key) -> bool {
+impl KeyKeeper for DataVessel {
+    fn update_current_key(&self, key: Key) -> bool {
         let (response, receiver) = std::sync::mpsc::channel::<bool>();
-        let _ = sender.send(DataAction::KeyKeeperSetKey { key, response });
+        let _ = self
+            .sender
+            .send(DataAction::KeyKeeperSetKey { key, response });
         receiver.recv().unwrap_or(false)
     }
 
-    fn get_current_key(sender: Sender<DataAction>) -> Key {
+    fn get_current_key(&self) -> Key {
         let (response, receiver) = std::sync::mpsc::channel::<Key>();
-        let _ = sender.send(DataAction::KeyKeeperGetKeyValue { response });
+        let _ = self
+            .sender
+            .clone()
+            .send(DataAction::KeyKeeperGetKeyValue { response });
         receiver.recv().unwrap_or(Key::empty())
     }
 
-    pub fn get_current_key_value(sender: Sender<DataAction>) -> String {
-        get_current_key(sender).key.to_string()
+    fn get_current_key_value(&self) -> String {
+        self.get_current_key().key.to_string()
     }
 
-    pub fn get_current_key_guid(sender: Sender<DataAction>) -> String {
-        get_current_key(sender).guid.to_string()
+    fn get_current_key_guid(&self) -> String {
+        self.get_current_key().guid.to_string()
     }
 
-    pub fn get_current_key_incarnation(sender: Sender<DataAction>) -> Option<u32> {
-        get_current_key(sender).incarnationId
+    fn get_current_key_incarnation(&self) -> Option<u32> {
+        self.get_current_key().incarnationId
     }
+}
+
+pub trait KeyKeeper {
+    fn update_current_key(&self, key: Key) -> bool;
+    fn get_current_key(&self) -> Key;
+    fn get_current_key_value(&self) -> String;
+    fn get_current_key_guid(&self) -> String;
+    fn get_current_key_incarnation(&self) -> Option<u32>;
 }

--- a/proxy_agent/src/data_vessel.rs
+++ b/proxy_agent/src/data_vessel.rs
@@ -86,11 +86,11 @@ impl DataVessel {
     }
 
     pub fn get_current_key_value(&self) -> String {
-        self.get_current_key().key.to_string()
+        self.get_current_key().key
     }
 
     pub fn get_current_key_guid(&self) -> String {
-        self.get_current_key().guid.to_string()
+        self.get_current_key().guid
     }
 
     pub fn get_current_key_incarnation(&self) -> Option<u32> {

--- a/proxy_agent/src/data_vessel.rs
+++ b/proxy_agent/src/data_vessel.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+use crate::key_keeper::key::Key;
+use std::sync::mpsc::Sender;
+
+pub enum DataAction {
+    Stop,
+    KeyKeeperSetKey {
+        key: Key,
+        response: std::sync::mpsc::Sender<bool>,
+    },
+    KeyKeeperGetKeyValue {
+        response: std::sync::mpsc::Sender<Key>,
+    },
+}
+
+pub fn start_receiver_async() -> Sender<DataAction> {
+    let (sender, receiver) = std::sync::mpsc::channel::<DataAction>();
+
+    std::thread::spawn(move || {
+        // chached data are defined here
+        let mut cached_key: Key = Key::empty();
+
+        while let Ok(action) = receiver.recv() {
+            match action {
+                DataAction::Stop => {
+                    break;
+                }
+                DataAction::KeyKeeperSetKey { key, response } => {
+                    // Set the key from the key keeper
+                    cached_key = key.clone();
+                    let _ = response.send(true);
+                }
+                DataAction::KeyKeeperGetKeyValue { response } => {
+                    // Get the key from the key keeper
+                    let _ = response.send(cached_key.clone());
+                }
+            }
+        }
+    });
+
+    sender
+}
+
+pub mod key_keeper {
+    use crate::data_vessel::DataAction;
+    use crate::key_keeper::key::Key;
+    use std::sync::mpsc::Sender;
+
+    pub fn update_current_key(sender: Sender<DataAction>, key: Key) -> bool {
+        let (response, receiver) = std::sync::mpsc::channel::<bool>();
+        let _ = sender.send(DataAction::KeyKeeperSetKey { key, response });
+        receiver.recv().unwrap_or(false)
+    }
+
+    fn get_current_key(sender: Sender<DataAction>) -> Key {
+        let (response, receiver) = std::sync::mpsc::channel::<Key>();
+        let _ = sender.send(DataAction::KeyKeeperGetKeyValue { response });
+        receiver.recv().unwrap_or(Key::empty())
+    }
+
+    pub fn get_current_key_value(sender: Sender<DataAction>) -> String {
+        get_current_key(sender).key.to_string()
+    }
+
+    pub fn get_current_key_guid(sender: Sender<DataAction>) -> String {
+        get_current_key(sender).guid.to_string()
+    }
+
+    pub fn get_current_key_incarnation(sender: Sender<DataAction>) -> Option<u32> {
+        get_current_key(sender).incarnationId
+    }
+}

--- a/proxy_agent/src/host_clients/imds_client.rs
+++ b/proxy_agent/src/host_clients/imds_client.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: MIT
 use super::instance_info::InstanceInfo;
 use crate::common::http::{self, http_request::HttpRequest, request::Request, response::Response};
-use crate::data_vessel::KeyKeeper;
+use crate::data_vessel::DataVessel;
 use std::io::{Error, ErrorKind};
 use url::Url;
 
-pub struct ImdsClient<T: KeyKeeper> {
+pub struct ImdsClient {
     ip: String,
     port: u16,
-    vessel: T,
+    vessel: DataVessel,
 }
 
-impl<T: KeyKeeper> ImdsClient<T> {
-    pub fn new(ip: &str, port: u16, vessel: T) -> Self {
+impl ImdsClient {
+    pub fn new(ip: &str, port: u16, vessel: DataVessel) -> Self {
         ImdsClient {
             ip: ip.to_string(),
             port,

--- a/proxy_agent/src/host_clients/wire_server_client.rs
+++ b/proxy_agent/src/host_clients/wire_server_client.rs
@@ -3,20 +3,20 @@
 use crate::common::http::{
     self, headers, http_request::HttpRequest, request::Request, response::Response,
 };
-use crate::data_vessel::KeyKeeper;
+use crate::data_vessel::DataVessel;
 use crate::host_clients::goal_state::{GoalState, SharedConfig};
 use std::io::{Error, ErrorKind};
 use std::{io::prelude::*, net::TcpStream};
 use url::{Position, Url};
 
-pub struct WireServerClient<T: KeyKeeper> {
+pub struct WireServerClient {
     ip: String,
     port: u16,
-    vessel: T,
+    vessel: DataVessel,
 }
 
-impl<T: KeyKeeper> WireServerClient<T> {
-    pub fn new(ip: &str, port: u16, vessel: T) -> Self {
+impl WireServerClient {
+    pub fn new(ip: &str, port: u16, vessel: DataVessel) -> Self {
         WireServerClient {
             ip: ip.to_string(),
             port,

--- a/proxy_agent/src/host_clients/wire_server_client.rs
+++ b/proxy_agent/src/host_clients/wire_server_client.rs
@@ -3,25 +3,24 @@
 use crate::common::http::{
     self, headers, http_request::HttpRequest, request::Request, response::Response,
 };
-use crate::data_vessel::key_keeper;
+use crate::data_vessel::KeyKeeper;
 use crate::host_clients::goal_state::{GoalState, SharedConfig};
 use std::io::{Error, ErrorKind};
-use std::sync::mpsc::Sender;
 use std::{io::prelude::*, net::TcpStream};
 use url::{Position, Url};
 
-pub struct WireServerClient {
+pub struct WireServerClient<T: KeyKeeper> {
     ip: String,
     port: u16,
-    sender: Sender<crate::data_vessel::DataAction>,
+    vessel: T,
 }
 
-impl WireServerClient {
-    pub fn new(ip: &str, port: u16, sender: Sender<crate::data_vessel::DataAction>) -> Self {
+impl<T: KeyKeeper> WireServerClient<T> {
+    pub fn new(ip: &str, port: u16, vessel: T) -> Self {
         WireServerClient {
             ip: ip.to_string(),
             port,
-            sender,
+            vessel,
         }
     }
 
@@ -54,8 +53,8 @@ impl WireServerClient {
         let http_request = HttpRequest::new_proxy_agent_request(
             url,
             req,
-            key_keeper::get_current_key_guid(self.sender.clone()),
-            key_keeper::get_current_key_value(self.sender.clone()),
+            self.vessel.get_current_key_guid(),
+            self.vessel.get_current_key_value(),
         )?;
 
         Ok(http_request)

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -29,7 +29,6 @@ const PROVISION_TIMEUP_IN_MILLISECONDS: u128 = 120000; // 2 minute
 const DELAY_START_EVENT_THREADS_IN_MILLISECONDS: u128 = 60000; // 1 minute
 
 static mut CURRENT_SECURE_CHANNEL_STATE: Lazy<String> = Lazy::new(|| String::from(UNKNOWN_STATE)); // state starts from Unknown
-                                                                                                   //static mut CURRENT_KEY: Lazy<Key> = Lazy::new(Key::empty);
 static SHUT_DOWN: Lazy<Arc<AtomicBool>> = Lazy::new(|| Arc::new(AtomicBool::new(false)));
 static mut STATUS_MESSAGE: Lazy<String> =
     Lazy::new(|| String::from("Key latch thread has not started yet."));

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -44,10 +44,10 @@ pub fn poll_status_async(
     key_dir: PathBuf,
     interval: Duration,
     config_start_redirector: bool,
-    sender: std::sync::mpsc::Sender<crate::data_vessel::DataAction>,
+    vessel: data_vessel::DataVessel,
 ) {
     thread::spawn(move || {
-        poll_secure_channel_status(base_url, key_dir, interval, config_start_redirector, sender);
+        poll_secure_channel_status(base_url, key_dir, interval, config_start_redirector, vessel);
     });
 }
 
@@ -57,7 +57,7 @@ fn poll_secure_channel_status(
     key_dir: PathBuf,
     interval: Duration,
     config_start_redirector: bool,
-    sender: std::sync::mpsc::Sender<crate::data_vessel::DataAction>,
+    vessel: data_vessel::DataVessel,
 ) {
     let message = "poll secure channel status thread started.";
     unsafe {
@@ -67,7 +67,7 @@ fn poll_secure_channel_status(
 
     // launch redirector initialization when the key keeper thread is running
     if config_start_redirector {
-        redirector::start_async(constants::PROXY_AGENT_PORT, sender.clone());
+        redirector::start_async(constants::PROXY_AGENT_PORT, vessel.clone());
     }
 
     _ = misc_helpers::try_create_folder(key_dir.to_path_buf());
@@ -96,6 +96,7 @@ fn poll_secure_channel_status(
     let mut started_event_threads: bool = false;
     let mut provision_timeup: bool = false;
     let shutdown = SHUT_DOWN.clone();
+    let key_keeper_vessel: Box<dyn data_vessel::KeyKeeper> = Box::new(vessel.clone());
     loop {
         if shutdown.load(Ordering::Relaxed) {
             let message = "Stop signal received, exiting the poll_secure_channel_status thread.";
@@ -125,14 +126,14 @@ fn poll_secure_channel_status(
         if !provision_timeup
             && helpers::get_elapsed_time_in_millisec() > PROVISION_TIMEUP_IN_MILLISECONDS
         {
-            provision::provision_timeup(None, sender.clone());
+            provision::provision_timeup(None, vessel.clone());
             provision_timeup = true;
         }
 
         if !started_event_threads
             && helpers::get_elapsed_time_in_millisec() > DELAY_START_EVENT_THREADS_IN_MILLISECONDS
         {
-            provision::start_event_threads(sender.clone());
+            provision::start_event_threads(vessel.clone());
             started_event_threads = true;
         }
 
@@ -190,9 +191,7 @@ fn poll_secure_channel_status(
         let state = status.get_secure_channel_state();
 
         // check if need fetch the key
-        if state != DISABLE_STATE
-            && guid != data_vessel::key_keeper::get_current_key_guid(sender.clone())
-        {
+        if state != DISABLE_STATE && guid != key_keeper_vessel.get_current_key_guid() {
             // search the key locally first
             let mut key_found = false;
             if !guid.is_empty() {
@@ -201,10 +200,7 @@ fn poll_secure_channel_status(
                     // read the key details locally and update
                     match misc_helpers::json_read_from_file::<Key>(key_file.to_path_buf()) {
                         Ok(key) => {
-                            data_vessel::key_keeper::update_current_key(
-                                sender.clone(),
-                                key.clone(),
-                            );
+                            key_keeper_vessel.update_current_key(key.clone());
 
                             let message = helpers::write_startup_event(
                                 "Found key details from local and ready to use.",
@@ -217,7 +213,7 @@ fn poll_secure_channel_status(
                             }
                             key_found = true;
 
-                            provision::key_latched(sender.clone());
+                            provision::key_latched(vessel.clone());
                         }
                         Err(e) => {
                             let message = format!("Failed to read latched key details from file: {:?}. Will try acquire the key details from Server.",
@@ -274,10 +270,7 @@ fn poll_secure_channel_status(
                     match key::attest_key(base_url.clone(), &key) {
                         Ok(()) => {
                             // update in memory
-                            data_vessel::key_keeper::update_current_key(
-                                sender.clone(),
-                                key.clone(),
-                            );
+                            key_keeper_vessel.update_current_key(key.clone());
 
                             helpers::write_startup_event(
                                 "Successfully attest the key and ready to use.",
@@ -289,7 +282,7 @@ fn poll_secure_channel_status(
                                 *STATUS_MESSAGE = message.to_string();
                             }
 
-                            provision::key_latched(sender.clone());
+                            provision::key_latched(vessel.clone());
                         }
                         Err(e) => {
                             logger::write_warning(format!("Failed to attest the key: {:?}", e));
@@ -324,7 +317,7 @@ fn poll_secure_channel_status(
                 unsafe {
                     *STATUS_MESSAGE = message.to_string();
                 }
-                provision::key_latched(sender.clone());
+                provision::key_latched(vessel.clone());
             }
         }
     }
@@ -355,9 +348,7 @@ pub fn stop() {
     SHUT_DOWN.store(true, Ordering::Relaxed);
 }
 
-pub fn get_status(
-    sender: std::sync::mpsc::Sender<data_vessel::DataAction>,
-) -> ProxyAgentDetailStatus {
+pub fn get_status(vessel: impl data_vessel::KeyKeeper) -> ProxyAgentDetailStatus {
     let shutdown = SHUT_DOWN.clone();
 
     let status = if shutdown.load(Ordering::Relaxed) {
@@ -369,18 +360,14 @@ pub fn get_status(
     let state_message = unsafe { STATUS_MESSAGE.to_string() };
     let mut states = HashMap::new();
     states.insert("secureChannelState".to_string(), get_secure_channel_state());
-    states.insert(
-        "keyGuid".to_string(),
-        data_vessel::key_keeper::get_current_key_guid(sender.clone()),
-    );
+    states.insert("keyGuid".to_string(), vessel.get_current_key_guid());
     states.insert("wireServerRuleId".to_string(), unsafe {
         WIRESERVER_RULE_ID.to_string()
     });
     states.insert("imdsRuleId".to_string(), unsafe {
         IMDS_RULE_ID.to_string()
     });
-    if let Some(incarnation) = data_vessel::key_keeper::get_current_key_incarnation(sender.clone())
-    {
+    if let Some(incarnation) = vessel.get_current_key_incarnation() {
         states.insert("keyIncarnationId".to_string(), incarnation.to_string());
     }
 
@@ -475,13 +462,13 @@ mod tests {
 
         // start poll_secure_channel_status
         let cloned_keys_dir = keys_dir.to_path_buf();
-        let sender = crate::data_vessel::start_receiver_async();
+        let vessel = crate::data_vessel::DataVessel::start_new_async();
         key_keeper::poll_status_async(
             Url::parse("http://127.0.0.1:8081/").unwrap(),
             cloned_keys_dir,
             Duration::from_millis(10),
             false,
-            sender.clone(),
+            vessel.clone(),
         );
 
         for _ in [0; 5] {
@@ -515,6 +502,6 @@ mod tests {
 
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-        _ = sender.send(crate::data_vessel::DataAction::Stop);
+        vessel.stop();
     }
 }

--- a/proxy_agent/src/main.rs
+++ b/proxy_agent/src/main.rs
@@ -3,6 +3,7 @@
 
 pub mod acl;
 pub mod common;
+pub mod data_vessel;
 pub mod host_clients;
 pub mod key_keeper;
 pub mod monitor;

--- a/proxy_agent/src/proxy/proxy_listener.rs
+++ b/proxy_agent/src/proxy/proxy_listener.rs
@@ -9,7 +9,7 @@ use crate::common::http;
 use crate::common::http::request::Request;
 use crate::common::http::response::Response;
 use crate::common::logger;
-use crate::data_vessel;
+use crate::data_vessel::DataVessel;
 use crate::provision;
 use crate::proxy::proxy_connection::Connection;
 use crate::proxy::proxy_summary::ProxySummary;
@@ -34,7 +34,7 @@ static mut CONNECTION_COUNT: Lazy<Mutex<u128>> = Lazy::new(|| Mutex::new(0));
 static mut STATUS_MESSAGE: Lazy<String> =
     Lazy::new(|| String::from("Proxy listner has not started yet."));
 
-pub fn start_async(port: u16, pool_size: u16, vessel: data_vessel::DataVessel) {
+pub fn start_async(port: u16, pool_size: u16, vessel: DataVessel) {
     _ = thread::Builder::new()
         .name("proxy_listener".to_string())
         .spawn(move || {
@@ -42,7 +42,7 @@ pub fn start_async(port: u16, pool_size: u16, vessel: data_vessel::DataVessel) {
         });
 }
 
-fn start(port: u16, pool_size: u16, vessel: data_vessel::DataVessel) {
+fn start(port: u16, pool_size: u16, vessel: DataVessel) {
     Connection::init_logger(config::get_logs_dir());
 
     let shutdown = SHUT_DOWN.clone();
@@ -131,7 +131,7 @@ pub fn stop(port: u16) {
     logger::write_warning("Sending stop signal.".to_string());
 }
 
-fn handle_connection(connection: &mut Connection, vessel: impl data_vessel::KeyKeeper + Clone) {
+fn handle_connection(connection: &mut Connection, vessel: DataVessel) {
     let stream = &connection.stream;
     Connection::write_information(connection.id, "Received connection.".to_string());
 
@@ -297,7 +297,7 @@ fn handle_connection_with_signature(
     connection: &mut Connection,
     mut request: Request,
     server_stream: &mut TcpStream,
-    vessel: impl data_vessel::KeyKeeper + Clone,
+    vessel: DataVessel,
 ) {
     let client_stream = &connection.stream;
     if request.expect_continue_request() {

--- a/proxy_agent/src/proxy/proxy_listener.rs
+++ b/proxy_agent/src/proxy/proxy_listener.rs
@@ -9,7 +9,7 @@ use crate::common::http;
 use crate::common::http::request::Request;
 use crate::common::http::response::Response;
 use crate::common::logger;
-use crate::data_vessel::key_keeper;
+use crate::data_vessel;
 use crate::provision;
 use crate::proxy::proxy_connection::Connection;
 use crate::proxy::proxy_summary::ProxySummary;
@@ -24,7 +24,6 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 use std::net::{IpAddr, Ipv4Addr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -35,15 +34,15 @@ static mut CONNECTION_COUNT: Lazy<Mutex<u128>> = Lazy::new(|| Mutex::new(0));
 static mut STATUS_MESSAGE: Lazy<String> =
     Lazy::new(|| String::from("Proxy listner has not started yet."));
 
-pub fn start_async(port: u16, pool_size: u16, sender: Sender<crate::data_vessel::DataAction>) {
+pub fn start_async(port: u16, pool_size: u16, vessel: data_vessel::DataVessel) {
     _ = thread::Builder::new()
         .name("proxy_listener".to_string())
         .spawn(move || {
-            start(port, pool_size, sender);
+            start(port, pool_size, vessel);
         });
 }
 
-fn start(port: u16, pool_size: u16, sender: Sender<crate::data_vessel::DataAction>) {
+fn start(port: u16, pool_size: u16, vessel: data_vessel::DataVessel) {
     Connection::init_logger(config::get_logs_dir());
 
     let shutdown = SHUT_DOWN.clone();
@@ -73,7 +72,7 @@ fn start(port: u16, pool_size: u16, sender: Sender<crate::data_vessel::DataActio
     unsafe {
         *STATUS_MESSAGE = message.to_string();
     }
-    provision::listener_started(sender.clone());
+    provision::listener_started(vessel.clone());
 
     let pool = ProxyPool::new(pool_size as usize);
 
@@ -97,7 +96,7 @@ fn start(port: u16, pool_size: u16, sender: Sender<crate::data_vessel::DataActio
 
             connection_count_clone = *connection_count_lock;
         }
-        let cloned_sender = sender.clone();
+        let cloned_vessel = vessel.clone();
         match connection {
             Ok(stream) => {
                 pool.execute(move || {
@@ -109,7 +108,7 @@ fn start(port: u16, pool_size: u16, sender: Sender<crate::data_vessel::DataActio
                         ip: String::new(),
                         port: 0,
                     };
-                    handle_connection(&mut connection, cloned_sender);
+                    handle_connection(&mut connection, cloned_vessel);
                 });
             }
             Err(e) => {
@@ -132,7 +131,7 @@ pub fn stop(port: u16) {
     logger::write_warning("Sending stop signal.".to_string());
 }
 
-fn handle_connection(connection: &mut Connection, sender: Sender<crate::data_vessel::DataAction>) {
+fn handle_connection(connection: &mut Connection, vessel: impl data_vessel::KeyKeeper + Clone) {
     let stream = &connection.stream;
     Connection::write_information(connection.id, "Received connection.".to_string());
 
@@ -291,14 +290,14 @@ fn handle_connection(connection: &mut Connection, sender: Sender<crate::data_ves
         return handle_connection_without_signature(connection, request, &mut server_stream);
     }
 
-    handle_connection_with_signature(connection, request, &mut server_stream, sender.clone());
+    handle_connection_with_signature(connection, request, &mut server_stream, vessel.clone());
 }
 
 fn handle_connection_with_signature(
     connection: &mut Connection,
     mut request: Request,
     server_stream: &mut TcpStream,
-    sender: Sender<crate::data_vessel::DataAction>,
+    vessel: impl data_vessel::KeyKeeper + Clone,
 ) {
     let client_stream = &connection.stream;
     if request.expect_continue_request() {
@@ -306,7 +305,7 @@ fn handle_connection_with_signature(
     }
 
     // Add header x-ms-azure-host-authorization
-    let key = key_keeper::get_current_key_value(sender.clone());
+    let key = vessel.get_current_key_value();
     if !key.is_empty() {
         let input_to_sign = request.as_sig_input();
         match helpers::compute_signature(key.to_string(), input_to_sign.as_slice()) {
@@ -327,7 +326,7 @@ fn handle_connection_with_signature(
                 let authorization_value = format!(
                     "{} {} {}",
                     constants::AUTHORIZATION_SCHEME,
-                    key_keeper::get_current_key_guid(sender.clone()),
+                    vessel.get_current_key_guid(),
                     sig
                 );
                 request.headers.add_header(
@@ -613,7 +612,7 @@ fn send_response(mut client_stream: &TcpStream, status: &str) {
     _ = client_stream.flush();
 }
 
-pub fn get_status(_sender: Sender<crate::data_vessel::DataAction>) -> ProxyAgentDetailStatus {
+pub fn get_status() -> ProxyAgentDetailStatus {
     let shutdown = SHUT_DOWN.clone();
 
     let status = if shutdown.load(Ordering::Relaxed) {
@@ -667,8 +666,8 @@ mod tests {
         Connection::init_logger(temp_test_path.to_path_buf());
 
         // start listener, the port must different from the one used in production code
-        let sender = crate::data_vessel::start_receiver_async();
-        let s = sender.clone();
+        let vessel = crate::data_vessel::DataVessel::start_new_async();
+        let s = vessel.clone();
         let port: u16 = 8091;
         let handle = thread::spawn(move || {
             proxy_listener::start(port, 1, s);
@@ -699,7 +698,7 @@ mod tests {
 
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(temp_test_path);
-        _ = sender.send(crate::data_vessel::DataAction::Stop);
+        vessel.stop();
     }
 
     const PROXY_ENDPOINT_ADDRESS: &str = "127.0.0.1:8083";
@@ -855,14 +854,14 @@ mod tests {
             );
         }
 
-        let sender = crate::data_vessel::start_receiver_async();
+        let vessel = crate::data_vessel::DataVessel::start_new_async();
         super::handle_connection_with_signature(
             connection,
             request,
             &mut server_stream,
-            sender.clone(),
+            vessel.clone(),
         );
-        _ = sender.send(crate::data_vessel::DataAction::Stop);
+        vessel.stop();
     }
 
     fn test_get_response() {

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -15,6 +15,7 @@ use proxy_agent_shared::telemetry::event_logger;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -25,15 +26,15 @@ static mut SUMMARY_MAP: Lazy<Mutex<HashMap<String, ProxyConnectionSummary>>> =
 static mut FAILED_AUTHENTICATE_SUMMARY_MAP: Lazy<Mutex<HashMap<String, ProxyConnectionSummary>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
-pub fn start_async(interval: Duration) {
+pub fn start_async(interval: Duration, sender: Sender<crate::data_vessel::DataAction>) {
     _ = thread::Builder::new()
         .name("guest_proxy_agent_status".to_string())
         .spawn(move || {
-            start(interval);
+            start(interval, sender);
         });
 }
 
-fn start(mut interval: Duration) {
+fn start(mut interval: Duration, sender: Sender<crate::data_vessel::DataAction>) {
     let shutdown = SHUT_DOWN.clone();
     if interval == Duration::default() {
         interval = Duration::from_secs(60); // update status every 1 minute
@@ -53,7 +54,7 @@ fn start(mut interval: Duration) {
             break;
         }
 
-        let aggregate_status = guest_proxy_agent_aggregate_status_new();
+        let aggregate_status = guest_proxy_agent_aggregate_status_new(sender.clone());
 
         if let Err(e) = write_aggregate_status_to_file(dir_path.clone(), aggregate_status) {
             logger::write_error(format!("Error writing aggregate status to file: {}", e));
@@ -80,10 +81,10 @@ fn start(mut interval: Duration) {
     }
 }
 
-pub fn proxy_agent_status_new() -> ProxyAgentStatus {
-    let key_latch_status = key_keeper::get_status();
-    let ebpf_status = redirector::get_status();
-    let proxy_status = proxy_listener::get_status();
+pub fn proxy_agent_status_new(sender: Sender<crate::data_vessel::DataAction>) -> ProxyAgentStatus {
+    let key_latch_status = key_keeper::get_status(sender.clone());
+    let ebpf_status = redirector::get_status(sender.clone());
+    let proxy_status = proxy_listener::get_status(sender.clone());
     let mut status = OveralState::SUCCESS.to_string();
     if key_latch_status.status != ModuleState::RUNNING
         || ebpf_status.status != ModuleState::RUNNING
@@ -119,10 +120,12 @@ pub fn increase_count(connection_summary: &mut ProxyConnectionSummary) {
     connection_summary.count += 1;
 }
 
-pub fn guest_proxy_agent_aggregate_status_new() -> GuestProxyAgentAggregateStatus {
+pub fn guest_proxy_agent_aggregate_status_new(
+    sender: Sender<crate::data_vessel::DataAction>,
+) -> GuestProxyAgentAggregateStatus {
     GuestProxyAgentAggregateStatus {
         timestamp: misc_helpers::get_date_time_string_with_miliseconds(),
-        proxyAgentStatus: proxy_agent_status_new(),
+        proxyAgentStatus: proxy_agent_status_new(sender.clone()),
         proxyConnectionSummary: get_all_connection_summary(false),
         failedAuthenticateSummary: get_all_connection_summary(true),
     }
@@ -186,8 +189,8 @@ mod tests {
         temp_test_path.push("write_aggregate_status_test");
         _ = fs::remove_dir_all(&temp_test_path);
         misc_helpers::try_create_folder(temp_test_path.clone()).unwrap();
-
-        let aggregate_status = guest_proxy_agent_aggregate_status_new();
+        let sender = crate::data_vessel::start_receiver_async();
+        let aggregate_status = guest_proxy_agent_aggregate_status_new(sender.clone());
 
         _ = write_aggregate_status_to_file(temp_test_path.clone(), aggregate_status);
 
@@ -214,5 +217,7 @@ mod tests {
                 || !gpa_aggregate_status.proxyConnectionSummary.is_empty(),
             "proxyConnectionSummary does not exist"
         );
+
+        _ = sender.send(crate::data_vessel::DataAction::Stop);
     }
 }

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use crate::common::{config, logger};
-use crate::data_vessel::{DataVessel, KeyKeeper};
+use crate::data_vessel::DataVessel;
 use crate::monitor;
 use crate::proxy::proxy_listener;
 use crate::proxy::proxy_summary::ProxySummary;
@@ -81,7 +81,7 @@ fn start(mut interval: Duration, vessel: DataVessel) {
     }
 }
 
-pub fn proxy_agent_status_new(vessel: impl KeyKeeper + Clone) -> ProxyAgentStatus {
+pub fn proxy_agent_status_new(vessel: DataVessel) -> ProxyAgentStatus {
     let key_latch_status = key_keeper::get_status(vessel.clone());
     let ebpf_status = redirector::get_status();
     let proxy_status = proxy_listener::get_status();
@@ -121,7 +121,7 @@ pub fn increase_count(connection_summary: &mut ProxyConnectionSummary) {
 }
 
 pub fn guest_proxy_agent_aggregate_status_new(
-    vessel: impl KeyKeeper + Clone,
+    vessel: DataVessel,
 ) -> GuestProxyAgentAggregateStatus {
     GuestProxyAgentAggregateStatus {
         timestamp: misc_helpers::get_date_time_string_with_miliseconds(),

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -7,7 +7,7 @@ mod windows;
 mod linux;
 
 use crate::common::{config, logger};
-use crate::data_vessel;
+use crate::data_vessel::DataVessel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::{ModuleState, ProxyAgentDetailStatus};
 use proxy_agent_shared::telemetry::event_logger;
@@ -39,13 +39,13 @@ impl AuditEntry {
 
 const MAX_STATUS_MESSAGE_LENGTH: usize = 1024;
 
-pub fn start_async(local_port: u16, vessel: data_vessel::DataVessel) {
+pub fn start_async(local_port: u16, vessel: DataVessel) {
     thread::spawn(move || {
         start(local_port, vessel);
     });
 }
 
-fn start(local_port: u16, vessel: data_vessel::DataVessel) -> bool {
+fn start(local_port: u16, vessel: DataVessel) -> bool {
     for _ in 0..5 {
         #[cfg(windows)]
         {

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -4,6 +4,7 @@ mod ebpf_obj;
 mod iptable_redirect;
 
 use crate::common::{config, constants, helpers, logger};
+use crate::data_vessel::DataVessel;
 use crate::provision;
 use crate::redirector::{ip_to_string, AuditEntry};
 use aya::maps::{HashMap, MapData};
@@ -17,7 +18,6 @@ use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
 use std::convert::TryFrom;
 use std::path::PathBuf;
-use std::sync::mpsc::Sender;
 
 static mut IS_STARTED: bool = false;
 static mut STATUS_MESSAGE: Lazy<String> =
@@ -25,7 +25,7 @@ static mut STATUS_MESSAGE: Lazy<String> =
 static mut LOCAL_PORT: u16 = 0;
 static mut BPF_OBJECT: Option<Bpf> = None;
 
-pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) -> bool {
+pub fn start(local_port: u16, vessel: DataVessel) -> bool {
     let mut bpf = match open_ebpf_file(super::get_ebpf_file_path()) {
         Ok(value) => value,
         Err(value) => return value,
@@ -122,7 +122,7 @@ pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) ->
     unsafe {
         *STATUS_MESSAGE = message.to_string();
     }
-    provision::redirector_ready(sender);
+    provision::redirector_ready(vessel);
 
     true
 }

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -17,6 +17,7 @@ use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
 use std::convert::TryFrom;
 use std::path::PathBuf;
+use std::sync::mpsc::Sender;
 
 static mut IS_STARTED: bool = false;
 static mut STATUS_MESSAGE: Lazy<String> =
@@ -24,7 +25,7 @@ static mut STATUS_MESSAGE: Lazy<String> =
 static mut LOCAL_PORT: u16 = 0;
 static mut BPF_OBJECT: Option<Bpf> = None;
 
-pub fn start(local_port: u16) -> bool {
+pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) -> bool {
     let mut bpf = match open_ebpf_file(super::get_ebpf_file_path()) {
         Ok(value) => value,
         Err(value) => return value,
@@ -121,7 +122,7 @@ pub fn start(local_port: u16) -> bool {
     unsafe {
         *STATUS_MESSAGE = message.to_string();
     }
-    provision::redirector_ready();
+    provision::redirector_ready(sender);
 
     true
 }

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -7,7 +7,7 @@ mod bpf_obj;
 mod bpf_prog;
 
 use crate::common::{self, config, constants, helpers, logger};
-use crate::key_keeper;
+use crate::data_vessel::DataVessel;
 use crate::provision;
 use crate::redirector::AuditEntry;
 use core::ffi::c_void;
@@ -24,7 +24,7 @@ static mut STATUS_MESSAGE: Lazy<String> =
     Lazy::new(|| String::from("Redirector has not started yet."));
 static mut LOCAL_PORT: u16 = 0;
 
-pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) -> bool {
+pub fn start(local_port: u16, vessel: DataVessel) -> bool {
     match bpf_prog::init() {
         Ok(_) => (),
         Err(e) => {
@@ -126,7 +126,7 @@ pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) ->
     unsafe {
         *STATUS_MESSAGE = message.to_string();
     }
-    provision::redirector_ready(sender);
+    provision::redirector_ready(vessel);
 
     true
 }

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -16,6 +16,7 @@ use std::mem;
 use std::net::TcpStream;
 use std::os::windows::io::AsRawSocket;
 use std::ptr;
+use std::sync::mpsc::Sender;
 use windows_sys::Win32::Networking::WinSock;
 
 static mut IS_STARTED: bool = false;
@@ -23,7 +24,7 @@ static mut STATUS_MESSAGE: Lazy<String> =
     Lazy::new(|| String::from("Redirector has not started yet."));
 static mut LOCAL_PORT: u16 = 0;
 
-pub fn start(local_port: u16) -> bool {
+pub fn start(local_port: u16, sender: Sender<crate::data_vessel::DataAction>) -> bool {
     match bpf_prog::init() {
         Ok(_) => (),
         Err(e) => {
@@ -125,7 +126,7 @@ pub fn start(local_port: u16) -> bool {
     unsafe {
         *STATUS_MESSAGE = message.to_string();
     }
-    provision::redirector_ready();
+    provision::redirector_ready(sender);
 
     true
 }

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -8,6 +8,7 @@ mod bpf_prog;
 
 use crate::common::{self, config, constants, helpers, logger};
 use crate::data_vessel::DataVessel;
+use crate::key_keeper;
 use crate::provision;
 use crate::redirector::AuditEntry;
 use core::ffi::c_void;
@@ -16,7 +17,6 @@ use std::mem;
 use std::net::TcpStream;
 use std::os::windows::io::AsRawSocket;
 use std::ptr;
-use std::sync::mpsc::Sender;
 use windows_sys::Win32::Networking::WinSock;
 
 static mut IS_STARTED: bool = false;

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -31,15 +31,17 @@ pub fn start_service() {
     ));
 
     let config_start_redirector = config::get_start_redirector();
+    let sender = crate::data_vessel::start_receiver_async();
 
     crate::key_keeper::poll_status_async(
         Url::parse(&format!("http://{}/", constants::WIRE_SERVER_IP)).unwrap(),
         config::get_keys_dir(),
         config::get_poll_key_status_duration(),
         config_start_redirector,
+        sender.clone(),
     );
 
-    proxy_listener::start_async(constants::PROXY_AGENT_PORT, 20);
+    proxy_listener::start_async(constants::PROXY_AGENT_PORT, 20, sender.clone());
 
     // TODO:: need start the monitor thread and write proxy agent status to the file
     // monitor::start_async(config::get_monitor_duration());

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -31,17 +31,17 @@ pub fn start_service() {
     ));
 
     let config_start_redirector = config::get_start_redirector();
-    let sender = crate::data_vessel::start_receiver_async();
+    let vessel = crate::data_vessel::DataVessel::start_new_async();
 
     crate::key_keeper::poll_status_async(
         Url::parse(&format!("http://{}/", constants::WIRE_SERVER_IP)).unwrap(),
         config::get_keys_dir(),
         config::get_poll_key_status_duration(),
         config_start_redirector,
-        sender.clone(),
+        vessel.clone(),
     );
 
-    proxy_listener::start_async(constants::PROXY_AGENT_PORT, 20, sender.clone());
+    proxy_listener::start_async(constants::PROXY_AGENT_PORT, 20, vessel.clone());
 
     // TODO:: need start the monitor thread and write proxy agent status to the file
     // monitor::start_async(config::get_monitor_duration());

--- a/proxy_agent/src/telemetry/event_reader.rs
+++ b/proxy_agent/src/telemetry/event_reader.rs
@@ -435,6 +435,7 @@ mod tests {
         }
 
         let temp_dir = env::temp_dir();
+        let sender = crate::data_vessel::start_receiver_async();
         start_async(temp_dir, Duration::from_millis(1000), false, sender.clone());
 
         let mut wait_milli_sec: i32 = 100;
@@ -459,6 +460,7 @@ mod tests {
             THREAD_PRIORITY_VERIFY_SUCCESS
         );
         assert!(THREAD_PRIORITY_VERFIY_DONE.load(Ordering::Relaxed));
+        _ = sender.send(crate::data_vessel::DataAction::Stop);
     }
 
     #[test]

--- a/proxy_agent/src/telemetry/event_reader.rs
+++ b/proxy_agent/src/telemetry/event_reader.rs
@@ -429,8 +429,8 @@ mod tests {
         }
 
         let temp_dir = env::temp_dir();
-        let sender = crate::data_vessel::start_receiver_async();
-        start_async(temp_dir, Duration::from_millis(1000), false, sender.clone());
+        let vessel = crate::data_vessel::DataVessel::start_new_async();
+        start_async(temp_dir, Duration::from_millis(1000), false, vessel.clone());
 
         let mut wait_milli_sec: i32 = 100;
         while wait_milli_sec <= 500 && !THREAD_PRIORITY_VERFIY_DONE.load(Ordering::Relaxed) {
@@ -454,7 +454,7 @@ mod tests {
             THREAD_PRIORITY_VERIFY_SUCCESS
         );
         assert!(THREAD_PRIORITY_VERFIY_DONE.load(Ordering::Relaxed));
-        _ = sender.send(crate::data_vessel::DataAction::Stop);
+        vessel.stop();
     }
 
     #[test]


### PR DESCRIPTION
- Created a centralized mod data_vessel
- move the first shared data 'Key' to data_vessel
- encapsulate the Key related functions. 
- modify the callers and relative places.