### PR TITLE
Update --status command to query current provision result

### DIFF
--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -13,6 +13,7 @@ serde = "1.0.152"
 serde_derive = "1.0.152"
 serde_json = "1.0.91"         # json Deserializer
 serde-xml-rs = "0.6.0"        # xml Deserializer
+bitflags = "2.6.0"            # support bitflag enum
 url = "2.3.1"                 # parse url string
 hmac-sha256 = "1.1.6"         # use HMAC using the SHA-256 hash function
 hex = "0.4.3"                 # hex encode 

--- a/proxy_agent/src/common/http/headers.rs
+++ b/proxy_agent/src/common/http/headers.rs
@@ -29,6 +29,11 @@ impl Headers {
         }
     }
 
+    /// Get the header (key, value) by key
+    pub fn get(&self, key: &str) -> Option<&(String, String)> {
+        self.map.get(&key.to_lowercase())
+    }
+
     pub fn copy(&self) -> Self {
         let mut headers = Headers::new();
         for header in self.map.values() {

--- a/proxy_agent/src/main.rs
+++ b/proxy_agent/src/main.rs
@@ -14,13 +14,14 @@ pub mod shared_state;
 pub mod telemetry;
 pub mod test_mock;
 
+use common::constants;
 use common::helpers;
 use proxy_agent_shared::misc_helpers;
 use shared_state::SharedState;
 use std::{process, time::Duration};
 
 #[cfg(windows)]
-use common::{constants, logger};
+use common::logger;
 #[cfg(windows)]
 use service::windows;
 #[cfg(windows)]

--- a/proxy_agent/src/main.rs
+++ b/proxy_agent/src/main.rs
@@ -63,9 +63,11 @@ async fn main() {
             if args.len() >= 4 && args[2].to_lowercase() == "--wait" {
                 wait_time = args[3].parse::<u64>().unwrap_or(0);
             }
-            let status =
-                provision::get_provision_status_wait(None, Some(Duration::from_secs(wait_time)))
-                    .await;
+            let status = provision::get_provision_status_wait(
+                constants::PROXY_AGENT_PORT,
+                Some(Duration::from_secs(wait_time)),
+            )
+            .await;
             if !status.0 {
                 // exit code 1 means provision not finished yet.
                 process::exit(1);

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::common::{config, helpers, logger};
+
+use crate::common::http::{self, http_request::HttpRequest, request::Request, response::Response};
+use crate::common::{config, constants, helpers, logger};
 use crate::proxy::proxy_listener;
 use crate::shared_state::{provision_wrapper, telemetry_wrapper, SharedState};
 use crate::telemetry::event_reader;
 use crate::{key_keeper, proxy_agent_status, redirector};
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
+use serde_derive::{Deserialize, Serialize};
+use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -14,27 +18,49 @@ use std::time::Duration;
 const STATUS_TAG_TMP_FILE_NAME: &str = "status.tag.tmp";
 const STATUS_TAG_FILE_NAME: &str = "status.tag";
 
+bitflags::bitflags! {
+    #[derive(Clone)]
+    pub struct ProvisionFlags: u8 {
+        const NONE = 0;
+        const REDIRECTOR_READY = 1;
+        const KEY_LATCH_READY = 2;
+        const LISTENER_READY = 4;
+        const ALL_READY = 7;
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct ProivsionState {
+    finished: bool,
+    errorMessage: String,
+}
+
+pub const PROVISION_URL_PATH: &str = "/provision";
+
 pub fn redirector_ready(shared_state: Arc<Mutex<SharedState>>) {
-    update_provision_state(1, None, shared_state);
+    update_provision_state(ProvisionFlags::REDIRECTOR_READY, None, shared_state);
 }
 
 pub fn key_latched(shared_state: Arc<Mutex<SharedState>>) {
-    update_provision_state(2, None, shared_state);
+    update_provision_state(ProvisionFlags::KEY_LATCH_READY, None, shared_state);
 }
 
 pub fn listener_started(shared_state: Arc<Mutex<SharedState>>) {
-    update_provision_state(4, None, shared_state);
+    update_provision_state(ProvisionFlags::LISTENER_READY, None, shared_state);
 }
 
 fn update_provision_state(
-    state: u8,
+    state: ProvisionFlags,
     provision_dir: Option<PathBuf>,
     shared_state: Arc<Mutex<SharedState>>,
 ) {
     let provision_state = provision_wrapper::update_state(shared_state.clone(), state);
-    if provision_state == 7 {
+    if provision_state.contains(ProvisionFlags::ALL_READY) {
+        provision_wrapper::set_provision_finished(shared_state.clone());
+
         // write provision success state here
-        write_provision_state(true, provision_dir, shared_state.clone());
+        write_provision_state(provision_dir, shared_state.clone());
 
         // start event threads right after provision successfully
         start_event_threads(shared_state.clone());
@@ -43,9 +69,11 @@ fn update_provision_state(
 
 pub fn provision_timeup(provision_dir: Option<PathBuf>, shared_state: Arc<Mutex<SharedState>>) {
     let provision_state = provision_wrapper::get_state(shared_state.clone());
-    if provision_state != 7 {
-        // write provision fail state here
-        write_provision_state(false, provision_dir, shared_state.clone());
+    if !provision_state.contains(ProvisionFlags::ALL_READY) {
+        provision_wrapper::set_provision_finished(shared_state.clone());
+
+        // write provision state
+        write_provision_state(provision_dir, shared_state.clone());
     }
 }
 
@@ -80,11 +108,7 @@ pub fn start_event_threads(shared_state: Arc<Mutex<SharedState>>) {
     ));
 }
 
-fn write_provision_state(
-    provision_success: bool,
-    provision_dir: Option<PathBuf>,
-    shared_state: Arc<Mutex<SharedState>>,
-) {
+fn write_provision_state(provision_dir: Option<PathBuf>, shared_state: Arc<Mutex<SharedState>>) {
     let provision_dir = provision_dir.unwrap_or_else(config::get_keys_dir);
 
     let provisioned_file: PathBuf = provision_dir.join("provisioned.tag");
@@ -94,24 +118,9 @@ fn write_provision_state(
         misc_helpers::get_date_time_string_with_milliseconds(),
     );
 
-    let mut status = String::new(); //provision success, write 0 byte to file
-    if !provision_success {
-        status.push_str(&format!(
-            "keyLatchStatus - {}\r\n",
-            key_keeper::get_status(shared_state.clone()).message
-        ));
-        status.push_str(&format!(
-            "ebpfProgramStatus - {}\r\n",
-            redirector::get_status(shared_state.clone()).message
-        ));
-        status.push_str(&format!(
-            "proxyListenerStatus - {}\r\n",
-            proxy_listener::get_status(shared_state.clone()).message
-        ));
-    }
-
+    let failed_state_message = get_provision_failed_state_message(shared_state.clone());
     let status_file: PathBuf = provision_dir.join(STATUS_TAG_TMP_FILE_NAME);
-    match std::fs::write(status_file, status.as_bytes()) {
+    match std::fs::write(status_file, failed_state_message.as_bytes()) {
         Ok(_) => {
             match std::fs::rename(
                 provision_dir.join(STATUS_TAG_TMP_FILE_NAME),
@@ -129,14 +138,57 @@ fn write_provision_state(
     }
 }
 
-pub async fn get_provision_status_wait(
-    provision_dir: Option<PathBuf>,
-    duration: Option<Duration>,
-) -> (bool, String) {
+/// Get provision failed state message
+fn get_provision_failed_state_message(shared_state: Arc<Mutex<SharedState>>) -> String {
+    let provision_state = provision_wrapper::get_state(shared_state.clone());
+
+    let mut state = String::new(); //provision success, write 0 byte to file
+    if !provision_state.contains(ProvisionFlags::REDIRECTOR_READY) {
+        state.push_str(&format!(
+            "ebpfProgramStatus - {}\r\n",
+            redirector::get_status(shared_state.clone()).message
+        ));
+    }
+
+    if !provision_state.contains(ProvisionFlags::KEY_LATCH_READY) {
+        state.push_str(&format!(
+            "keyLatchStatus - {}\r\n",
+            key_keeper::get_status(shared_state.clone()).message
+        ));
+    }
+
+    if !provision_state.contains(ProvisionFlags::LISTENER_READY) {
+        state.push_str(&format!(
+            "proxyListenerStatus - {}\r\n",
+            proxy_listener::get_status(shared_state.clone()).message
+        ));
+    }
+
+    state
+}
+
+pub fn get_provision_state(shared_state: Arc<Mutex<SharedState>>) -> ProivsionState {
+    ProivsionState {
+        finished: provision_wrapper::get_provision_finished(shared_state.clone()),
+        errorMessage: get_provision_failed_state_message(shared_state),
+    }
+}
+
+pub async fn get_provision_status_wait(port: u16, duration: Option<Duration>) -> (bool, String) {
     loop {
-        let provision_status = get_provision_status(provision_dir.clone());
-        if provision_status.0 {
-            return provision_status;
+        let provision_state = get_current_provision_status(port);
+        let (finished, message) = match provision_state {
+            Ok(state) => (state.finished, state.errorMessage),
+            Err(e) => {
+                println!(
+                    "Failed to query the current provision state with error: {}.",
+                    e
+                );
+                (false, String::new())
+            }
+        };
+        if finished {
+            return (finished, message);
         }
 
         if let Some(d) = duration {
@@ -146,7 +198,8 @@ pub async fn get_provision_status_wait(
             }
         }
 
-        return provision_status;
+        // wait timedout return as 'not finished'
+        return (false, String::new());
     }
 }
 
@@ -154,27 +207,48 @@ pub async fn get_provision_status_wait(
 // return value
 //  bool - true provision finished; false provision not finished
 //  String - provision error message, empty means provision success or provision failed.
-fn get_provision_status(provision_dir: Option<PathBuf>) -> (bool, String) {
-    let provision_dir = provision_dir.unwrap_or_else(config::get_keys_dir);
+fn get_current_provision_status(port: u16) -> std::io::Result<ProivsionState> {
+    let provision_url =
+        url::Url::parse(&format!("http://127.0.0.1:{}{}", port, PROVISION_URL_PATH)).map_err(
+            |e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to parse provision url with error: {}", e),
+                )
+            },
+        )?;
+    let mut req = Request::new(PROVISION_URL_PATH.to_string(), "GET".to_string());
+    req.headers
+        .add_header(constants::METADATA_HEADER.to_string(), "True ".to_string());
 
-    let status_file: PathBuf = provision_dir.join(STATUS_TAG_FILE_NAME);
-    if !status_file.exists() {
-        return (false, String::new());
+    let mut http_request = HttpRequest::new(provision_url, req);
+    http_request
+        .request
+        .headers
+        .add_header("Host".to_string(), http_request.get_host());
+
+    let response = http::get_response_in_string(&mut http_request)?;
+    let response_body = response.get_body_as_string()?;
+    if response.status != Response::OK {
+        return Err(Error::new(
+            ErrorKind::Other,
+            format!("Host response {} - {}", response.status, response_body),
+        ));
     }
 
-    match std::fs::read_to_string(status_file) {
-        Ok(status) => (true, status),
-        Err(e) => {
-            println!("Failed to read status.tag file with error: {}", e);
-            (false, String::new())
-        }
-    }
+    let state: ProivsionState = serde_json::from_str(&response_body)?;
+    Ok(state)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::common::logger;
+    use crate::provision::ProvisionFlags;
+    use crate::proxy::proxy_connection::Connection;
+    use crate::proxy::proxy_listener;
     use crate::shared_state::provision_wrapper;
     use crate::shared_state::SharedState;
+    use proxy_agent_shared::logger_manager;
     use std::env;
     use std::fs;
     use std::time::Duration;
@@ -182,13 +256,31 @@ mod tests {
     #[tokio::test]
     async fn provision_state_test() {
         let mut temp_test_path = env::temp_dir();
-        temp_test_path.push("update_provision_state_test");
+        let logger_key = "provision_state_test";
+        temp_test_path.push(logger_key);
 
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
 
-        let provision_status =
-            super::get_provision_status_wait(Some(temp_test_path.to_path_buf()), None).await;
+        logger_manager::init_logger(
+            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
+            temp_test_path.clone(),
+            logger_key.to_string(),
+            10 * 1024 * 1024,
+            20,
+        );
+        Connection::init_logger(temp_test_path.to_path_buf());
+
+        // start listener, the port must different from the one used in production code
+        let shared_state = SharedState::new();
+        let port: u16 = 8092;
+        proxy_listener::start_async(port, 1, shared_state.clone());
+
+        // give some time to let the listener started
+        let sleep_duration = Duration::from_millis(100);
+        tokio::time::sleep(sleep_duration).await;
+
+        let provision_status = super::get_provision_status_wait(port, None).await;
         assert!(!provision_status.0, "provision_status.0 must be false");
         assert_eq!(
             0,
@@ -196,7 +288,6 @@ mod tests {
             "provision_status.1 must be empty"
         );
 
-        let shared_state = SharedState::new();
         let dir1 = temp_test_path.to_path_buf();
         let dir2 = temp_test_path.to_path_buf();
         let dir3 = temp_test_path.to_path_buf();
@@ -205,13 +296,13 @@ mod tests {
         let s3 = shared_state.clone();
         let handles = vec![
             tokio::task::spawn_blocking(|| {
-                super::update_provision_state(1, Some(dir1), s1);
+                super::update_provision_state(ProvisionFlags::REDIRECTOR_READY, Some(dir1), s1);
             }),
             tokio::task::spawn_blocking(|| {
-                super::update_provision_state(2, Some(dir2), s2);
+                super::update_provision_state(ProvisionFlags::KEY_LATCH_READY, Some(dir2), s2);
             }),
             tokio::task::spawn_blocking(|| {
-                super::update_provision_state(4, Some(dir3), s3);
+                super::update_provision_state(ProvisionFlags::LISTENER_READY, Some(dir3), s3);
             }),
         ];
 
@@ -230,11 +321,8 @@ mod tests {
             "success status.tag file must be empty"
         );
 
-        let provision_status = super::get_provision_status_wait(
-            Some(temp_test_path.to_path_buf()),
-            Some(Duration::from_millis(5)),
-        )
-        .await;
+        let provision_status =
+            super::get_provision_status_wait(port, Some(Duration::from_millis(5))).await;
         assert!(provision_status.0, "provision_status.0 must be true");
         assert_eq!(
             0,
@@ -246,14 +334,8 @@ mod tests {
             provision_wrapper::get_event_log_threads_initialized(shared_state.clone());
         assert!(event_threads_initialized);
 
-        // write status.tag file
-        _ = fs::write(status_file, "this is test message".as_bytes());
-        let provision_status = super::get_provision_status(Some(temp_test_path.to_path_buf()));
-        assert!(provision_status.0, "provision_status.0 must be true");
-        assert!(
-            !provision_status.1.is_empty(),
-            "provision_status.1 should not empty"
-        );
+        // stop listener
+        proxy_listener::stop(port, shared_state);
 
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -174,6 +174,8 @@ pub fn get_provision_state(shared_state: Arc<Mutex<SharedState>>) -> ProivsionSt
     }
 }
 
+/// Get current provision status and wait until provision finished or timeout
+/// it serves for --status --wait command line option
 pub async fn get_provision_status_wait(port: u16, duration: Option<Duration>) -> (bool, String) {
     loop {
         let provision_state = get_current_provision_status(port);
@@ -203,7 +205,7 @@ pub async fn get_provision_status_wait(port: u16, duration: Option<Duration>) ->
     }
 }
 
-// Get provision status
+// Get current provision status from GPA service via http request
 // return value
 //  bool - true provision finished; false provision not finished
 //  String - provision error message, empty means provision success or provision failed.

--- a/proxy_agent/src/proxy/proxy_listener.rs
+++ b/proxy_agent/src/proxy/proxy_listener.rs
@@ -690,6 +690,9 @@ fn handle_provision_state_check_request(
     mut client_stream: &TcpStream,
     shared_state: Arc<Mutex<SharedState>>,
 ) {
+    // notify key_keeper to poll the status
+    key_keeper_wrapper::notify(shared_state.clone());
+
     let provision_state = provision::get_provision_state(shared_state);
     let (response_status, provision_state) = match serde_json::to_string(&provision_state) {
         Ok(json) => {


### PR DESCRIPTION
- Update --status command to query current provision result
- keep failed messages only for provision state
- provision state query request checks for Metadata header
- provision state check request to notify the key_keepr to poll status.