### PR TITLE
Query VMExtension Instance View result for AddLinuxVMExtensionCase

### DIFF
--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -66,7 +66,7 @@ namespace GuestProxyAgentTest.TestCases
             var startTime = DateTime.UtcNow;
             while (true)
             {
-                var vmExtension = await vmr.GetVirtualMachineExtensions().GetAsync(EXTENSION_NAME);
+                var vmExtension = await vmr.GetVirtualMachineExtensionAsync(EXTENSION_NAME, expand: "instanceView");
                 var instanceView = vmExtension?.Value?.Data?.InstanceView;
                 if (instanceView?.Statuses?.Count > 0 && instanceView.Statuses[0].DisplayStatus == "Provisioning succeeded")
                 {

--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -48,9 +48,15 @@ namespace GuestProxyAgentTest.TestCases
                 var provisioningState = result.Value.Data.ProvisioningState;
                 if (result.HasValue && result.Value.Data != null && result.Value.Data.ProvisioningState == "Succeeded")
                 {
+                    // add vm extension operation succeeded
                     context.TestResultDetails.Succeed = true;
                     context.TestResultDetails.CustomOut = FormatVMExtensionData(result.Value.Data);
                     return;
+                }
+                else
+                {
+                    // capture the provisioning data into TestResultDetails and continue poll the extension instance view
+                    context.TestResultDetails.StdErr = string.Format("VMExtension provisioning data: {}", FormatVMExtensionData(result?.Value?.Data););
                 }
             }
             catch (Exception ex)

--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -13,8 +13,10 @@ namespace GuestProxyAgentTest.TestCases
         public AddLinuxVMExtensionCase() : base("AddLinuxVMExtensionCase")
         { }
         public AddLinuxVMExtensionCase(string testCaseName) : base(testCaseName)
-        { 
+        {
         }
+
+        private const string EXTENSION_NAME = "ProxyAgentLinuxTest";
 
         public override async Task StartAsync(TestCaseExecutionContext context)
         {
@@ -27,19 +29,59 @@ namespace GuestProxyAgentTest.TestCases
                 TypeHandlerVersion = "1.0",
                 AutoUpgradeMinorVersion = false,
                 EnableAutomaticUpgrade = false,
-                Settings = 
+                Settings =
                 {
                 }
             };
-            var result = await vmr.GetVirtualMachineExtensions().CreateOrUpdateAsync(Azure.WaitUntil.Completed, "ProxyAgentLinuxTest", vmExtData);
-            context.TestResultDetails = new GuestProxyAgentTest.Models.TestCaseResultDetails
+
+            try
             {
-                CustomOut =  result.Value.Data.ToString(),
-                StdOut = "",
-                StdErr =  "",
-                Succeed = result.Value.Data.ProvisioningState == "Succeeded",
-                FromBlob = false,
-            };
+                context.TestResultDetails = new GuestProxyAgentTest.Models.TestCaseResultDetails
+                {
+                    StdOut = "",
+                    StdErr = "",
+                    Succeed = false,
+                    FromBlob = false,
+                };
+
+                var result = await vmr.GetVirtualMachineExtensions().CreateOrUpdateAsync(Azure.WaitUntil.Completed, EXTENSION_NAME, vmExtData);
+                var provisioningState = result.Value.Data.ProvisioningState;
+                if (result.HasValue && result.Value.Data != null && result.Value.Data.ProvisioningState == "Succeeded")
+                {
+                    context.TestResultDetails.Succeed = true;
+                    context.TestResultDetails.CustomOut = FormatVMExtensionData(result.Value.Data);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                // capture the exception into TestResultDetails and continue poll the extension instance view
+                context.TestResultDetails.StdErr = ex.ToString();
+            }
+
+            // poll the extension isntance view for 5 minutes more
+            var startTime = DateTime.UtcNow;
+            while (true)
+            {
+                var vmExtension = await vmr.GetVirtualMachineExtensions().GetAsync(EXTENSION_NAME);
+                var instanceView = vmExtension?.Value?.Data?.InstanceView;
+                if (instanceView?.Statuses?.Count > 0 && instanceView.Statuses[0].DisplayStatus == "Provisioning succeeded")
+                {
+                    context.TestResultDetails.Succeed = true;
+                    context.TestResultDetails.CustomOut = FormatVMExtensionData(vmExtension.Value.Data);
+                    return;
+                }
+
+                if (DateTime.UtcNow - startTime > TimeSpan.FromMinutes(5))
+                {
+                    // poll timed out, report failure with the extension data
+                    context.TestResultDetails.CustomOut = FormatVMExtensionData(vmExtension?.Value?.Data);
+                    return;
+                }
+
+                // wait for 10 seconds before polling again
+                await Task.Delay(10000);
+            }
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -13,8 +13,7 @@ namespace GuestProxyAgentTest.TestCases
         public AddLinuxVMExtensionCase() : base("AddLinuxVMExtensionCase")
         { }
         public AddLinuxVMExtensionCase(string testCaseName) : base(testCaseName)
-        {
-        }
+        { }
 
         private const string EXTENSION_NAME = "ProxyAgentLinuxTest";
 
@@ -29,9 +28,7 @@ namespace GuestProxyAgentTest.TestCases
                 TypeHandlerVersion = "1.0",
                 AutoUpgradeMinorVersion = false,
                 EnableAutomaticUpgrade = false,
-                Settings =
-                {
-                }
+                Settings = { }
             };
 
             try
@@ -56,7 +53,7 @@ namespace GuestProxyAgentTest.TestCases
                 else
                 {
                     // capture the provisioning data into TestResultDetails and continue poll the extension instance view
-                    context.TestResultDetails.StdErr = string.Format("VMExtension provisioning data: {}", FormatVMExtensionData(result?.Value?.Data););
+                    context.TestResultDetails.StdErr = string.Format("VMExtension provisioning data: {}", FormatVMExtensionData(result?.Value?.Data));
                 }
             }
             catch (Exception ex)

--- a/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+using Azure.ResourceManager.Compute;
+using Azure.ResourceManager.Compute.Models;
 using GuestProxyAgentTest.Models;
 using GuestProxyAgentTest.Settings;
 using GuestProxyAgentTest.TestScenarios;
 using GuestProxyAgentTest.Utilities;
+using System.Text;
 
 namespace GuestProxyAgentTest.TestCases
 {
@@ -48,7 +51,7 @@ namespace GuestProxyAgentTest.TestCases
         {
             var testScenarioSetting = context.ScenarioSetting;
             string custJsonSas = null!;
-            if(includeCustomJsonOutputSasParam)
+            if (includeCustomJsonOutputSasParam)
             {
                 var custJsonPath = Path.Combine(Path.GetTempPath(), $"{testScenarioSetting.testGroupName}_{testScenarioSetting.testScenarioName}_{TestCaseName}.json");
                 using (File.CreateText(custJsonPath)) ConsoleLog("Created empty test file for customized json output file.");
@@ -63,6 +66,37 @@ namespace GuestProxyAgentTest.TestCases
                         .AddParameters(parameterList));
         }
 
-        protected void ConsoleLog(string message) { Console.WriteLine($"[{TestCaseName}]: " + message);}
+        protected void ConsoleLog(string message) { Console.WriteLine($"[{TestCaseName}]: " + message); }
+
+        protected string FormatVMExtensionData(VirtualMachineExtensionData data)
+        {
+            if (data == null)
+            {
+                return "null";
+            }
+            return string.Format("ProvisioningState: {0}, Publisher: {1}, ExtensionType: {2}, TypeHandlerVersion: {3}, AutoUpgradeMinorVersion: {4}, EnableAutomaticUpgrade: {5}, InstanceView: {6}",
+                 data.ProvisioningState, data.Publisher, data.ExtensionType, data.TypeHandlerVersion, data.AutoUpgradeMinorVersion, data.EnableAutomaticUpgrade, FormatVMExtensionInstanceView(data.InstanceView));
+        }
+
+        protected string FormatVMExtensionInstanceView(VirtualMachineExtensionInstanceView instanceView)
+        {
+            if (instanceView == null)
+            {
+                return "null";
+            }
+            return string.Format("Name: {0}, ExntesionType:{1}, ExtensionVersion:{2} Statuses: {3}, Substatuses: {4}", instanceView.Name,
+                instanceView.VirtualMachineExtensionInstanceViewType, instanceView.TypeHandlerVersion
+                , FormatVMInstanceViewStatus(instanceView.Statuses), FormatVMInstanceViewStatus(instanceView.Substatuses));
+        }
+
+        protected string FormatVMInstanceViewStatus(IList<InstanceViewStatus> instanceView)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            foreach (var status in instanceView)
+            {
+                stringBuilder.AppendFormat("Code: {0}, Level: {1}, DisplayStatus: {2}, Message: {3}", status.Code, status.Level, status.DisplayStatus, status.Message);
+            }
+            return stringBuilder.ToString();
+        }
     }
 }


### PR DESCRIPTION
When running E2E tests, AddLinuxVMExtnsionCase may failed in two situations:

1. The Add VM Extension operation may finished but not with ProvisioningState with Succeeded, while it finished success later.
2. The Add VM Extension operation may fail with exception, while it finished success later. 

To make this test more robust, we could poll & check the VM Extension instance view result with 5 minutes timeout. 