### PR TITLE
Use strong enum type instead of string.

### DIFF
--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -431,9 +431,9 @@ pub fn stop(shared_state: Arc<Mutex<SharedState>>) {
 /// ```
 pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if key_keeper_wrapper::get_shutdown(shared_state.clone()) {
-        ModuleState::Stopped
+        ModuleState::STOPPED
     } else {
-        ModuleState::Running
+        ModuleState::RUNNING
     };
 
     let mut states = HashMap::new();

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -431,9 +431,9 @@ pub fn stop(shared_state: Arc<Mutex<SharedState>>) {
 /// ```
 pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if key_keeper_wrapper::get_shutdown(shared_state.clone()) {
-        ModuleState::STOPPED.to_string()
+        ModuleState::Stopped
     } else {
-        ModuleState::RUNNING.to_string()
+        ModuleState::Running
     };
 
     let mut states = HashMap::new();

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -54,9 +54,9 @@ pub fn stop(shared_state: Arc<Mutex<SharedState>>) {
 
 pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if proxy_listener_wrapper::get_shutdown(shared_state.clone()) {
-        ModuleState::Stopped
+        ModuleState::STOPPED
     } else {
-        ModuleState::Running
+        ModuleState::RUNNING
     };
 
     ProxyAgentDetailStatus {

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -54,9 +54,9 @@ pub fn stop(shared_state: Arc<Mutex<SharedState>>) {
 
 pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if proxy_listener_wrapper::get_shutdown(shared_state.clone()) {
-        ModuleState::STOPPED.to_string()
+        ModuleState::Stopped
     } else {
-        ModuleState::RUNNING.to_string()
+        ModuleState::Running
     };
 
     ProxyAgentDetailStatus {

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -78,9 +78,9 @@ async fn loop_status(interval: Duration, shared_state: Arc<Mutex<SharedState>>) 
 
 fn get_telemetry_log_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if telemetry_wrapper::get_logger_shutdown(shared_state.clone()) {
-        ModuleState::Stopped
+        ModuleState::STOPPED
     } else {
-        ModuleState::Running
+        ModuleState::RUNNING
     };
 
     ProxyAgentDetailStatus {
@@ -94,13 +94,13 @@ fn proxy_agent_status_new(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentSt
     let key_latch_status = key_keeper::get_status(shared_state.clone());
     let ebpf_status = redirector::get_status(shared_state.clone());
     let proxy_status = proxy_server::get_status(shared_state.clone());
-    let status = if key_latch_status.status != ModuleState::Running
-        || ebpf_status.status != ModuleState::Running
-        || proxy_status.status != ModuleState::Running
+    let status = if key_latch_status.status != ModuleState::RUNNING
+        || ebpf_status.status != ModuleState::RUNNING
+        || proxy_status.status != ModuleState::RUNNING
     {
-        OverallState::Error
+        OverallState::ERROR
     } else {
-        OverallState::Success
+        OverallState::SUCCESS
     };
 
     ProxyAgentStatus {
@@ -108,7 +108,7 @@ fn proxy_agent_status_new(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentSt
         status,
         // monitorStatus is proxy_agent_status itself status
         monitorStatus: ProxyAgentDetailStatus {
-            status: ModuleState::Running,
+            status: ModuleState::RUNNING,
             message: "proxy_agent_status thread started.".to_string(),
             states: None,
         },

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -78,9 +78,9 @@ async fn loop_status(interval: Duration, shared_state: Arc<Mutex<SharedState>>) 
 
 fn get_telemetry_log_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStatus {
     let status = if telemetry_wrapper::get_logger_shutdown(shared_state.clone()) {
-        ModuleState::STOPPED.to_string()
+        ModuleState::Stopped
     } else {
-        ModuleState::RUNNING.to_string()
+        ModuleState::Running
     };
 
     ProxyAgentDetailStatus {
@@ -94,20 +94,21 @@ fn proxy_agent_status_new(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentSt
     let key_latch_status = key_keeper::get_status(shared_state.clone());
     let ebpf_status = redirector::get_status(shared_state.clone());
     let proxy_status = proxy_server::get_status(shared_state.clone());
-    let mut status = OverallState::SUCCESS.to_string();
-    if key_latch_status.status != ModuleState::RUNNING
-        || ebpf_status.status != ModuleState::RUNNING
-        || proxy_status.status != ModuleState::RUNNING
+    let status = if key_latch_status.status != ModuleState::Running
+        || ebpf_status.status != ModuleState::Running
+        || proxy_status.status != ModuleState::Running
     {
-        status = OverallState::ERROR.to_string();
-    }
+        OverallState::Error
+    } else {
+        OverallState::Success
+    };
 
     ProxyAgentStatus {
         version: misc_helpers::get_current_version(),
         status,
         // monitorStatus is proxy_agent_status itself status
         monitorStatus: ProxyAgentDetailStatus {
-            status: ModuleState::RUNNING.to_string(),
+            status: ModuleState::Running,
             message: "proxy_agent_status thread started.".to_string(),
             states: None,
         },

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -159,9 +159,9 @@ pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStat
     }
 
     let status = if is_started(shared_state.clone()) {
-        ModuleState::RUNNING.to_string()
+        ModuleState::Running
     } else {
-        ModuleState::STOPPED.to_string()
+        ModuleState::Stopped
     };
 
     ProxyAgentDetailStatus {

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -159,9 +159,9 @@ pub fn get_status(shared_state: Arc<Mutex<SharedState>>) -> ProxyAgentDetailStat
     }
 
     let status = if is_started(shared_state.clone()) {
-        ModuleState::Running
+        ModuleState::RUNNING
     } else {
-        ModuleState::Stopped
+        ModuleState::STOPPED
     };
 
     ProxyAgentDetailStatus {

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -761,29 +761,29 @@ mod tests {
 
         let proxy_agent_status_obj = ProxyAgentStatus {
             version: "1.0.0".to_string(),
-            status: OverallState::SUCCESS.to_string(),
+            status: OverallState::Success,
             monitorStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING.to_string(),
+                status: ModuleState::Running,
                 message: "test".to_string(),
                 states: None,
             },
             keyLatchStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING.to_string(),
+                status: ModuleState::Running,
                 message: "test".to_string(),
                 states: None,
             },
             ebpfProgramStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING.to_string(),
+                status: ModuleState::Running,
                 message: "test".to_string(),
                 states: None,
             },
             proxyListenerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING.to_string(),
+                status: ModuleState::Running,
                 message: "test".to_string(),
                 states: None,
             },
             telemetryLoggerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING.to_string(),
+                status: ModuleState::Running,
                 message: "test".to_string(),
                 states: None,
             },

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -761,29 +761,29 @@ mod tests {
 
         let proxy_agent_status_obj = ProxyAgentStatus {
             version: "1.0.0".to_string(),
-            status: OverallState::Success,
+            status: OverallState::SUCCESS,
             monitorStatus: ProxyAgentDetailStatus {
-                status: ModuleState::Running,
+                status: ModuleState::RUNNING,
                 message: "test".to_string(),
                 states: None,
             },
             keyLatchStatus: ProxyAgentDetailStatus {
-                status: ModuleState::Running,
+                status: ModuleState::RUNNING,
                 message: "test".to_string(),
                 states: None,
             },
             ebpfProgramStatus: ProxyAgentDetailStatus {
-                status: ModuleState::Running,
+                status: ModuleState::RUNNING,
                 message: "test".to_string(),
                 states: None,
             },
             proxyListenerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::Running,
+                status: ModuleState::RUNNING,
                 message: "test".to_string(),
                 states: None,
             },
             telemetryLoggerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::Running,
+                status: ModuleState::RUNNING,
                 message: "test".to_string(),
                 states: None,
             },

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -3,23 +3,77 @@
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub struct ModuleState;
-impl ModuleState {
-    pub const RUNNING: &'static str = "RUNNING";
-    pub const STOPPED: &'static str = "STOPPED";
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum ModuleState {
+    Unknown,
+    Running,
+    Stopped,
 }
 
-pub struct OverallState;
+impl ModuleState {
+    const RUNNING: &'static str = "RUNNING";
+    const STOPPED: &'static str = "STOPPED";
+    const UNKNOWN: &'static str = "UNKNOWN";
+}
+
+impl From<&str> for ModuleState {
+    fn from(s: &str) -> Self {
+        match s.to_uppercase().as_str() {
+            ModuleState::RUNNING => ModuleState::Running,
+            ModuleState::STOPPED => ModuleState::Stopped,
+            _ => ModuleState::Unknown,
+        }
+    }
+}
+
+impl From<ModuleState> for String {
+    fn from(s: ModuleState) -> Self {
+        match s {
+            ModuleState::Running => ModuleState::RUNNING.to_string(),
+            ModuleState::Stopped => ModuleState::STOPPED.to_string(),
+            ModuleState::Unknown => ModuleState::UNKNOWN.to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum OverallState {
+    Success,
+    Error,
+    Unknown,
+}
+
 impl OverallState {
-    pub const SUCCESS: &'static str = "SUCCESS"; // All required modules are running
-    pub const ERROR: &'static str = "ERROR"; // One or more required modules are not running
+    const SUCCESS: &'static str = "SUCCESS"; // All required modules are running
+    const ERROR: &'static str = "ERROR"; // One or more required modules are not running
+    const UNKNOWN: &'static str = "UNKNOWN";
+}
+
+impl From<&str> for OverallState {
+    fn from(s: &str) -> Self {
+        match s.to_uppercase().as_str() {
+            OverallState::SUCCESS => OverallState::Success,
+            OverallState::ERROR => OverallState::Error,
+            _ => OverallState::Unknown,
+        }
+    }
+}
+
+impl From<OverallState> for String {
+    fn from(s: OverallState) -> Self {
+        match s {
+            OverallState::Success => OverallState::SUCCESS.to_string(),
+            OverallState::Error => OverallState::ERROR.to_string(),
+            OverallState::Unknown => OverallState::UNKNOWN.to_string(),
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize)]
 #[allow(non_snake_case)]
 pub struct ProxyAgentDetailStatus {
-    pub status: String,  // ModuleState, RUNNING|STOPPED
-    pub message: String, // detail message
+    pub status: ModuleState, // ModuleState, RUNNING|STOPPED
+    pub message: String,     // detail message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub states: Option<HashMap<String, String>>, // module specific states
 }
@@ -28,7 +82,7 @@ pub struct ProxyAgentDetailStatus {
 #[allow(non_snake_case)]
 pub struct ProxyAgentStatus {
     pub version: String,
-    pub status: String, // OverallState, SUCCESS|FAILED
+    pub status: OverallState, // OverallState, SUCCESS|FAILED
     pub monitorStatus: ProxyAgentDetailStatus,
     pub keyLatchStatus: ProxyAgentDetailStatus,
     pub ebpfProgramStatus: ProxyAgentDetailStatus,

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -5,68 +5,16 @@ use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum ModuleState {
-    Unknown,
-    Running,
-    Stopped,
-}
-
-impl ModuleState {
-    const RUNNING: &'static str = "RUNNING";
-    const STOPPED: &'static str = "STOPPED";
-    const UNKNOWN: &'static str = "UNKNOWN";
-}
-
-impl From<&str> for ModuleState {
-    fn from(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            ModuleState::RUNNING => ModuleState::Running,
-            ModuleState::STOPPED => ModuleState::Stopped,
-            _ => ModuleState::Unknown,
-        }
-    }
-}
-
-impl From<ModuleState> for String {
-    fn from(s: ModuleState) -> Self {
-        match s {
-            ModuleState::Running => ModuleState::RUNNING.to_string(),
-            ModuleState::Stopped => ModuleState::STOPPED.to_string(),
-            ModuleState::Unknown => ModuleState::UNKNOWN.to_string(),
-        }
-    }
+    UNKNOWN,
+    RUNNING,
+    STOPPED,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum OverallState {
-    Success,
-    Error,
-    Unknown,
-}
-
-impl OverallState {
-    const SUCCESS: &'static str = "SUCCESS"; // All required modules are running
-    const ERROR: &'static str = "ERROR"; // One or more required modules are not running
-    const UNKNOWN: &'static str = "UNKNOWN";
-}
-
-impl From<&str> for OverallState {
-    fn from(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            OverallState::SUCCESS => OverallState::Success,
-            OverallState::ERROR => OverallState::Error,
-            _ => OverallState::Unknown,
-        }
-    }
-}
-
-impl From<OverallState> for String {
-    fn from(s: OverallState) -> Self {
-        match s {
-            OverallState::Success => OverallState::SUCCESS.to_string(),
-            OverallState::Error => OverallState::ERROR.to_string(),
-            OverallState::Unknown => OverallState::UNKNOWN.to_string(),
-        }
-    }
+    SUCCESS,
+    ERROR,
+    UNKNOWN,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
Searched our codebase with "&'static str" and replace them with strong type enum.

This PR is addressing the feedback from https://github.com/Azure/GuestProxyAgent/issues/117
`There are a couple of places where the use of new enums would be more robust, e.g. ModuleState has associated string constants, which doesn't prevent other arbitrary states from being used where a module state is expected, leading to the rather awkward and very fragile need to use a comment!
pub status: String,  // ModuleState, RUNNING|STOPPED
`