### PR TITLE
Dump the AccessControl rules for supportability purpose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "concurrent-queue",
  "once_cell",
  "os_info",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",

--- a/proxy_agent/src/common/config.rs
+++ b/proxy_agent/src/common/config.rs
@@ -118,7 +118,7 @@ impl Default for Config {
 
 impl Config {
     pub fn from_json_file(file_path: PathBuf) -> Self {
-        misc_helpers::json_read_from_file::<Config>(file_path.to_path_buf()).unwrap_or_else(|_| {
+        misc_helpers::json_read_from_file::<Config>(&file_path).unwrap_or_else(|_| {
             panic!(
                 "Error in reading Config from Json file: {}",
                 misc_helpers::path_to_string(file_path.to_path_buf())

--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -35,3 +35,6 @@ pub const DEFAULT_MAX_EVENT_FILE_COUNT: usize = 30;
 
 pub const CGROUP_ROOT: &str = "/sys/fs/cgroup";
 pub const EGID: u32 = 3080;
+
+pub const MAX_LOG_FILE_COUNT: usize = 20;
+pub const MAX_LOG_FILE_SIZE: u64 = 20 * 1024 * 1024; // 20MB

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -253,7 +253,7 @@ async fn loop_poll(
                     imds: proxy_authenticator_wrapper::get_imds_rules(shared_state.clone()),
                 },
             );
-            rules.write_all(&log_dir, 20);
+            rules.write_all(&log_dir, constants::MAX_LOG_FILE_COUNT);
         }
 
         let state = status.get_secure_channel_state();

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -69,7 +69,7 @@ pub struct KeyStatus {
     pub authorizationRules: Option<AuthorizationRules>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[allow(non_snake_case)]
 pub struct AuthorizationRules {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -19,9 +19,11 @@
 
 use super::{proxy_connection::Connection, Claims};
 use crate::common::logger;
-use crate::key_keeper::key::{AuthorizationItem, Identity, Privilege, Role};
+use crate::key_keeper::key::{AuthorizationItem, AuthorizationRules, Identity, Privilege, Role};
+use proxy_agent_shared::misc_helpers;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -56,7 +58,8 @@ impl std::str::FromStr for AuthorizationMode {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[allow(non_snake_case)]
-pub struct AuthorizationRules {
+pub struct ComputedAuthorizationItem {
+    pub id: String,
     // The default access: allow -> true, deny-> false
     pub defaultAllowed: bool,
     // disabled, audit, enforce
@@ -72,8 +75,10 @@ pub struct AuthorizationRules {
 }
 
 #[allow(dead_code)]
-impl AuthorizationRules {
-    pub fn from_authorization_item(authorization_item: AuthorizationItem) -> AuthorizationRules {
+impl ComputedAuthorizationItem {
+    pub fn from_authorization_item(
+        authorization_item: AuthorizationItem,
+    ) -> ComputedAuthorizationItem {
         let authorization_mode = match AuthorizationMode::from_str(&authorization_item.mode) {
             Ok(mode) => mode,
             Err(err) => {
@@ -146,7 +151,8 @@ impl AuthorizationRules {
             }
         }
 
-        AuthorizationRules {
+        ComputedAuthorizationItem {
+            id: authorization_item.id,
             defaultAllowed: authorization_item.defaultAccess.to_lowercase() == "allow",
             mode: authorization_mode,
             identities: identity_dict,
@@ -235,13 +241,107 @@ impl AuthorizationRules {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+#[allow(non_snake_case)]
+pub struct ComputedAuthorizationRules {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub imds: Option<ComputedAuthorizationItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wireserver: Option<ComputedAuthorizationItem>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[allow(non_snake_case)]
+pub struct AuthorizationRulesForLogging {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputRules: Option<AuthorizationRules>,
+    pub computedRules: ComputedAuthorizationRules,
+}
+
+impl AuthorizationRulesForLogging {
+    pub fn new(
+        input_rules: Option<AuthorizationRules>,
+        computed_rules: ComputedAuthorizationRules,
+    ) -> AuthorizationRulesForLogging {
+        AuthorizationRulesForLogging {
+            inputRules: input_rules,
+            computedRules: computed_rules,
+        }
+    }
+
+    /// Write the authorization rules to a file for support purpose
+    /// The file name is in the format of "AuthorizationRules_{timestamp}.json"
+    /// The content is the json string of the AuthorizationRulesForLogging object
+    /// The file is written to the path_dir specified by the input parameter
+    pub fn write_all(&self, path_dir: &PathBuf, max_file_count: usize) {
+        // remove the old files
+        let files = match misc_helpers::search_files(path_dir, r"^AuthorizationRules_.*\.json$") {
+            Ok(files) => files,
+            Err(e) => {
+                // This should not happen, log the error and skip write the file
+                logger::write_error(format!(
+                    "Failed to search the old authorization rules files under dir {} with error: {}",
+                    path_dir.display(),
+                    e
+                ));
+                return;
+            }
+        };
+        if files.len() >= max_file_count {
+            let mut count = max_file_count;
+            for file in &files {
+                std::fs::remove_file(file).unwrap_or_else(|e| {
+                    logger::write_error(format!(
+                        "Failed to remove the old authorization rules file {} with error: {}",
+                        file.display(),
+                        e
+                    ));
+                });
+                count += 1;
+
+                if count > files.len() {
+                    break;
+                }
+            }
+        }
+
+        // compute the file name
+        let new_file_name = format!(
+            "AuthorizationRules_{}-{}.json",
+            misc_helpers::get_date_time_string_with_milliseconds(),
+            misc_helpers::get_date_time_unix_nano()
+        )
+        .replace(':', ".");
+        let full_file_path = path_dir.join(new_file_name);
+        match misc_helpers::json_write_to_file(&self, &full_file_path) {
+            Ok(_) => {
+                logger::write_information(format!(
+                    "Authorization rules are written to file: {}",
+                    full_file_path.display()
+                ));
+            }
+            Err(e) => {
+                logger::write_error(format!(
+                    "Failed to write the authorization rules to file {} with error: {}",
+                    full_file_path.display(),
+                    e
+                ));
+            }
+        };
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::{AuthorizationRulesForLogging, ComputedAuthorizationRules};
+    use crate::common::logger;
     use crate::key_keeper::key::{
-        AccessControlRules, AuthorizationItem, Identity, Privilege, Role, RoleAssignment,
+        AccessControlRules, AuthorizationItem, AuthorizationRules, Identity, Privilege, Role,
+        RoleAssignment,
     };
-    use crate::proxy::authorization_rules::{AuthorizationMode, AuthorizationRules};
+    use crate::proxy::authorization_rules::{AuthorizationMode, ComputedAuthorizationItem};
     use crate::proxy::{proxy_connection::Connection, Claims};
+    use proxy_agent_shared::{logger_manager, misc_helpers};
     use std::str::FromStr;
 
     #[test]
@@ -280,7 +380,7 @@ mod tests {
             rules: Some(access_control_rules),
             id: "0".to_string(),
         };
-        let rules = AuthorizationRules::from_authorization_item(authorization_item);
+        let rules = ComputedAuthorizationItem::from_authorization_item(authorization_item);
         let _clone_rules = rules.clone();
         assert!(!rules.defaultAllowed);
         assert_eq!(rules.mode, AuthorizationMode::Enforce);
@@ -336,7 +436,7 @@ mod tests {
             rules: Some(access_control_rules),
             id: "0".to_string(),
         };
-        let rules = AuthorizationRules::from_authorization_item(authorization_item);
+        let rules = ComputedAuthorizationItem::from_authorization_item(authorization_item);
         assert!(!rules.defaultAllowed);
         assert_eq!(rules.mode, AuthorizationMode::Audit);
         assert!(!rules.privilegeAssignments.is_empty());
@@ -372,7 +472,7 @@ mod tests {
             rules: Some(access_control_rules),
             id: "0".to_string(),
         };
-        let rules = AuthorizationRules::from_authorization_item(authorization_item);
+        let rules = ComputedAuthorizationItem::from_authorization_item(authorization_item);
         assert!(!rules.defaultAllowed);
         assert_eq!(rules.mode, AuthorizationMode::Disabled);
         assert!(!rules.privilegeAssignments.is_empty());
@@ -413,7 +513,7 @@ mod tests {
             rules: Some(access_control_rules),
             id: "0".to_string(),
         };
-        let rules = AuthorizationRules::from_authorization_item(authorization_item);
+        let rules = ComputedAuthorizationItem::from_authorization_item(authorization_item);
         assert!(!rules.defaultAllowed);
         assert_eq!(rules.mode, AuthorizationMode::Enforce);
         assert!(!rules.privilegeAssignments.is_empty());
@@ -424,5 +524,86 @@ mod tests {
         assert!(!rules.is_allowed(0, url, claims.clone()));
         let relativeurl = hyper::Uri::from_str("/test?").unwrap();
         assert!(!rules.is_allowed(0, relativeurl, claims.clone()));
+    }
+
+    #[tokio::test]
+    async fn test_authorization_rules_for_logging() {
+        let mut temp_test_path = std::env::temp_dir();
+        temp_test_path.push("test_authorization_rules_for_logging");
+        let mut log_dir = temp_test_path.to_path_buf();
+        log_dir.push("Logs");
+
+        // clean up and ignore the clean up errors
+        match std::fs::remove_dir_all(&temp_test_path) {
+            Ok(_) => {}
+            Err(e) => {
+                print!("Failed to remove_dir_all with error {}.", e);
+            }
+        }
+        misc_helpers::try_create_folder(temp_test_path.clone()).unwrap();
+
+        // init main logger
+        logger_manager::init_logger(
+            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
+            log_dir.clone(),
+            "logger_key".to_string(),
+            10 * 1024 * 1024,
+            20,
+        );
+
+        let access_control_rules = AccessControlRules {
+            roles: Some(vec![Role {
+                name: "test".to_string(),
+                privileges: vec!["test".to_string(), "test1".to_string()],
+            }]),
+            privileges: Some(vec![Privilege {
+                name: "test".to_string(),
+                path: "/test".to_string(),
+                queryParameters: None,
+            }]),
+            identities: Some(vec![Identity {
+                name: "test".to_string(),
+                exePath: Some("test".to_string()),
+                groupName: Some("test".to_string()),
+                processName: Some("test".to_string()),
+                userName: Some("test".to_string()),
+            }]),
+            roleAssignments: Some(vec![RoleAssignment {
+                role: "test".to_string(),
+                identities: vec!["test".to_string()],
+            }]),
+        };
+        let authorization_item: AuthorizationItem = AuthorizationItem {
+            defaultAccess: "deny".to_string(),
+            mode: "enforce".to_string(),
+            rules: Some(access_control_rules),
+            id: "0".to_string(),
+        };
+        let computed_authorization_item =
+            ComputedAuthorizationItem::from_authorization_item(authorization_item.clone());
+
+        let authorization_rules_for_logging = AuthorizationRulesForLogging::new(
+            Some(AuthorizationRules {
+                imds: Some(authorization_item.clone()),
+                wireserver: Some(authorization_item.clone()),
+            }),
+            ComputedAuthorizationRules {
+                imds: Some(computed_authorization_item.clone()),
+                wireserver: Some(computed_authorization_item.clone()),
+            },
+        );
+
+        let max_file_count = 5;
+        for _ in 0..10 {
+            authorization_rules_for_logging.write_all(&temp_test_path, max_file_count);
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+
+        let files =
+            misc_helpers::search_files(&temp_test_path, r"^AuthorizationRules_.*\.json$").unwrap();
+        assert_eq!(files.len(), max_file_count);
+
+        // clean up and ignore the clean up errors
+        _ = std::fs::remove_dir_all(&temp_test_path);
     }
 }

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -23,7 +23,7 @@ use crate::key_keeper::key::{AuthorizationItem, AuthorizationRules, Identity, Pr
 use proxy_agent_shared::misc_helpers;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::Path;
 use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -273,7 +273,7 @@ impl AuthorizationRulesForLogging {
     /// The file name is in the format of "AuthorizationRules_{timestamp}.json"
     /// The content is the json string of the AuthorizationRulesForLogging object
     /// The file is written to the path_dir specified by the input parameter
-    pub fn write_all(&self, path_dir: &PathBuf, max_file_count: usize) {
+    pub fn write_all(&self, path_dir: &Path, max_file_count: usize) {
         // remove the old files
         let files = match misc_helpers::search_files(path_dir, r"^AuthorizationRules_.*\.json$") {
             Ok(files) => files,

--- a/proxy_agent/src/proxy/proxy_authorizer.rs
+++ b/proxy_agent/src/proxy/proxy_authorizer.rs
@@ -18,7 +18,7 @@
 //! authorize.authorize(1, url, shared_state.clone());
 //!  
 
-use super::authorization_rules::{AuthorizationMode, AuthorizationRules};
+use super::authorization_rules::{AuthorizationMode, ComputedAuthorizationItem};
 use super::proxy_connection::Connection;
 use super::proxy_summary::ProxySummary;
 use crate::key_keeper::key::AuthorizationItem;
@@ -32,7 +32,7 @@ pub fn set_wireserver_rules(
     shared_state: Arc<Mutex<SharedState>>,
     authorization_item: Option<AuthorizationItem>,
 ) {
-    let rules = authorization_item.map(AuthorizationRules::from_authorization_item);
+    let rules = authorization_item.map(ComputedAuthorizationItem::from_authorization_item);
     proxy_authenticator_wrapper::set_wireserver_rules(shared_state, rules);
 }
 
@@ -40,7 +40,7 @@ pub fn set_imds_rules(
     shared_state: Arc<Mutex<SharedState>>,
     authorization_item: Option<AuthorizationItem>,
 ) {
-    let rules = authorization_item.map(AuthorizationRules::from_authorization_item);
+    let rules = authorization_item.map(ComputedAuthorizationItem::from_authorization_item);
     proxy_authenticator_wrapper::set_imds_rules(shared_state, rules);
 }
 

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -3,7 +3,7 @@
 
 //! This module contains the connection context struct for the proxy listener, and write proxy processing logs to local file.
 
-use crate::common::hyper_client;
+use crate::common::{constants, hyper_client};
 use crate::proxy::Claims;
 use proxy_agent_shared::{logger_manager, rolling_logger::RollingLogger};
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
@@ -45,8 +45,8 @@ impl Connection {
             Connection::CONNECTION_LOGGER_KEY.to_string(),
             log_folder,
             "ProxyAgent.Connection.log".to_string(),
-            20 * 1024 * 1024,
-            30,
+            constants::MAX_LOG_FILE_SIZE,
+            constants::MAX_LOG_FILE_COUNT as u16,
         );
     }
 

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -144,7 +144,7 @@ fn write_aggregate_status_to_file(
     let full_file_path = dir_path.clone();
     let full_file_path = full_file_path.join("status.json");
 
-    if let Err(e) = misc_helpers::json_write_to_file(&status, full_file_path.clone()) {
+    if let Err(e) = misc_helpers::json_write_to_file(&status, &full_file_path) {
         logger::write_error(format!("Error writing status to status file: {}", e));
     }
 
@@ -178,9 +178,8 @@ mod tests {
         let file_path = temp_test_path.join("status.json");
         assert!(file_path.exists(), "File does not exist in the directory");
 
-        let file_content = misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
-            file_path.clone().to_path_buf(),
-        );
+        let file_content =
+            misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(&file_path);
         assert!(file_content.is_ok(), "Failed to read file content");
 
         //Check if field were written

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -46,6 +46,7 @@ pub fn start_service(shared_state: Arc<Mutex<SharedState>>) {
             .parse()
             .unwrap(),
         config::get_keys_dir(),
+        config::get_logs_dir(),
         config::get_poll_key_status_duration(),
         config_start_redirector,
         shared_state.clone(),

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -29,8 +29,8 @@ pub fn start_service(shared_state: Arc<Mutex<SharedState>>) {
         logger::AGENT_LOGGER_KEY.to_string(),
         config::get_logs_dir(),
         "ProxyAgent.log".to_string(),
-        20 * 1024 * 1024,
-        20,
+        constants::MAX_LOG_FILE_SIZE,
+        constants::MAX_LOG_FILE_COUNT as u16,
     );
     logger::write_information(format!(
         "============== GuestProxyAgent ({}) is starting on {}, elapsed: {}",

--- a/proxy_agent/src/shared_state.rs
+++ b/proxy_agent/src/shared_state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::provision::ProvisionFlags;
-use crate::proxy::authorization_rules::AuthorizationRules;
+use crate::proxy::authorization_rules::ComputedAuthorizationItem;
 use crate::redirector;
 use crate::telemetry::event_reader::VMMetaData;
 use crate::{key_keeper::key::Key, proxy::User};
@@ -60,9 +60,9 @@ pub struct SharedState {
 
     // proxy_authenticator
     /// The authorization rules for the WireServer endpoints
-    wireserver_rules: Option<AuthorizationRules>,
+    wireserver_rules: Option<ComputedAuthorizationItem>,
     /// The authorization rules for the IMDS endpoints
-    imds_rules: Option<AuthorizationRules>,
+    imds_rules: Option<ComputedAuthorizationItem>,
 
     // provision
     /// The provision state, it is a bitflag field
@@ -397,30 +397,32 @@ pub mod proxy_listener_wrapper {
 
 pub mod proxy_authenticator_wrapper {
     use super::SharedState;
-    use crate::proxy::authorization_rules::AuthorizationRules;
+    use crate::proxy::authorization_rules::ComputedAuthorizationItem;
     use std::sync::{Arc, Mutex};
 
     pub fn set_wireserver_rules(
         shared_state: Arc<Mutex<SharedState>>,
-        rules: Option<AuthorizationRules>,
+        rules: Option<ComputedAuthorizationItem>,
     ) {
         shared_state.lock().unwrap().wireserver_rules = rules;
     }
 
     pub fn get_wireserver_rules(
         shared_state: Arc<Mutex<SharedState>>,
-    ) -> Option<AuthorizationRules> {
+    ) -> Option<ComputedAuthorizationItem> {
         shared_state.lock().unwrap().wireserver_rules.clone()
     }
 
     pub fn set_imds_rules(
         shared_state: Arc<Mutex<SharedState>>,
-        rules: Option<AuthorizationRules>,
+        rules: Option<ComputedAuthorizationItem>,
     ) {
         shared_state.lock().unwrap().imds_rules = rules;
     }
 
-    pub fn get_imds_rules(shared_state: Arc<Mutex<SharedState>>) -> Option<AuthorizationRules> {
+    pub fn get_imds_rules(
+        shared_state: Arc<Mutex<SharedState>>,
+    ) -> Option<ComputedAuthorizationItem> {
         shared_state.lock().unwrap().imds_rules.clone()
     }
 }

--- a/proxy_agent/src/telemetry/event_reader.rs
+++ b/proxy_agent/src/telemetry/event_reader.rs
@@ -206,7 +206,7 @@ async fn process_events_and_clean(
 ) -> usize {
     let mut num_events_logged = 0;
     for file in files {
-        match misc_helpers::json_read_from_file::<Vec<Event>>(file.to_path_buf()) {
+        match misc_helpers::json_read_from_file::<Vec<Event>>(&file) {
             Ok(events) => {
                 num_events_logged += events.len();
                 send_events(events, wire_server_client, shared_state.clone()).await;
@@ -383,7 +383,7 @@ mod tests {
         misc_helpers::try_create_folder(events_dir.to_path_buf()).unwrap();
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, file_path.to_path_buf()).unwrap();
+        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
 
         // Check the events processed
         let files = misc_helpers::get_files(&events_dir).unwrap();

--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -20,7 +20,7 @@ pub fn get_handler_environment(exe_path: PathBuf) -> HandlerEnvironment {
     handler_env_path.push(constants::HANDLER_ENVIRONMENT_FILE);
 
     let handler_env_file: Vec<structs::Handler> =
-        match misc_helpers::json_read_from_file(handler_env_path) {
+        match misc_helpers::json_read_from_file(&handler_env_path) {
             Ok(temp) => temp,
             Err(e) => {
                 eprintln!("Error in reading handler env file: {e}");
@@ -369,7 +369,7 @@ mod tests {
         let handler_env_obj: Vec<Handler> = serde_json::from_str(json_handler_linux).unwrap();
 
         //Write the deserialized json object to HandlerEnvironment.json file
-        _ = misc_helpers::json_write_to_file(&handler_env_obj, handler_env_file);
+        _ = misc_helpers::json_write_to_file(&handler_env_obj, &handler_env_file);
 
         let handler_env = super::get_handler_environment(temp_test_path.to_path_buf());
         assert_eq!(handler_env.logFolder, "log".to_string());
@@ -413,10 +413,9 @@ mod tests {
             substatus: Default::default(),
         };
         common::report_status(status_folder, &Some(seq_no.to_string()), &handler_status);
-        let status_obj = misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(
-            expected_status_file.to_path_buf(),
-        )
-        .unwrap();
+        let status_obj =
+            misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(&expected_status_file)
+                .unwrap();
         assert_eq!(status_obj.len(), 1);
         assert_eq!(status_obj[0].status.name, "test".to_string());
 
@@ -506,10 +505,9 @@ mod tests {
         let expected_status_file: &PathBuf = &temp_test_path.join("status").join("0.status");
 
         super::report_status_enable_command(status_folder, &Some(config_seq_no.to_string()), None);
-        let status_obj = misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(
-            expected_status_file.to_path_buf(),
-        )
-        .unwrap();
+        let status_obj =
+            misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(&expected_status_file)
+                .unwrap();
         assert_eq!(status_obj.len(), 1);
         assert_eq!(status_obj[0].status.operation, "Enable");
         _ = fs::remove_dir_all(&temp_test_path);
@@ -537,10 +535,9 @@ mod tests {
             },
         };
         common::report_heartbeat(expected_heartbeat_file.to_path_buf(), heartbeat_obj);
-        let heartbeat_obj = misc_helpers::json_read_from_file::<Vec<TopLevelHeartbeat>>(
-            expected_heartbeat_file.to_path_buf(),
-        )
-        .unwrap();
+        let heartbeat_obj =
+            misc_helpers::json_read_from_file::<Vec<TopLevelHeartbeat>>(&expected_heartbeat_file)
+                .unwrap();
         assert_eq!(heartbeat_obj.len(), 1);
         assert_eq!(heartbeat_obj[0].heartbeat.status, "test".to_string());
 

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -311,7 +311,7 @@ fn report_proxy_agent_aggregate_status(
 
     let proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus;
     match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
-        aggregate_status_file_path,
+        &aggregate_status_file_path,
     ) {
         Ok(ok) => {
             write_state_event(
@@ -712,10 +712,9 @@ mod tests {
                 &mut status_state_obj,
             );
 
-            let handler_status = misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(
-                expected_status_file.to_path_buf(),
-            )
-            .unwrap();
+            let handler_status =
+                misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(&expected_status_file)
+                    .unwrap();
             assert_eq!(handler_status.len(), 1);
             assert_eq!(handler_status[0].status.code, 0);
 
@@ -735,10 +734,9 @@ mod tests {
                 &mut status,
                 &mut status_state_obj,
             );
-            let handler_status_bad = misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(
-                expected_status_file_bad.to_path_buf(),
-            )
-            .unwrap();
+            let handler_status_bad =
+                misc_helpers::json_read_from_file::<Vec<TopLevelStatus>>(expected_status_file_bad)
+                    .unwrap();
             assert_eq!(handler_status_bad.len(), 1);
             assert_eq!(handler_status_bad[0].status.code, 1);
 

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -13,6 +13,7 @@ thread-id = "4.0.0"
 serde = "1.0.152"
 serde_derive = "1.0.152"
 serde_json = "1.0.91"         # json Deserializer
+regex = "1.9.5"               # match file name 
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.5.0"     # windows NT service

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -3,7 +3,11 @@
 use regex::bytes::Regex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::{fs, fs::File, path::PathBuf, process::Command};
+use std::{
+    fs::{self, File},
+    path::{Path, PathBuf},
+    process::Command,
+};
 use thread_id;
 use time::{format_description, OffsetDateTime};
 
@@ -62,7 +66,7 @@ pub fn try_create_folder(dir: PathBuf) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn json_write_to_file<T>(obj: &T, file_path: &PathBuf) -> std::io::Result<()>
+pub fn json_write_to_file<T>(obj: &T, file_path: &Path) -> std::io::Result<()>
 where
     T: ?Sized + Serialize,
 {
@@ -72,7 +76,7 @@ where
     Ok(())
 }
 
-pub fn json_read_from_file<T>(file_path: &PathBuf) -> std::io::Result<T>
+pub fn json_read_from_file<T>(file_path: &Path) -> std::io::Result<T>
 where
     T: DeserializeOwned,
 {
@@ -150,7 +154,7 @@ pub fn get_current_version() -> String {
     VERSION.to_string()
 }
 
-pub fn get_files(dir: &PathBuf) -> std::io::Result<Vec<PathBuf>> {
+pub fn get_files(dir: &Path) -> std::io::Result<Vec<PathBuf>> {
     // search files
     let mut files: Vec<PathBuf> = Vec::new();
     for entry in fs::read_dir(dir)? {
@@ -185,7 +189,7 @@ pub fn get_files(dir: &PathBuf) -> std::io::Result<Vec<PathBuf>> {
 /// let search_regex_pattern = r"^MyFile.*\.json$"; // Regex pattern to match "MyFile*.json"
 /// let files = misc_helpers::search_files(&dir, search_regex_pattern).unwrap();
 /// ```
-pub fn search_files(dir: &PathBuf, search_regex_pattern: &str) -> std::io::Result<Vec<PathBuf>> {
+pub fn search_files(dir: &Path, search_regex_pattern: &str) -> std::io::Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     let regex = match Regex::new(search_regex_pattern) {
         Ok(re) => re,

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+use regex::bytes::Regex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::{fs, fs::File, path::PathBuf, process::Command};
@@ -61,7 +62,7 @@ pub fn try_create_folder(dir: PathBuf) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn json_write_to_file<T>(obj: &T, file_path: PathBuf) -> std::io::Result<()>
+pub fn json_write_to_file<T>(obj: &T, file_path: &PathBuf) -> std::io::Result<()>
 where
     T: ?Sized + Serialize,
 {
@@ -71,7 +72,7 @@ where
     Ok(())
 }
 
-pub fn json_read_from_file<T>(file_path: PathBuf) -> std::io::Result<T>
+pub fn json_read_from_file<T>(file_path: &PathBuf) -> std::io::Result<T>
 where
     T: DeserializeOwned,
 {
@@ -150,7 +151,7 @@ pub fn get_current_version() -> String {
 }
 
 pub fn get_files(dir: &PathBuf) -> std::io::Result<Vec<PathBuf>> {
-    // search log files
+    // search files
     let mut files: Vec<PathBuf> = Vec::new();
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
@@ -160,6 +161,53 @@ pub fn get_files(dir: &PathBuf) -> std::io::Result<Vec<PathBuf>> {
             continue;
         }
         files.push(file_full_path);
+    }
+    files.sort();
+    Ok(files)
+}
+
+/// Search files in a directory with a regex pattern
+/// # Arguments
+/// * `dir` - The directory to search
+/// * `search_regex_pattern` - The regex pattern to search
+/// # Returns
+/// A vector of PathBufs that match the search pattern in ascending order
+/// # Errors
+/// Returns an error if the regex pattern is invalid or if there is an IO error
+/// # Example
+/// ```rust
+/// use std::path::PathBuf;
+/// use proxy_agent_shared::misc_helpers;
+/// let dir = PathBuf::from("C:\\");
+/// let search_regex_pattern = r"^(.*\.log)$";  // search for files with .log extension
+/// let files = misc_helpers::search_files(&dir, search_regex_pattern).unwrap();
+///
+/// let search_regex_pattern = r"^MyFile.*\.json$"; // Regex pattern to match "MyFile*.json"
+/// let files = misc_helpers::search_files(&dir, search_regex_pattern).unwrap();
+/// ```
+pub fn search_files(dir: &PathBuf, search_regex_pattern: &str) -> std::io::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let regex = match Regex::new(search_regex_pattern) {
+        Ok(re) => re,
+        Err(e) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to create regex with error {}", e),
+            ));
+        }
+    };
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_full_path = entry.path();
+        let metadata = fs::metadata(&file_full_path)?;
+        if !metadata.is_file() {
+            continue;
+        }
+        let file_name = get_file_name(file_full_path.clone());
+        if regex.is_match(file_name.as_bytes()) {
+            files.push(file_full_path);
+        }
     }
     files.sort();
     Ok(files)
@@ -240,8 +288,8 @@ mod tests {
             current_exe_dir: super::get_current_exe_dir().to_str().unwrap().to_string(),
         };
 
-        super::json_write_to_file(&test, json_file.clone()).unwrap();
-        let json = super::json_read_from_file::<TestStruct>(json_file.clone()).unwrap();
+        super::json_write_to_file(&test, &json_file).unwrap();
+        let json = super::json_read_from_file::<TestStruct>(&json_file).unwrap();
 
         assert_eq!(test.thread_id, json.thread_id);
         assert_eq!(
@@ -327,6 +375,59 @@ mod tests {
         let path = PathBuf::new();
         let file_name = super::get_file_name(path);
         assert_eq!("InvalidPath", file_name, "file_name mismatch");
+    }
+
+    #[test]
+    fn search_files_test() {
+        let mut temp_test_path = env::temp_dir();
+        temp_test_path.push("search_files_test");
+        // clean up and ignore the clean up errors
+        _ = fs::remove_dir_all(&temp_test_path);
+        super::try_create_folder(temp_test_path.clone()).unwrap();
+
+        let test = TestStruct {
+            thread_id: super::get_thread_identity(),
+            date_time_string_with_milliseconds: super::get_date_time_string_with_milliseconds(),
+            date_time_string: super::get_date_time_string(),
+            date_time_rfc1123_string: super::get_date_time_rfc1123_string(),
+            date_time_unix_nano: super::get_date_time_unix_nano(),
+            long_os_version: super::get_long_os_version(),
+            current_exe_dir: super::get_current_exe_dir().to_str().unwrap().to_string(),
+        };
+
+        // write 2 json files to the temp_test_path
+        let json_file = temp_test_path.as_path();
+        let json_file = json_file.join("test.json");
+        super::json_write_to_file(&test, &json_file).unwrap();
+        let json_file = temp_test_path.as_path();
+        let json_file = json_file.join("test_1.json");
+        super::json_write_to_file(&test, &json_file).unwrap();
+
+        let files = super::search_files(&temp_test_path, "test.json").unwrap();
+        assert_eq!(
+            1,
+            files.len(),
+            "file count mismatch with 'test.json' search"
+        );
+
+        let files = super::search_files(&temp_test_path, r"^test.*\.json$").unwrap();
+        assert_eq!(
+            2,
+            files.len(),
+            "file count mismatch with 'test*.json' search"
+        );
+        assert_eq!(
+            "test.json",
+            super::get_file_name(files[0].clone()),
+            "First file name mismatch"
+        );
+        assert_eq!(
+            "test_1.json",
+            super::get_file_name(files[1].clone()),
+            "Second file name mismatch"
+        );
+
+        _ = fs::remove_dir_all(&temp_test_path);
     }
 
     #[test]

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -125,7 +125,7 @@ fn start<F>(
         let mut file_path = event_dir.to_path_buf();
 
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        match misc_helpers::json_write_to_file(&events, file_path.to_path_buf()) {
+        match misc_helpers::json_write_to_file(&events, &file_path) {
             Ok(()) => {
                 logger_manager::write(
                     logger_key,


### PR DESCRIPTION
- Dump the AccessControl rules for supportability purpose in key_keeper module
- remove unnecessarily ownership move in misc_helper function json_write_to_file & json_read_from_file