### PR TITLE
Proxy Agent: Convert all remaining errors to custom-defined error types

### DIFF
--- a/proxy_agent/src/acl.rs
+++ b/proxy_agent/src/acl.rs
@@ -19,9 +19,10 @@ mod windows_acl;
 #[cfg(not(windows))]
 mod linux_acl;
 
+use crate::common::result::Result;
 use std::path::PathBuf;
 
-pub fn acl_directory(dir_to_acl: PathBuf) -> std::io::Result<()> {
+pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
     if !dir_to_acl.exists() || !dir_to_acl.is_dir() {
         return Ok(());
     }

--- a/proxy_agent/src/acl/linux_acl.rs
+++ b/proxy_agent/src/acl/linux_acl.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::common::logger;
+use crate::common::{logger, result::Result};
 use nix::unistd::{chown, Gid, Uid};
 use proxy_agent_shared::misc_helpers;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
-pub fn acl_directory(dir_to_acl: PathBuf) -> std::io::Result<()> {
+pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
     let dir_str = misc_helpers::path_to_string(&dir_to_acl);
     logger::write(format!(
         "acl_directory: start to set root-only permission to folder {}.",

--- a/proxy_agent/src/acl/windows_acl.rs
+++ b/proxy_agent/src/acl/windows_acl.rs
@@ -7,7 +7,6 @@ use crate::common::{
     result::Result,
 };
 use proxy_agent_shared::misc_helpers;
-// use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use winapi::um::winnt::PSID;
 use windows_acl::acl::{AceType, ACL};

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -40,6 +40,14 @@ impl Error {
     pub fn wire_server(error_type: WireServerErrorType, message: String) -> Self {
         Self::new(ErrorType::WireServer(error_type, message))
     }
+
+    pub fn acl(error: AclErrorType, error_code: u32) -> Self {
+        Self::new(ErrorType::Acl(error, error_code))
+    }
+
+    pub fn bpf(error: BpfErrorType) -> Self {
+        Self::new(ErrorType::Bpf(error))
+    }
 }
 
 impl Display for Error {
@@ -69,6 +77,12 @@ enum ErrorType {
 
     #[error("Failed to parse URL {0} with error: {1}")]
     ParseUrl(String, String),
+
+    #[error("acl_directory: {0} with error: {1}")]
+    Acl(AclErrorType, u32),
+
+    #[error("{0}")]
+    Bpf(BpfErrorType),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -111,6 +125,45 @@ pub enum KeyErrorType {
 
     #[error("Failed to join {0} and {1} with error: {2}")]
     ParseKeyUrl(String, String, InvalidUri),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AclErrorType {
+    #[error("Failed to get ACL object for folder '{0}'")]
+    AclObject(String),
+
+    #[error("Failed to get SID for '{0}'")]
+    Sid(String),
+
+    #[error("Failed to get ACL entries for folder '{0}'")]
+    AclEntries(String),
+
+    #[error("Failed to add entry for SID '{0}'")]
+    AddEntry(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BpfErrorType {
+    #[error("Failed to lookup element '{0}' in BPF map 'audit_map'. {1}")]
+    MapLookupElem(String, String),
+
+    #[error("Failed to retrieve file descriptor of the BPF map 'audit_map' with error: {0}")]
+    MapFileDescriptor(String),
+
+    #[error("Failed to find valid map 'audit_map' in BPF object with error: {0}")]
+    FindBpfMap(String),
+
+    #[error("Failed to get eBPF API: API is not loaded")]
+    GetBpfApi,
+
+    #[error("Loading eBPF API from file path '{0}' failed with error: {1}")]
+    LoadBpfApi(String, libloading::Error),
+
+    #[error("Loading BPF API function '{0}' failed with error: {1}")]
+    LoadBpfApiFunction(String, libloading::Error),
+
+    #[error("CString initialization failed with error: {0}")]
+    CString(std::ffi::NulError),
 }
 
 #[cfg(test)]

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -52,6 +52,10 @@ impl Error {
     pub fn windows_api(error: WindowsApiErrorType) -> Self {
         Self::new(ErrorType::WindowsApi(error))
     }
+
+    pub fn invalid(error: String) -> Self {
+        Self::new(ErrorType::Invalid(error))
+    }
 }
 
 impl Display for Error {
@@ -90,6 +94,9 @@ enum ErrorType {
 
     #[error("{0}")]
     WindowsApi(WindowsApiErrorType),
+
+    #[error("{0} is invalid")]
+    Invalid(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -157,17 +164,23 @@ pub enum BpfErrorType {
     #[error("Failed to retrieve file descriptor of the BPF map 'audit_map' with error: {0}")]
     MapFileDescriptor(String),
 
-    #[error("Failed to find valid map 'audit_map' in BPF object with error: {0}")]
-    FindBpfMap(String),
+    #[error("Failed to get valid map 'audit_map' in BPF object with error: {0}")]
+    GetBpfMap(String),
 
     #[error("Failed to get eBPF API: API is not loaded")]
     GetBpfApi,
 
+    #[error("Failed to get BPF object: Object is not initialized")]
+    GetBpfObject,
+
     #[error("Loading eBPF API from file path '{0}' failed with error: {1}")]
-    LoadBpfApi(String, libloading::Error),
+    LoadBpfApi(String, String),
 
     #[error("Loading BPF API function '{0}' failed with error: {1}")]
-    LoadBpfApiFunction(String, libloading::Error),
+    LoadBpfApiFunction(String, String),
+
+    #[error("Failed to load HashMap 'audit_map' with error: {0}")]
+    LoadBpfMapHashMap(String),
 
     #[error("CString initialization failed with error: {0}")]
     CString(std::ffi::NulError),
@@ -176,7 +189,7 @@ pub enum BpfErrorType {
 #[derive(Debug, thiserror::Error)]
 pub enum WindowsApiErrorType {
     #[error("Loading NetUserGetLocalGroups failed with error: {0}")]
-    LoadNetUserGetLocalGroups(libloading::Error),
+    LoadNetUserGetLocalGroups(String),
 
     #[error("LsaGetLogonSessionData {0}")]
     LsaGetLogonSessionData(String),

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -48,6 +48,10 @@ impl Error {
     pub fn bpf(error: BpfErrorType) -> Self {
         Self::new(ErrorType::Bpf(error))
     }
+
+    pub fn windows_api(error: WindowsApiErrorType) -> Self {
+        Self::new(ErrorType::WindowsApi(error))
+    }
 }
 
 impl Display for Error {
@@ -83,6 +87,9 @@ enum ErrorType {
 
     #[error("{0}")]
     Bpf(BpfErrorType),
+
+    #[error("{0}")]
+    WindowsApi(WindowsApiErrorType),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -164,6 +171,24 @@ pub enum BpfErrorType {
 
     #[error("CString initialization failed with error: {0}")]
     CString(std::ffi::NulError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WindowsApiErrorType {
+    #[error("Loading NetUserGetLocalGroups failed with error: {0}")]
+    LoadNetUserGetLocalGroups(libloading::Error),
+
+    #[error("LsaGetLogonSessionData {0}")]
+    LsaGetLogonSessionData(String),
+
+    #[error("WinSock::WSAIoctl - SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT: {0}")]
+    WSAIoctl(i32),
+
+    #[error("GlobalMemoryStatusExfailed: {0}")]
+    GlobalMemoryStatusEx(String),
+
+    #[error("{0}")]
+    WindowsOsError(std::io::Error),
 }
 
 #[cfg(test)]

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -197,7 +197,7 @@ pub enum WindowsApiErrorType {
     #[error("WinSock::WSAIoctl - SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT: {0}")]
     WSAIoctl(i32),
 
-    #[error("GlobalMemoryStatusExfailed: {0}")]
+    #[error("GlobalMemoryStatusEx failed: {0}")]
     GlobalMemoryStatusEx(String),
 
     #[error("{0}")]

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -41,6 +41,7 @@ pub mod proxy_summary;
 #[cfg(windows)]
 mod windows;
 
+use crate::common::result::Result;
 use crate::shared_state::SharedState;
 use crate::{redirector::AuditEntry, shared_state::proxy_wrapper};
 use serde_derive::{Deserialize, Serialize};
@@ -81,7 +82,7 @@ pub struct User {
 const UNDEFINED: &str = "undefined";
 const EMPTY: &str = "empty";
 
-fn get_user(logon_id: u64, shared_state: Arc<Mutex<SharedState>>) -> std::io::Result<User> {
+fn get_user(logon_id: u64, shared_state: Arc<Mutex<SharedState>>) -> Result<User> {
     // cache the logon_id -> user_name
     match proxy_wrapper::get_user(shared_state.clone(), logon_id) {
         Some(user) => Ok(user),
@@ -131,7 +132,7 @@ impl Claims {
         entry: &AuditEntry,
         client_ip: IpAddr,
         shared_state: Arc<Mutex<SharedState>>,
-    ) -> std::io::Result<Self> {
+    ) -> Result<Self> {
         let p = Process::from_pid(entry.process_id);
         let u = get_user(entry.logon_id, shared_state)?;
         Ok(Claims {
@@ -209,7 +210,7 @@ impl Process {
 }
 
 impl User {
-    pub fn from_logon_id(logon_id: u64) -> std::io::Result<Self> {
+    pub fn from_logon_id(logon_id: u64) -> Result<Self> {
         let user_name;
         let mut user_groups: Vec<String> = Vec::new();
 

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -270,9 +270,13 @@ async fn handle_request(
                 ) {
                     Ok(data) => entry = Some(data),
                     Err(e) => {
-                        Connection::write_warning(
-                            connection_id,
-                            format!("Failed to get lookup_audit_from_stream_socket: {}", e),
+                        let err = format!("Failed to get lookup_audit_from_stream: {}", e);
+                        event_logger::write_event(
+                            event_logger::WARN_LEVEL,
+                            err,
+                            "handle_request",
+                            "proxy_listener",
+                            Connection::CONNECTION_LOGGER_KEY,
                         );
                     }
                 }

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -19,7 +19,9 @@
 //! tokio::spawn(proxy_server::start(port, shared_state.clone()));
 //! ```
 
-use crate::common::{config, constants, helpers, hyper_client, logger, result::Result};
+use crate::common::{
+    config, constants, error::Error, helpers, hyper_client, logger, result::Result,
+};
 use crate::proxy::proxy_connection::{Connection, ConnectionContext};
 use crate::proxy::{proxy_authorizer, proxy_summary::ProxySummary, Claims};
 use crate::shared_state::{
@@ -188,11 +190,15 @@ async fn accept_one_request(
 }
 
 // Set the read timeout for the stream
-fn set_stream_read_time_out(
-    stream: TcpStream,
-) -> std::io::Result<(TcpStream, std::net::TcpStream)> {
+fn set_stream_read_time_out(stream: TcpStream) -> Result<(TcpStream, std::net::TcpStream)> {
     // Convert the stream to a std stream
-    let std_stream = stream.into_std()?;
+    let std_stream = stream.into_std().map_err(|e| {
+        Error::io(
+            "Failed to convert Tokio stream into std equivalent".to_string(),
+            e,
+        )
+    })?;
+
     // Set the read timeout
     if let Err(e) = std_stream.set_read_timeout(Some(std::time::Duration::from_secs(10))) {
         Connection::write_warning(
@@ -202,10 +208,17 @@ fn set_stream_read_time_out(
     }
 
     // Clone the stream for the service_fn
-    let cloned_std_stream = std_stream.try_clone()?;
+    let cloned_std_stream = std_stream
+        .try_clone()
+        .map_err(|e| Error::io("Failed to clone TCP stream".to_string(), e))?;
 
     // Convert the std stream back
-    let tokio_tcp_stream = TcpStream::from_std(std_stream)?;
+    let tokio_tcp_stream = TcpStream::from_std(std_stream).map_err(|e| {
+        Error::io(
+            "Failed to convert std stream into Tokio equivalent".to_string(),
+            e,
+        )
+    })?;
 
     Ok((tokio_tcp_stream, cloned_std_stream))
 }
@@ -257,16 +270,10 @@ async fn handle_request(
                 ) {
                     Ok(data) => entry = Some(data),
                     Err(e) => {
-                        if e.kind() != std::io::ErrorKind::Unsupported {
-                            let err = format!("Failed to get lookup_audit_from_stream: {}", e);
-                            event_logger::write_event(
-                                event_logger::WARN_LEVEL,
-                                err,
-                                "handle_request",
-                                "proxy_listener",
-                                Connection::CONNECTION_LOGGER_KEY,
-                            );
-                        }
+                        Connection::write_warning(
+                            connection_id,
+                            format!("Failed to get lookup_audit_from_stream_socket: {}", e),
+                        );
                     }
                 }
             }

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -66,9 +66,12 @@ fn net_user_get_local_groups(
 ) -> Result<u32> {
     unsafe {
         let fun_name = "NetUserGetLocalGroups\0";
-        let net_user_get_local_groups: Symbol<NetUserGetLocalGroups> = NETAPI32_DLL
-            .get(fun_name.as_bytes())
-            .map_err(|e| Error::windows_api(WindowsApiErrorType::LoadNetUserGetLocalGroups(e)))?;
+        let net_user_get_local_groups: Symbol<NetUserGetLocalGroups> =
+            NETAPI32_DLL.get(fun_name.as_bytes()).map_err(|e| {
+                Error::windows_api(WindowsApiErrorType::LoadNetUserGetLocalGroups(
+                    e.to_string(),
+                ))
+            })?;
         let status = net_user_get_local_groups(
             servername,
             username,
@@ -255,10 +258,7 @@ pub fn query_basic_process_info(handler: isize) -> Result<PROCESS_BASIC_INFORMAT
 }
 pub fn get_process_handler(pid: u32) -> Result<HANDLE> {
     if pid == 0 {
-        return Err(Error::new(
-            ErrorKind::InvalidInput,
-            "pid 0 is not a valid process id",
-        ));
+        return Err(Error::invalid("pid 0".to_string()));
     }
     let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
 

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-use crate::common::logger;
+use crate::common::{
+    error::{Error, WindowsApiErrorType},
+    logger,
+    result::Result,
+};
 use libloading::{Library, Symbol};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::io::{Error, ErrorKind};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 use windows_sys::Win32::Foundation::{BOOL, HANDLE, LUID, NTSTATUS, UNICODE_STRING};
@@ -60,16 +63,12 @@ fn net_user_get_local_groups(
     prefmaxlen: u32,
     entriesread: *mut u32,
     totalentries: *mut u32,
-) -> std::io::Result<u32> {
+) -> Result<u32> {
     unsafe {
         let fun_name = "NetUserGetLocalGroups\0";
-        let net_user_get_local_groups: Symbol<NetUserGetLocalGroups> =
-            NETAPI32_DLL.get(fun_name.as_bytes()).map_err(|e| {
-                Error::new(
-                    ErrorKind::Other,
-                    format!("Loading {} failed with error: {}", fun_name, e),
-                )
-            })?;
+        let net_user_get_local_groups: Symbol<NetUserGetLocalGroups> = NETAPI32_DLL
+            .get(fun_name.as_bytes())
+            .map_err(|e| Error::windows_api(WindowsApiErrorType::LoadNetUserGetLocalGroups(e)))?;
         let status = net_user_get_local_groups(
             servername,
             username,
@@ -99,7 +98,7 @@ fn load_users() -> HashMap<u64, &'static str> {
 /*
     Get user name and user group names
 */
-pub fn get_user(logon_id: u64) -> std::io::Result<(String, Vec<String>)> {
+pub fn get_user(logon_id: u64) -> Result<(String, Vec<String>)> {
     let mut user_name;
     let luid = LUID {
         LowPart: (logon_id & 0xFFFFFFFF) as u32, // get lower part of 32 bits
@@ -109,13 +108,9 @@ pub fn get_user(logon_id: u64) -> std::io::Result<(String, Vec<String>)> {
     let mut data = MaybeUninit::<*mut SECURITY_LOGON_SESSION_DATA>::uninit();
     let status = unsafe { Identity::LsaGetLogonSessionData(&luid, data.as_mut_ptr()) };
     if status != 0 {
-        let e = Error::from_raw_os_error(status as i32);
-        return Err(Error::new(
-            ErrorKind::Other,
-            format!(
-                "LsaGetLogonSessionData failed ({}) with os error: {}",
-                status, e
-            ),
+        let e = std::io::Error::from_raw_os_error(status as i32);
+        return Err(Error::windows_api(
+            WindowsApiErrorType::LsaGetLogonSessionData(format!("failed with os error: {}", e)),
         ));
     }
 
@@ -123,10 +118,12 @@ pub fn get_user(logon_id: u64) -> std::io::Result<(String, Vec<String>)> {
     if session_data.UserName.Length != 0 {
         user_name = from_unicode_string(&session_data.UserName);
     } else {
-        let e = Error::last_os_error();
-        return Err(Error::new(
-            ErrorKind::Other,
-            format!("LsaGetLogonSessionData could not get the user name: {}", e),
+        let e = std::io::Error::last_os_error();
+        return Err(Error::windows_api(
+            WindowsApiErrorType::LsaGetLogonSessionData(format!(
+                "could not get the user name: {}",
+                e
+            )),
         ));
     }
     let mut domain_user_name = user_name.clone();
@@ -165,7 +162,7 @@ pub fn get_user(logon_id: u64) -> std::io::Result<(String, Vec<String>)> {
             user_groups.push(group_name);
         }
     } else {
-        let e = Error::from_raw_os_error(status as i32);
+        let e = std::io::Error::from_raw_os_error(status as i32);
         logger::write_warning(format!(
             "NetUserGetLocalGroups '{}' failed ({}) with os error: {}",
             domain_user_name, status, e
@@ -236,7 +233,7 @@ const STATUS_INFO_LENGTH_MISMATCH: NTSTATUS = -1073741820;
 const PROCESS_BASIC_INFORMATION_CLASS: PROCESSINFOCLASS = 0;
 const PROCESS_COMMAND_LINE_INFORMATION_CLASS: PROCESSINFOCLASS = 60;
 
-pub fn query_basic_process_info(handler: isize) -> std::io::Result<PROCESS_BASIC_INFORMATION> {
+pub fn query_basic_process_info(handler: isize) -> Result<PROCESS_BASIC_INFORMATION> {
     unsafe {
         let mut process_basic_information = std::mem::zeroed::<PROCESS_BASIC_INFORMATION>();
         let mut return_length = 0;
@@ -249,12 +246,14 @@ pub fn query_basic_process_info(handler: isize) -> std::io::Result<PROCESS_BASIC
         );
 
         if status != 0 {
-            return Err(Error::from_raw_os_error(status));
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::from_raw_os_error(status),
+            )));
         }
         Ok(process_basic_information)
     }
 }
-pub fn get_process_handler(pid: u32) -> std::io::Result<HANDLE> {
+pub fn get_process_handler(pid: u32) -> Result<HANDLE> {
     if pid == 0 {
         return Err(Error::new(
             ErrorKind::InvalidInput,
@@ -266,13 +265,15 @@ pub fn get_process_handler(pid: u32) -> std::io::Result<HANDLE> {
     unsafe {
         let handler = OpenProcess(options, FALSE, pid);
         if handler == 0 {
-            return Err(Error::last_os_error());
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::last_os_error(),
+            )));
         }
         Ok(handler)
     }
 }
 
-pub fn get_process_cmd(handler: isize) -> std::io::Result<String> {
+pub fn get_process_cmd(handler: isize) -> Result<String> {
     unsafe {
         let mut return_length = 0;
         let status: NTSTATUS = NtQueryInformationProcess(
@@ -287,7 +288,9 @@ pub fn get_process_cmd(handler: isize) -> std::io::Result<String> {
             && status != STATUS_BUFFER_TOO_SMALL
             && status != STATUS_INFO_LENGTH_MISMATCH
         {
-            return Err(Error::from_raw_os_error(status));
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::from_raw_os_error(status),
+            )));
         }
         println!("return_length: {}", return_length);
 
@@ -304,7 +307,9 @@ pub fn get_process_cmd(handler: isize) -> std::io::Result<String> {
         );
         if status < 0 {
             eprintln!("NtQueryInformationProcess failed with status: {}", status);
-            return Err(Error::from_raw_os_error(status));
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::from_raw_os_error(status),
+            )));
         }
         buffer.set_len(buf_len);
         buffer.push(0);
@@ -321,24 +326,28 @@ pub fn get_process_cmd(handler: isize) -> std::io::Result<String> {
 }
 
 #[allow(dead_code)]
-pub fn get_process_name(handler: isize) -> std::io::Result<String> {
+pub fn get_process_name(handler: isize) -> Result<String> {
     unsafe {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleBaseNameW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
         if size == 0 {
-            return Err(Error::last_os_error());
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::last_os_error(),
+            )));
         }
         let name = String::from_utf16_lossy(&buffer[..size as usize]);
         Ok(name)
     }
 }
 
-pub fn get_process_full_name(handler: isize) -> std::io::Result<String> {
+pub fn get_process_full_name(handler: isize) -> Result<String> {
     unsafe {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleFileNameExW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
         if size == 0 {
-            return Err(Error::last_os_error());
+            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+                std::io::Error::last_os_error(),
+            )));
         }
         let name = String::from_utf16_lossy(&buffer[..size as usize]);
         Ok(name)

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -56,9 +56,7 @@ async fn loop_status(interval: Duration, shared_state: Arc<Mutex<SharedState>>) 
     loop {
         let aggregate_status = guest_proxy_agent_aggregate_status_new(shared_state.clone());
 
-        if let Err(e) = write_aggregate_status_to_file(dir_path.clone(), aggregate_status) {
-            logger::write_error(format!("Error writing aggregate status to file: {}", e));
-        }
+        write_aggregate_status_to_file(dir_path.clone(), aggregate_status);
 
         let elapsed_time = start_time.elapsed();
 
@@ -137,18 +135,16 @@ fn guest_proxy_agent_aggregate_status_new(
     }
 }
 
-fn write_aggregate_status_to_file(
-    dir_path: PathBuf,
-    status: GuestProxyAgentAggregateStatus,
-) -> std::io::Result<()> {
+fn write_aggregate_status_to_file(dir_path: PathBuf, status: GuestProxyAgentAggregateStatus) {
     let full_file_path = dir_path.clone();
     let full_file_path = full_file_path.join("status.json");
 
     if let Err(e) = misc_helpers::json_write_to_file(&status, &full_file_path) {
-        logger::write_error(format!("Error writing status to status file: {}", e));
+        logger::write_error(format!(
+            "Error writing aggregate status to status file: {}",
+            e
+        ));
     }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -173,7 +169,7 @@ mod tests {
         let shared_state = SharedState::new();
         let aggregate_status = guest_proxy_agent_aggregate_status_new(shared_state.clone());
 
-        _ = write_aggregate_status_to_file(temp_test_path.clone(), aggregate_status);
+        write_aggregate_status_to_file(temp_test_path.clone(), aggregate_status);
 
         let file_path = temp_test_path.join("status.json");
         assert!(file_path.exists(), "File does not exist in the directory");

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -35,7 +35,7 @@ mod windows;
 #[cfg(not(windows))]
 mod linux;
 
-use crate::common::{config, logger};
+use crate::common::{config, logger, result::Result};
 use crate::shared_state::SharedState;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::{ModuleState, ProxyAgentDetailStatus};
@@ -182,10 +182,7 @@ pub fn is_started(shared_state: Arc<Mutex<SharedState>>) -> bool {
     }
 }
 
-pub fn lookup_audit(
-    source_port: u16,
-    shared_state: Arc<Mutex<SharedState>>,
-) -> std::io::Result<AuditEntry> {
+pub fn lookup_audit(source_port: u16, shared_state: Arc<Mutex<SharedState>>) -> Result<AuditEntry> {
     #[cfg(windows)]
     {
         windows::lookup_audit(source_port, shared_state)
@@ -197,24 +194,8 @@ pub fn lookup_audit(
 }
 
 #[cfg(windows)]
-pub fn get_audit_from_stream_socket(raw_socket_id: usize) -> std::io::Result<AuditEntry> {
+pub fn get_audit_from_stream_socket(raw_socket_id: usize) -> Result<AuditEntry> {
     windows::get_audit_from_redirect_context(raw_socket_id)
-}
-
-pub fn get_audit_from_stream(_tcp_stream: &std::net::TcpStream) -> std::io::Result<AuditEntry> {
-    #[cfg(windows)]
-    {
-        use std::os::windows::io::AsRawSocket;
-
-        windows::get_audit_from_redirect_context(_tcp_stream.as_raw_socket() as usize)
-    }
-    #[cfg(not(windows))]
-    {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "get_audit_from_redirect_context for linux is not supported",
-        ))
-    }
 }
 
 pub fn ip_to_string(ip: u32) -> String {

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -5,7 +5,7 @@ mod bpf_api;
 mod bpf_obj;
 mod bpf_prog;
 
-use crate::common::{self, config, constants, helpers, logger};
+use crate::common::{self, config, constants, helpers, logger, result::Result};
 use crate::key_keeper;
 use crate::provision;
 use crate::redirector::AuditEntry;
@@ -166,14 +166,11 @@ pub fn is_started(shared_state: Arc<Mutex<SharedState>>) -> bool {
     redirector_wrapper::get_is_started(shared_state.clone())
 }
 
-pub fn lookup_audit(
-    source_port: u16,
-    shared_state: Arc<Mutex<SharedState>>,
-) -> std::io::Result<AuditEntry> {
+pub fn lookup_audit(source_port: u16, shared_state: Arc<Mutex<SharedState>>) -> Result<AuditEntry> {
     bpf_prog::lookup_bpf_audit_map(source_port, shared_state)
 }
 
-pub fn get_audit_from_redirect_context(raw_socket_id: usize) -> std::io::Result<AuditEntry> {
+pub fn get_audit_from_redirect_context(raw_socket_id: usize) -> Result<AuditEntry> {
     // WSAIoctl - SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT
     let value = AuditEntry::empty();
     let redirect_context_size = mem::size_of::<AuditEntry>() as u32;
@@ -191,9 +188,7 @@ pub fn get_audit_from_redirect_context(raw_socket_id: usize) -> std::io::Result<
             None,
         )
     };
-    common::windows::check_winsock_last_error(
-        "WinSock::WSAIoctl - SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT",
-    )?;
+    common::windows::check_winsock_last_error()?;
 
     Ok(value)
 }

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -4,13 +4,17 @@
 #![allow(non_snake_case)]
 
 use super::bpf_obj::*;
-use crate::common::logger;
+use crate::common::{
+    error::{BpfErrorType, Error},
+    logger,
+    result::Result,
+};
 use libloading::{Library, Symbol};
 use once_cell::sync::Lazy;
 use proxy_agent_shared::misc_helpers;
 use std::env;
 use std::ffi::{c_char, c_int, c_uint, c_void, CString};
-use std::io::{Error, ErrorKind};
+//use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
 static EBPF_API: Lazy<Option<Library>> = Lazy::new(init_ebpf_lib);
@@ -51,7 +55,7 @@ fn init_ebpf_lib() -> Option<Library> {
     None
 }
 
-fn load_ebpf_api(bpf_api_file_path: PathBuf) -> std::io::Result<Library> {
+fn load_ebpf_api(bpf_api_file_path: PathBuf) -> Result<Library> {
     // Safety: Loading a library on  Windows has the following safety requirements:
     // 1. The safety requirements of the library initialization and/or termination routines must be met.
     // The eBPF for Windows library does not have any safety requirements for its initialization and de-initialization function[0].
@@ -60,38 +64,25 @@ fn load_ebpf_api(bpf_api_file_path: PathBuf) -> std::io::Result<Library> {
     // 2. Calling this function is not safe in multi-thread scenarios where a library file name is provided and the library
     //     search path is modified.
     // We satisfy the this requirement by providing the absolute path to the library.
-    match unsafe { Library::new(bpf_api_file_path.as_path()) } {
-        Ok(api) => Ok(api),
-        Err(e) => {
-            let message = format!(
-                "Loading ebpf api from file {} failed with error: {}",
-                misc_helpers::path_to_string(&bpf_api_file_path),
-                e
-            );
-            Err(Error::new(ErrorKind::Other, message))
-        }
-    }
+    unsafe { Library::new(bpf_api_file_path.as_path()) }.map_err(|e| {
+        Error::bpf(BpfErrorType::LoadBpfApi(
+            misc_helpers::path_to_string(&bpf_api_file_path),
+            e,
+        ))
+    })
 }
 
-fn get_ebpf_api() -> std::io::Result<&'static Library> {
+fn get_ebpf_api() -> Result<&'static Library> {
     match EBPF_API.as_ref() {
         Some(api) => Ok(api),
-        None => {
-            let message = "Ebpf api is not loaded".to_string();
-            Err(Error::new(ErrorKind::Other, message))
-        }
+        None => Err(Error::bpf(BpfErrorType::GetBpfApi)),
     }
 }
 
 // function name must null terminated with '\0'.
-fn get_ebpf_api_fun<'a, T>(ebpf_api: &'a Library, name: &str) -> std::io::Result<Symbol<'a, T>> {
-    match unsafe { ebpf_api.get(name.as_bytes()) } {
-        Ok(f) => Ok(f),
-        Err(e) => {
-            let message: String = format!("Loading {} failed with error: {}", name, e);
-            Err(Error::new(ErrorKind::Other, message))
-        }
-    }
+fn get_ebpf_api_fun<'a, T>(ebpf_api: &'a Library, name: &str) -> Result<Symbol<'a, T>> {
+    unsafe { ebpf_api.get(name.as_bytes()) }
+        .map_err(|e| Error::bpf(BpfErrorType::LoadBpfApiFunction(name.to_string(), e)))
 }
 
 // Object
@@ -133,11 +124,11 @@ type BpfMapLookupElem =
 
 type BpfMapDeleteElem = unsafe extern "C" fn(map_fd: c_int, key: *const c_void) -> c_int;
 
-fn get_cstring(s: &str) -> std::io::Result<CString> {
-    CString::new(s).map_err(|e| Error::new(ErrorKind::InvalidInput, e))
+fn get_cstring(s: &str) -> Result<CString> {
+    CString::new(s).map_err(|e| Error::bpf(BpfErrorType::CString(e)))
 }
 
-pub fn bpf_object__open(path: &str) -> std::io::Result<*mut bpf_object> {
+pub fn bpf_object__open(path: &str) -> Result<*mut bpf_object> {
     let ebpf_api = get_ebpf_api()?;
     let open_ebpf_object: Symbol<BpfObjectOpen> = get_ebpf_api_fun(ebpf_api, "bpf_object__open\0")?;
     // lifetime of the value must be longer than the lifetime of the pointer returned by as_ptr
@@ -145,13 +136,13 @@ pub fn bpf_object__open(path: &str) -> std::io::Result<*mut bpf_object> {
     Ok(unsafe { open_ebpf_object(c_string.as_ptr()) })
 }
 
-pub fn bpf_object__load(obj: *mut bpf_object) -> std::io::Result<c_int> {
+pub fn bpf_object__load(obj: *mut bpf_object) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let load_ebpf_object: Symbol<BpfObjectLoad> = get_ebpf_api_fun(ebpf_api, "bpf_object__load\0")?;
     Ok(unsafe { load_ebpf_object(obj) })
 }
 
-pub fn bpf_object__close(object: *mut bpf_object) -> std::io::Result<c_void> {
+pub fn bpf_object__close(object: *mut bpf_object) -> Result<c_void> {
     let ebpf_api = get_ebpf_api()?;
     let object__close: Symbol<BpfObjectClose> = get_ebpf_api_fun(ebpf_api, "bpf_object__close\0")?;
     Ok(unsafe { object__close(object) })
@@ -160,7 +151,7 @@ pub fn bpf_object__close(object: *mut bpf_object) -> std::io::Result<c_void> {
 pub fn bpf_object__find_program_by_name(
     obj: *mut bpf_object,
     name: &str,
-) -> std::io::Result<*mut ebpf_program_t> {
+) -> Result<*mut ebpf_program_t> {
     let ebpf_api = get_ebpf_api()?;
     let find_program_by_name: Symbol<BpfObjectFindProgramByName> =
         get_ebpf_api_fun(ebpf_api, "bpf_object__find_program_by_name\0")?;
@@ -175,7 +166,7 @@ pub fn ebpf_prog_attach(
     attach_parameters: *const c_void,
     attach_params_size: usize,
     link: *mut *mut ebpf_link_t,
-) -> std::io::Result<c_int> {
+) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let program_attach: Symbol<EBpfProgAttach> =
         get_ebpf_api_fun(ebpf_api, "ebpf_program_attach\0")?;
@@ -190,23 +181,20 @@ pub fn ebpf_prog_attach(
     })
 }
 
-pub fn bpf_link_disconnect(link: *mut ebpf_link_t) -> std::io::Result<c_void> {
+pub fn bpf_link_disconnect(link: *mut ebpf_link_t) -> Result<c_void> {
     let ebpf_api = get_ebpf_api()?;
     let link_disconnect: Symbol<BpfLinkDisconnect> =
         get_ebpf_api_fun(ebpf_api, "bpf_link__disconnect\0")?;
     Ok(unsafe { link_disconnect(link) })
 }
 
-pub fn bpf_link_destroy(link: *mut ebpf_link_t) -> std::io::Result<c_int> {
+pub fn bpf_link_destroy(link: *mut ebpf_link_t) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let link_destroy: Symbol<BpfLinkDestroy> = get_ebpf_api_fun(ebpf_api, "bpf_link__destroy\0")?;
     Ok(unsafe { link_destroy(link) })
 }
 
-pub fn bpf_object__find_map_by_name(
-    obj: *mut bpf_object,
-    name: &str,
-) -> std::io::Result<*mut bpf_map> {
+pub fn bpf_object__find_map_by_name(obj: *mut bpf_object, name: &str) -> Result<*mut bpf_map> {
     let ebpf_api = get_ebpf_api()?;
     let find_map_by_name: Symbol<BpfObjectFindMapByName> =
         get_ebpf_api_fun(ebpf_api, "bpf_object__find_map_by_name\0")?;
@@ -215,7 +203,7 @@ pub fn bpf_object__find_map_by_name(
     Ok(unsafe { find_map_by_name(obj, c_string.as_ptr()) })
 }
 
-pub fn bpf_map__fd(map: *mut bpf_map) -> std::io::Result<c_int> {
+pub fn bpf_map__fd(map: *mut bpf_map) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let map__fd: Symbol<BpfMapFd> = get_ebpf_api_fun(ebpf_api, "bpf_map__fd\0")?;
     Ok(unsafe { map__fd(map) })
@@ -226,25 +214,21 @@ pub fn bpf_map_update_elem(
     key: *const c_void,
     value: *const c_void,
     flags: c_uint,
-) -> std::io::Result<c_int> {
+) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let map_update_elem: Symbol<BpfMapUpdateElem> =
         get_ebpf_api_fun(ebpf_api, "bpf_map_update_elem\0")?;
     Ok(unsafe { map_update_elem(map_fd, key, value, flags) })
 }
 
-pub fn bpf_map_lookup_elem(
-    map_fd: c_int,
-    key: *const c_void,
-    value: *mut c_void,
-) -> std::io::Result<c_int> {
+pub fn bpf_map_lookup_elem(map_fd: c_int, key: *const c_void, value: *mut c_void) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let map_lookup_elem: Symbol<BpfMapLookupElem> =
         get_ebpf_api_fun(ebpf_api, "bpf_map_lookup_elem\0")?;
     Ok(unsafe { map_lookup_elem(map_fd, key, value) })
 }
 
-pub fn bpf_map_delete_elem(map_fd: c_int, key: *const c_void) -> std::io::Result<c_int> {
+pub fn bpf_map_delete_elem(map_fd: c_int, key: *const c_void) -> Result<c_int> {
     let ebpf_api = get_ebpf_api()?;
     let map_delete_elem: Symbol<BpfMapDeleteElem> =
         get_ebpf_api_fun(ebpf_api, "bpf_map_delete_elem\0")?;

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -14,7 +14,6 @@ use once_cell::sync::Lazy;
 use proxy_agent_shared::misc_helpers;
 use std::env;
 use std::ffi::{c_char, c_int, c_uint, c_void, CString};
-//use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
 static EBPF_API: Lazy<Option<Library>> = Lazy::new(init_ebpf_lib);
@@ -67,7 +66,7 @@ fn load_ebpf_api(bpf_api_file_path: PathBuf) -> Result<Library> {
     unsafe { Library::new(bpf_api_file_path.as_path()) }.map_err(|e| {
         Error::bpf(BpfErrorType::LoadBpfApi(
             misc_helpers::path_to_string(&bpf_api_file_path),
-            e,
+            e.to_string(),
         ))
     })
 }
@@ -81,8 +80,12 @@ fn get_ebpf_api() -> Result<&'static Library> {
 
 // function name must null terminated with '\0'.
 fn get_ebpf_api_fun<'a, T>(ebpf_api: &'a Library, name: &str) -> Result<Symbol<'a, T>> {
-    unsafe { ebpf_api.get(name.as_bytes()) }
-        .map_err(|e| Error::bpf(BpfErrorType::LoadBpfApiFunction(name.to_string(), e)))
+    unsafe { ebpf_api.get(name.as_bytes()) }.map_err(|e| {
+        Error::bpf(BpfErrorType::LoadBpfApiFunction(
+            name.to_string(),
+            e.to_string(),
+        ))
+    })
 }
 
 // Object

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -292,10 +292,10 @@ pub fn lookup_bpf_audit_map(
     match redirector_wrapper::get_bpf_object(shared_state.clone()) {
         Some(obj) => {
             let audit_map = bpf_object__find_map_by_name(obj.lock().unwrap().0, "audit_map")
-                .map_err(|e| Error::bpf(BpfErrorType::FindBpfMap(e.to_string())))?;
+                .map_err(|e| Error::bpf(BpfErrorType::GetBpfMap(e.to_string())))?;
 
             if audit_map.is_null() {
-                return Err(Error::bpf(BpfErrorType::FindBpfMap(
+                return Err(Error::bpf(BpfErrorType::GetBpfMap(
                     "bpf_object__find_map_by_name 'audit_map' returns null pointer".to_string(),
                 )));
             }

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -4,12 +4,15 @@ use super::bpf_api::*;
 use super::bpf_obj::*;
 use crate::common::constants;
 use crate::common::logger;
+use crate::common::{
+    error::{BpfErrorType, Error},
+    result::Result,
+};
 use crate::redirector::AuditEntry;
 use crate::shared_state::redirector_wrapper;
 use crate::shared_state::SharedState;
 use proxy_agent_shared::misc_helpers;
 use std::ffi::c_void;
-use std::io::{Error, ErrorKind};
 use std::mem::size_of_val;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -285,66 +288,50 @@ Return Value:
 pub fn lookup_bpf_audit_map(
     source_port: u16,
     shared_state: Arc<Mutex<SharedState>>,
-) -> std::io::Result<AuditEntry> {
+) -> Result<AuditEntry> {
     match redirector_wrapper::get_bpf_object(shared_state.clone()) {
         Some(obj) => {
-            let audit_map = match bpf_object__find_map_by_name(obj.lock().unwrap().0, "audit_map") {
-                Ok(m) => m,
-                Err(e) => {
-                    let message = format!(
-                        "Failed to find audit map in bpf object with error: {error}.",
-                        error = e
-                    );
-                    return Err(Error::new(ErrorKind::InvalidInput, message));
-                }
-            };
+            let audit_map = bpf_object__find_map_by_name(obj.lock().unwrap().0, "audit_map")
+                .map_err(|e| Error::bpf(BpfErrorType::FindBpfMap(e.to_string())))?;
+
             if audit_map.is_null() {
-                let message = "bpf_object__find_map_by_name 'audit_map' return null.".to_string();
-                return Err(Error::new(ErrorKind::InvalidInput, message));
+                return Err(Error::bpf(BpfErrorType::FindBpfMap(
+                    "bpf_object__find_map_by_name 'audit_map' returns null pointer".to_string(),
+                )));
             }
-            let map_fd = match bpf_map__fd(audit_map) {
-                Ok(fd) => fd,
-                Err(e) => {
-                    let message = format!(
-                        "Failed to get audit map fd in bpf object with error: {error}.",
-                        error = e
-                    );
-                    return Err(Error::new(ErrorKind::InvalidInput, message));
-                }
-            };
+
+            let map_fd = bpf_map__fd(audit_map)
+                .map_err(|e| Error::bpf(BpfErrorType::MapFileDescriptor(e.to_string())))?;
 
             // query by source port.
             let key = sock_addr_audit_key_t::from_source_port(source_port);
             let value = AuditEntry::empty();
 
-            let result = match bpf_map_lookup_elem(
+            let result = bpf_map_lookup_elem(
                 map_fd,
                 &key as *const sock_addr_audit_key_t as *const c_void,
                 &value as *const AuditEntry as *mut c_void,
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    let message =
-                        format!("Failed to lookup {source_port} in bpf audit map with error: {e}.");
-                    return Err(Error::new(ErrorKind::InvalidInput, message));
-                }
-            };
+            )
+            .map_err(|e| {
+                Error::bpf(BpfErrorType::MapLookupElem(
+                    source_port.to_string(),
+                    format!("Error: {}", e),
+                ))
+            })?;
 
             if result != 0 {
-                let message = format!(
-                    "Failed to lookup {source_port} in bpf audit map with result: {result}."
-                );
-                return Err(Error::new(ErrorKind::InvalidInput, message));
+                return Err(Error::bpf(BpfErrorType::MapLookupElem(
+                    source_port.to_string(),
+                    format!("Result: {}", result),
+                )));
             }
 
             Ok(value)
         }
-        None => {
-            let message = format!(
-                "Failed to lookup {source_port} in bpf audit map because bpf has not loaded."
-            );
-            Err(Error::new(ErrorKind::InvalidInput, message))
-        }
+        None => Err(Error::bpf(BpfErrorType::MapLookupElem(
+            source_port.to_string(),
+            "BPF has not loaded".to_string(),
+        ))),
     }
 }
 


### PR DESCRIPTION
This PR is addressing the feedback from https://github.com/Azure/GuestProxyAgent/issues/117.

This PR is a follow up to my previous PR - https://github.com/Azure/GuestProxyAgent/pull/134 - where I introduced custom result and error types as part of improving overall readability, maintainability and error handling within our codebase.

In this PR, all remaining error instances are moved over to custom error types defined within the proxy_agent crate only. Since this PR is already large enough, I will introduce changes to the extension and shared crates in a next PR.

Tests Link: https://msazure.visualstudio.com/One/_build/results?buildId=106290309&view=results (150/150 passed)