### PR TITLE
Proxy Agent: Move custom error type to enum

### DIFF
--- a/proxy_agent/src/acl/windows_acl.rs
+++ b/proxy_agent/src/acl/windows_acl.rs
@@ -22,13 +22,13 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
     let dir_str = misc_helpers::path_to_string(&dir_to_acl);
 
     let mut acl = ACL::from_file_path(&dir_str, true)
-        .map_err(|e| Error::acl(AclErrorType::AclObject(dir_str.to_string()), e))?;
+        .map_err(|e| Error::Acl(AclErrorType::AclObject(dir_str.to_string()), e))?;
 
     let system_sid = helper::string_to_sid(LOCAL_SYSTEM_SID)
-        .map_err(|e| Error::acl(AclErrorType::Sid(LOCAL_SYSTEM_SID.to_string()), e))?;
+        .map_err(|e| Error::Acl(AclErrorType::Sid(LOCAL_SYSTEM_SID.to_string()), e))?;
 
     let admin_sid = helper::string_to_sid(BUILDIN_ADMIN_SID)
-        .map_err(|e| Error::acl(AclErrorType::Sid(BUILDIN_ADMIN_SID.to_string()), e))?;
+        .map_err(|e| Error::Acl(AclErrorType::Sid(BUILDIN_ADMIN_SID.to_string()), e))?;
 
     logger::write(format!(
         "acl_directory: removing all the remaining access rules for folder {}.",
@@ -68,7 +68,7 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
             }
         }
         Err(e) => {
-            return Err(Error::acl(AclErrorType::AclEntries(dir_str), e));
+            return Err(Error::Acl(AclErrorType::AclEntries(dir_str), e));
         }
     }
 
@@ -91,7 +91,7 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
             ));
         }
         Err(e) => {
-            return Err(Error::acl(
+            return Err(Error::Acl(
                 AclErrorType::AddEntry(LOCAL_SYSTEM_SID.to_string()),
                 e,
             ));
@@ -110,7 +110,7 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
             ));
         }
         Err(e) => {
-            return Err(Error::acl(
+            return Err(Error::Acl(
                 AclErrorType::AddEntry(LOCAL_SYSTEM_SID.to_string()),
                 e,
             ));

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -6,7 +6,7 @@ use http::{uri::InvalidUri, StatusCode};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("IO error: {0}: {1}")]
-    IO(String, std::io::Error),
+    Io(String, std::io::Error),
 
     #[error("{0}")]
     Hyper(HyperErrorType),

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     IO(String, std::io::Error),
 
     #[error("{0}")]
-    Hyper(Box<HyperErrorType>),
+    Hyper(HyperErrorType),
 
     #[error("Hex encoded key '{0}' is invalid: {1}")]
     Hex(String, hex::FromHexError),
@@ -166,10 +166,10 @@ mod test {
 
     #[test]
     fn error_formatting_test() {
-        let mut error = Error::Hyper(Box::new(super::HyperErrorType::ServerError(
+        let mut error = Error::Hyper(super::HyperErrorType::ServerError(
             "testurl.com".to_string(),
             StatusCode::from_u16(500).unwrap(),
-        )));
+        ));
         assert_eq!(
             error.to_string(),
             "Failed to get response from testurl.com, status code: 500 Internal Server Error"

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -2,72 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 use http::{uri::InvalidUri, StatusCode};
-use std::error::Error as StdError;
-use std::fmt::Display;
-
-#[derive(Debug)]
-pub struct Error(Box<ErrorType>);
-
-impl Error {
-    fn new(error: ErrorType) -> Self {
-        Self(Box::new(error))
-    }
-
-    pub fn io(message: String, error: std::io::Error) -> Self {
-        Self::new(ErrorType::IO(message, error))
-    }
-
-    pub fn hyper(error: HyperErrorType) -> Self {
-        Self::new(ErrorType::Hyper(error))
-    }
-
-    pub fn hex(message: String, error: hex::FromHexError) -> Self {
-        Self::new(ErrorType::Hex(message, error))
-    }
-
-    pub fn key(error: KeyErrorType) -> Self {
-        Self::new(ErrorType::Key(error))
-    }
-
-    pub fn parse_url(url: String, error: InvalidUri) -> Self {
-        Self::new(ErrorType::ParseUrl(url, error.to_string()))
-    }
-
-    pub fn parse_url_message(url: String, message: String) -> Self {
-        Self::new(ErrorType::ParseUrl(url, message))
-    }
-
-    pub fn wire_server(error_type: WireServerErrorType, message: String) -> Self {
-        Self::new(ErrorType::WireServer(error_type, message))
-    }
-
-    pub fn acl(error: AclErrorType, error_code: u32) -> Self {
-        Self::new(ErrorType::Acl(error, error_code))
-    }
-
-    pub fn bpf(error: BpfErrorType) -> Self {
-        Self::new(ErrorType::Bpf(error))
-    }
-
-    pub fn windows_api(error: WindowsApiErrorType) -> Self {
-        Self::new(ErrorType::WindowsApi(error))
-    }
-
-    pub fn invalid(error: String) -> Self {
-        Self::new(ErrorType::Invalid(error))
-    }
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl StdError for Error {}
 
 #[derive(Debug, thiserror::Error)]
-enum ErrorType {
+pub enum Error {
     #[error("IO error: {0}: {1}")]
     IO(String, std::io::Error),
 
@@ -211,7 +148,7 @@ mod test {
 
     #[test]
     fn error_formatting_test() {
-        let mut error = Error::hyper(super::HyperErrorType::ServerError(
+        let mut error = Error::Hyper(super::HyperErrorType::ServerError(
             "testurl.com".to_string(),
             StatusCode::from_u16(500).unwrap(),
         ));
@@ -220,7 +157,7 @@ mod test {
             "Failed to get response from testurl.com, status code: 500 Internal Server Error"
         );
 
-        error = Error::wire_server(
+        error = Error::WireServer(
             WireServerErrorType::Telemetry,
             "Invalid response".to_string(),
         );
@@ -229,7 +166,7 @@ mod test {
             "Telemetry call to wire server failed with the error: Invalid response"
         );
 
-        error = Error::key(KeyErrorType::SendKeyRequest(
+        error = Error::Key(KeyErrorType::SendKeyRequest(
             "acquire".to_string(),
             error.to_string(),
         ));

--- a/proxy_agent/src/common/helpers.rs
+++ b/proxy_agent/src/common/helpers.rs
@@ -70,7 +70,7 @@ pub fn compute_signature(hex_encoded_key: &str, input_to_sign: &[u8]) -> Result<
             let result = mac.finalize();
             Ok(hex::encode(result))
         }
-        Err(e) => Err(Error::hex(hex_encoded_key.to_string(), e)),
+        Err(e) => Err(Error::Hex(hex_encoded_key.to_string(), e)),
     }
 }
 

--- a/proxy_agent/src/common/hyper_client.rs
+++ b/proxy_agent/src/common/hyper_client.rs
@@ -73,10 +73,10 @@ where
     let response = send_request(&host, port, request, log_fun).await?;
     let status = response.status();
     if !status.is_success() {
-        return Err(Error::Hyper(Box::new(HyperErrorType::ServerError(
+        return Err(Error::Hyper(HyperErrorType::ServerError(
             full_url.to_string(),
             status,
-        ))));
+        )));
     }
 
     read_response_body(response).await
@@ -128,10 +128,10 @@ where
         let frame = match next {
             Ok(f) => f,
             Err(e) => {
-                return Err(Error::Hyper(Box::new(HyperErrorType::Custom(
+                return Err(Error::Hyper(HyperErrorType::Custom(
                     "Failed to get next frame from response".to_string(),
                     e,
-                ))))
+                )))
             }
         };
         if let Some(chunk) = frame.data_ref() {
@@ -148,9 +148,9 @@ where
                     body_string.push_str(&String::from_utf16_lossy(&u16_vec));
                 }
                 "utf-32" => {
-                    return Err(Error::Hyper(Box::new(HyperErrorType::Deserialize(
+                    return Err(Error::Hyper(HyperErrorType::Deserialize(
                         "utf-32 charset is not supported".to_string(),
-                    ))))
+                    )))
                 }
                 _ => {
                     // default to utf-8
@@ -163,26 +163,26 @@ where
     match content_type {
         "xml" => match serde_xml_rs::from_str(&body_string) {
             Ok(t) => Ok(t),
-            Err(e) => Err(Error::Hyper(Box::new(
+            Err(e) => Err(Error::Hyper(
                 HyperErrorType::Deserialize(
                     format!(
                         "Failed to xml deserialize response body with content_type {} from: {} with error {}",
                         content_type, body_string, e
                     )
                 ),
-            ))),
+            )),
         },
         // default to json
         _ => match serde_json::from_str(&body_string) {
             Ok(t) => Ok(t),
-            Err(e) => Err(Error::Hyper(Box::new(
+            Err(e) => Err(Error::Hyper(
                 HyperErrorType::Deserialize(
                     format!(
                         "Failed to json deserialize response body with {} from: {} with error {}",
                         content_type, body_string, e
                     )
                 ),
-            ))),
+            )),
         },
     }
 }
@@ -245,8 +245,9 @@ pub fn build_request(
     };
     match request_builder.body(boxed_body) {
         Ok(r) => Ok(r),
-        Err(e) => Err(Error::Hyper(Box::new(HyperErrorType::RequestBuilder(
-            format!("Failed to build request body: {}", e),
+        Err(e) => Err(Error::Hyper(HyperErrorType::RequestBuilder(format!(
+            "Failed to build request body: {}",
+            e
         )))),
     }
 }
@@ -281,10 +282,10 @@ where
     let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
         .await
         .map_err(|e| {
-            Error::Hyper(Box::new(HyperErrorType::Custom(
+            Error::Hyper(HyperErrorType::Custom(
                 format!("Failed to establish connection to {}", addr),
                 e,
-            )))
+            ))
         })?;
 
     tokio::task::spawn(async move {
@@ -294,10 +295,10 @@ where
     });
 
     sender.send_request(request).await.map_err(|e| {
-        Error::Hyper(Box::new(HyperErrorType::Custom(
+        Error::Hyper(HyperErrorType::Custom(
             format!("Failed to send request to {}", full_url),
             e,
-        )))
+        ))
     })
 }
 
@@ -342,9 +343,9 @@ fn request_to_sign_input(request_builder: &Builder, body: Option<Vec<u8>>) -> Re
     let mut data: Vec<u8> = match request_builder.method_ref() {
         Some(m) => m.as_str().as_bytes().to_vec(),
         None => {
-            return Err(Error::Hyper(Box::new(HyperErrorType::RequestBuilder(
+            return Err(Error::Hyper(HyperErrorType::RequestBuilder(
                 "Failed to get method from request builder".to_string(),
-            ))))
+            )))
         }
     };
     data.extend(LF.as_bytes());
@@ -370,9 +371,9 @@ fn request_to_sign_input(request_builder: &Builder, body: Option<Vec<u8>>) -> Re
             data.extend(path_para.1.as_bytes());
         }
         None => {
-            return Err(Error::Hyper(Box::new(HyperErrorType::RequestBuilder(
+            return Err(Error::Hyper(HyperErrorType::RequestBuilder(
                 "Failed to get method from request builder".to_string(),
-            ))))
+            )))
         }
     }
 

--- a/proxy_agent/src/common/hyper_client.rs
+++ b/proxy_agent/src/common/hyper_client.rs
@@ -270,7 +270,7 @@ where
     let stream = match TcpStream::connect(addr.to_string()).await {
         Ok(tcp_stream) => tcp_stream,
         Err(e) => {
-            return Err(Error::IO(
+            return Err(Error::Io(
                 format!("Failed to open TCP connection to {}", addr),
                 e,
             ))

--- a/proxy_agent/src/common/windows.rs
+++ b/proxy_agent/src/common/windows.rs
@@ -28,7 +28,7 @@ pub fn get_memory_in_mb() -> Result<u64> {
     unsafe {
         (*data).dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
         if GlobalMemoryStatusEx(data) == 0 {
-            return Err(Error::windows_api(
+            return Err(Error::WindowsApi(
                 WindowsApiErrorType::GlobalMemoryStatusEx(
                     std::io::Error::last_os_error().to_string(),
                 ),
@@ -42,7 +42,7 @@ pub fn get_memory_in_mb() -> Result<u64> {
 pub fn check_winsock_last_error() -> Result<()> {
     let error = unsafe { WinSock::WSAGetLastError() };
     if error != 0 {
-        return Err(Error::windows_api(WindowsApiErrorType::WSAIoctl(error)));
+        return Err(Error::WindowsApi(WindowsApiErrorType::WSAIoctl(error)));
     }
 
     Ok(())

--- a/proxy_agent/src/host_clients/imds_client.rs
+++ b/proxy_agent/src/host_clients/imds_client.rs
@@ -48,8 +48,8 @@ impl ImdsClient {
         let url: String = format!("http://{}:{}/{}", self.ip, self.port, IMDS_URI);
 
         let url: Uri = url
-            .parse()
-            .map_err(|e: InvalidUri| Error::ParseUrl(url, e.to_string()))?;
+            .parse::<hyper::Uri>()
+            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
         let mut headers = HashMap::new();
         headers.insert("Metadata".to_string(), "true".to_string());
 

--- a/proxy_agent/src/host_clients/imds_client.rs
+++ b/proxy_agent/src/host_clients/imds_client.rs
@@ -22,7 +22,6 @@
 use super::instance_info::InstanceInfo;
 use crate::common::{error::Error, hyper_client, logger, result::Result};
 use crate::shared_state::{key_keeper_wrapper, SharedState};
-use http::uri::InvalidUri;
 use hyper::Uri;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/proxy_agent/src/host_clients/imds_client.rs
+++ b/proxy_agent/src/host_clients/imds_client.rs
@@ -22,6 +22,7 @@
 use super::instance_info::InstanceInfo;
 use crate::common::{error::Error, hyper_client, logger, result::Result};
 use crate::shared_state::{key_keeper_wrapper, SharedState};
+use http::uri::InvalidUri;
 use hyper::Uri;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -46,7 +47,9 @@ impl ImdsClient {
     pub async fn get_imds_instance_info(&self) -> Result<InstanceInfo> {
         let url: String = format!("http://{}:{}/{}", self.ip, self.port, IMDS_URI);
 
-        let url: Uri = url.parse().map_err(|e| Error::parse_url(url, e))?;
+        let url: Uri = url
+            .parse()
+            .map_err(|e: InvalidUri| Error::ParseUrl(url, e.to_string()))?;
         let mut headers = HashMap::new();
         headers.insert("Metadata".to_string(), "true".to_string());
 

--- a/proxy_agent/src/host_clients/wire_server_client.rs
+++ b/proxy_agent/src/host_clients/wire_server_client.rs
@@ -57,8 +57,8 @@ impl WireServerClient {
 
         let url = format!("http://{}:{}/{}", self.ip, self.port, TELEMETRY_DATA_URI);
         let url: Uri = url
-            .parse()
-            .map_err(|e: InvalidUri| Error::ParseUrl(url, e.to_string()))?;
+            .parse::<hyper::Uri>()
+            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
         let mut headers = HashMap::new();
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
         headers.insert(
@@ -104,8 +104,8 @@ impl WireServerClient {
     pub async fn get_goalstate(&self) -> Result<GoalState> {
         let url = format!("http://{}:{}/{}", self.ip, self.port, GOALSTATE_URI);
         let url = url
-            .parse()
-            .map_err(|e: InvalidUri| Error::ParseUrl(url, e.to_string()))?;
+            .parse::<hyper::Uri>()
+            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
         let mut headers = HashMap::new();
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
 
@@ -123,8 +123,8 @@ impl WireServerClient {
     pub async fn get_shared_config(&self, url: String) -> Result<SharedConfig> {
         let mut headers = HashMap::new();
         let url = url
-            .parse()
-            .map_err(|e: InvalidUri| Error::ParseUrl(url, e.to_string()))?;
+            .parse::<hyper::Uri>()
+            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
 
         hyper_client::get(

--- a/proxy_agent/src/host_clients/wire_server_client.rs
+++ b/proxy_agent/src/host_clients/wire_server_client.rs
@@ -27,7 +27,7 @@ use crate::common::{
 };
 use crate::host_clients::goal_state::{GoalState, SharedConfig};
 use crate::shared_state::{key_keeper_wrapper, SharedState};
-use http::{uri::InvalidUri, Method};
+use http::Method;
 use hyper::Uri;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -456,7 +456,7 @@ impl KeyStatus {
         }
 
         if !validate_result {
-            return Err(Error::key(KeyErrorType::KeyStatusValidation(
+            return Err(Error::Key(KeyErrorType::KeyStatusValidation(
                 validate_message,
             )));
         }
@@ -673,7 +673,7 @@ pub async fn get_status(base_url: &Uri) -> Result<KeyStatus> {
     let (host, port) = hyper_client::host_port_from_uri(base_url)?;
     let url = format!("http://{}:{}{}", host, port, STATUS_URL);
     let url: Uri = url.parse().map_err(|e| {
-        Error::key(KeyErrorType::ParseKeyUrl(
+        Error::Key(KeyErrorType::ParseKeyUrl(
             base_url.to_string(),
             STATUS_URL.to_string(),
             e,
@@ -692,7 +692,7 @@ pub async fn acquire_key(base_url: &Uri) -> Result<Key> {
     let (host, port) = hyper_client::host_port_from_uri(base_url)?;
     let url = format!("http://{}:{}{}", host, port, KEY_URL);
     let url: Uri = url.parse().map_err(|e| {
-        Error::key(KeyErrorType::ParseKeyUrl(
+        Error::Key(KeyErrorType::ParseKeyUrl(
             base_url.to_string(),
             KEY_URL.to_string(),
             e,
@@ -716,14 +716,14 @@ pub async fn acquire_key(base_url: &Uri) -> Result<Key> {
         match hyper_client::send_request(&host, port, request, logger::write_warning).await {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::key(KeyErrorType::SendKeyRequest(
+                return Err(Error::Key(KeyErrorType::SendKeyRequest(
                     format!("{}", KeyAction::Acquire),
                     e.to_string(),
                 )));
             }
         };
     if response.status() != StatusCode::OK {
-        return Err(Error::key(KeyErrorType::KeyResponse(
+        return Err(Error::Key(KeyErrorType::KeyResponse(
             format!("{}", KeyAction::Acquire),
             response.status(),
         )));
@@ -740,7 +740,7 @@ pub async fn attest_key(base_url: &Uri, key: &Key) -> Result<()> {
     );
     let url: Uri = url
         .parse()
-        .map_err(|e| Error::key(KeyErrorType::ParseKeyUrl(base_url.to_string(), url, e)))?;
+        .map_err(|e| Error::Key(KeyErrorType::ParseKeyUrl(base_url.to_string(), url, e)))?;
 
     let mut headers = HashMap::new();
     headers.insert(constants::METADATA_HEADER.to_string(), "True ".to_string());
@@ -756,14 +756,14 @@ pub async fn attest_key(base_url: &Uri, key: &Key) -> Result<()> {
         match hyper_client::send_request(&host, port, request, logger::write_warning).await {
             Ok(r) => r,
             Err(e) => {
-                return Err(Error::key(KeyErrorType::SendKeyRequest(
+                return Err(Error::Key(KeyErrorType::SendKeyRequest(
                     format!("{}", KeyAction::Attest),
                     e.to_string(),
                 )));
             }
         };
     if response.status() != StatusCode::OK {
-        return Err(Error::key(KeyErrorType::KeyResponse(
+        return Err(Error::Key(KeyErrorType::KeyResponse(
             format!("{}", KeyAction::Attest),
             response.status(),
         )));

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -47,7 +47,6 @@ use crate::proxy::proxy_server;
 use crate::shared_state::{provision_wrapper, telemetry_wrapper, SharedState};
 use crate::telemetry::event_reader;
 use crate::{key_keeper, proxy_agent_status, redirector};
-use http::uri::InvalidUri;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
 use serde_derive::{Deserialize, Serialize};

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -47,6 +47,7 @@ use crate::proxy::proxy_server;
 use crate::shared_state::{provision_wrapper, telemetry_wrapper, SharedState};
 use crate::telemetry::event_reader;
 use crate::{key_keeper, proxy_agent_status, redirector};
+use http::uri::InvalidUri;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
 use serde_derive::{Deserialize, Serialize};
@@ -337,7 +338,7 @@ async fn get_current_provision_status(port: u16) -> Result<ProvisionState> {
 
     let provision_url: hyper::Uri = provision_url
         .parse()
-        .map_err(|e| Error::parse_url(provision_url, e))?;
+        .map_err(|e: InvalidUri| Error::ParseUrl(provision_url, e.to_string()))?;
 
     let mut headers = HashMap::new();
     headers.insert(constants::METADATA_HEADER.to_string(), "true".to_string());

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -337,8 +337,8 @@ async fn get_current_provision_status(port: u16) -> Result<ProvisionState> {
     );
 
     let provision_url: hyper::Uri = provision_url
-        .parse()
-        .map_err(|e: InvalidUri| Error::ParseUrl(provision_url, e.to_string()))?;
+        .parse::<hyper::Uri>()
+        .map_err(|e| Error::ParseUrl(provision_url, e.to_string()))?;
 
     let mut headers = HashMap::new();
     headers.insert(constants::METADATA_HEADER.to_string(), "true".to_string());

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -193,7 +193,7 @@ async fn accept_one_request(
 fn set_stream_read_time_out(stream: TcpStream) -> Result<(TcpStream, std::net::TcpStream)> {
     // Convert the stream to a std stream
     let std_stream = stream.into_std().map_err(|e| {
-        Error::IO(
+        Error::Io(
             "Failed to convert Tokio stream into std equivalent".to_string(),
             e,
         )
@@ -210,11 +210,11 @@ fn set_stream_read_time_out(stream: TcpStream) -> Result<(TcpStream, std::net::T
     // Clone the stream for the service_fn
     let cloned_std_stream = std_stream
         .try_clone()
-        .map_err(|e| Error::IO("Failed to clone TCP stream".to_string(), e))?;
+        .map_err(|e| Error::Io("Failed to clone TCP stream".to_string(), e))?;
 
     // Convert the std stream back
     let tokio_tcp_stream = TcpStream::from_std(std_stream).map_err(|e| {
-        Error::IO(
+        Error::Io(
             "Failed to convert std stream into Tokio equivalent".to_string(),
             e,
         )

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -193,7 +193,7 @@ async fn accept_one_request(
 fn set_stream_read_time_out(stream: TcpStream) -> Result<(TcpStream, std::net::TcpStream)> {
     // Convert the stream to a std stream
     let std_stream = stream.into_std().map_err(|e| {
-        Error::io(
+        Error::IO(
             "Failed to convert Tokio stream into std equivalent".to_string(),
             e,
         )
@@ -210,11 +210,11 @@ fn set_stream_read_time_out(stream: TcpStream) -> Result<(TcpStream, std::net::T
     // Clone the stream for the service_fn
     let cloned_std_stream = std_stream
         .try_clone()
-        .map_err(|e| Error::io("Failed to clone TCP stream".to_string(), e))?;
+        .map_err(|e| Error::IO("Failed to clone TCP stream".to_string(), e))?;
 
     // Convert the std stream back
     let tokio_tcp_stream = TcpStream::from_std(std_stream).map_err(|e| {
-        Error::io(
+        Error::IO(
             "Failed to convert std stream into Tokio equivalent".to_string(),
             e,
         )

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -68,7 +68,7 @@ fn net_user_get_local_groups(
         let fun_name = "NetUserGetLocalGroups\0";
         let net_user_get_local_groups: Symbol<NetUserGetLocalGroups> =
             NETAPI32_DLL.get(fun_name.as_bytes()).map_err(|e| {
-                Error::windows_api(WindowsApiErrorType::LoadNetUserGetLocalGroups(
+                Error::WindowsApi(WindowsApiErrorType::LoadNetUserGetLocalGroups(
                     e.to_string(),
                 ))
             })?;
@@ -112,7 +112,7 @@ pub fn get_user(logon_id: u64) -> Result<(String, Vec<String>)> {
     let status = unsafe { Identity::LsaGetLogonSessionData(&luid, data.as_mut_ptr()) };
     if status != 0 {
         let e = std::io::Error::from_raw_os_error(status as i32);
-        return Err(Error::windows_api(
+        return Err(Error::WindowsApi(
             WindowsApiErrorType::LsaGetLogonSessionData(format!("failed with os error: {}", e)),
         ));
     }
@@ -122,7 +122,7 @@ pub fn get_user(logon_id: u64) -> Result<(String, Vec<String>)> {
         user_name = from_unicode_string(&session_data.UserName);
     } else {
         let e = std::io::Error::last_os_error();
-        return Err(Error::windows_api(
+        return Err(Error::WindowsApi(
             WindowsApiErrorType::LsaGetLogonSessionData(format!(
                 "could not get the user name: {}",
                 e
@@ -249,7 +249,7 @@ pub fn query_basic_process_info(handler: isize) -> Result<PROCESS_BASIC_INFORMAT
         );
 
         if status != 0 {
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::from_raw_os_error(status),
             )));
         }
@@ -258,14 +258,14 @@ pub fn query_basic_process_info(handler: isize) -> Result<PROCESS_BASIC_INFORMAT
 }
 pub fn get_process_handler(pid: u32) -> Result<HANDLE> {
     if pid == 0 {
-        return Err(Error::invalid("pid 0".to_string()));
+        return Err(Error::Invalid("pid 0".to_string()));
     }
     let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
 
     unsafe {
         let handler = OpenProcess(options, FALSE, pid);
         if handler == 0 {
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::last_os_error(),
             )));
         }
@@ -288,7 +288,7 @@ pub fn get_process_cmd(handler: isize) -> Result<String> {
             && status != STATUS_BUFFER_TOO_SMALL
             && status != STATUS_INFO_LENGTH_MISMATCH
         {
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::from_raw_os_error(status),
             )));
         }
@@ -307,7 +307,7 @@ pub fn get_process_cmd(handler: isize) -> Result<String> {
         );
         if status < 0 {
             eprintln!("NtQueryInformationProcess failed with status: {}", status);
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::from_raw_os_error(status),
             )));
         }
@@ -331,7 +331,7 @@ pub fn get_process_name(handler: isize) -> Result<String> {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleBaseNameW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
         if size == 0 {
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::last_os_error(),
             )));
         }
@@ -345,7 +345,7 @@ pub fn get_process_full_name(handler: isize) -> Result<String> {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleFileNameExW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
         if size == 0 {
-            return Err(Error::windows_api(WindowsApiErrorType::WindowsOsError(
+            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
                 std::io::Error::last_os_error(),
             )));
         }

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -455,7 +455,7 @@ pub fn close(shared_state: Arc<Mutex<SharedState>>) {
 pub fn lookup_audit(source_port: u16, shared_state: Arc<Mutex<SharedState>>) -> Result<AuditEntry> {
     match redirector_wrapper::get_bpf_object(shared_state.clone()) {
         Some(ref bpf) => lookup_audit_internal(&bpf.lock().unwrap(), source_port),
-        None => Err(Error::bpf(BpfErrorType::GetBpfObject)),
+        None => Err(Error::Bpf(BpfErrorType::GetBpfObject)),
     }
 }
 
@@ -475,15 +475,15 @@ fn lookup_audit_internal(bpf: &Bpf, source_port: u16) -> Result<AuditEntry> {
                             destination_port: audit_value.destination_port as u16,
                         })
                     }
-                    Err(err) => Err(Error::bpf(BpfErrorType::MapLookupElem(
+                    Err(err) => Err(Error::Bpf(BpfErrorType::MapLookupElem(
                         source_port.to_string(),
                         err.to_string(),
                     ))),
                 }
             }
-            Err(err) => Err(Error::bpf(BpfErrorType::LoadBpfMapHashMap(err.to_string()))),
+            Err(err) => Err(Error::Bpf(BpfErrorType::LoadBpfMapHashMap(err.to_string()))),
         },
-        None => Err(Error::bpf(BpfErrorType::GetBpfMap(
+        None => Err(Error::Bpf(BpfErrorType::GetBpfMap(
             "Map does not exist".to_string(),
         ))),
     }

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -64,7 +64,7 @@ fn load_ebpf_api(bpf_api_file_path: PathBuf) -> Result<Library> {
     //     search path is modified.
     // We satisfy the this requirement by providing the absolute path to the library.
     unsafe { Library::new(bpf_api_file_path.as_path()) }.map_err(|e| {
-        Error::bpf(BpfErrorType::LoadBpfApi(
+        Error::Bpf(BpfErrorType::LoadBpfApi(
             misc_helpers::path_to_string(&bpf_api_file_path),
             e.to_string(),
         ))
@@ -74,14 +74,14 @@ fn load_ebpf_api(bpf_api_file_path: PathBuf) -> Result<Library> {
 fn get_ebpf_api() -> Result<&'static Library> {
     match EBPF_API.as_ref() {
         Some(api) => Ok(api),
-        None => Err(Error::bpf(BpfErrorType::GetBpfApi)),
+        None => Err(Error::Bpf(BpfErrorType::GetBpfApi)),
     }
 }
 
 // function name must null terminated with '\0'.
 fn get_ebpf_api_fun<'a, T>(ebpf_api: &'a Library, name: &str) -> Result<Symbol<'a, T>> {
     unsafe { ebpf_api.get(name.as_bytes()) }.map_err(|e| {
-        Error::bpf(BpfErrorType::LoadBpfApiFunction(
+        Error::Bpf(BpfErrorType::LoadBpfApiFunction(
             name.to_string(),
             e.to_string(),
         ))
@@ -128,7 +128,7 @@ type BpfMapLookupElem =
 type BpfMapDeleteElem = unsafe extern "C" fn(map_fd: c_int, key: *const c_void) -> c_int;
 
 fn get_cstring(s: &str) -> Result<CString> {
-    CString::new(s).map_err(|e| Error::bpf(BpfErrorType::CString(e)))
+    CString::new(s).map_err(|e| Error::Bpf(BpfErrorType::CString(e)))
 }
 
 pub fn bpf_object__open(path: &str) -> Result<*mut bpf_object> {

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -292,16 +292,16 @@ pub fn lookup_bpf_audit_map(
     match redirector_wrapper::get_bpf_object(shared_state.clone()) {
         Some(obj) => {
             let audit_map = bpf_object__find_map_by_name(obj.lock().unwrap().0, "audit_map")
-                .map_err(|e| Error::bpf(BpfErrorType::GetBpfMap(e.to_string())))?;
+                .map_err(|e| Error::Bpf(BpfErrorType::GetBpfMap(e.to_string())))?;
 
             if audit_map.is_null() {
-                return Err(Error::bpf(BpfErrorType::GetBpfMap(
+                return Err(Error::Bpf(BpfErrorType::GetBpfMap(
                     "bpf_object__find_map_by_name 'audit_map' returns null pointer".to_string(),
                 )));
             }
 
             let map_fd = bpf_map__fd(audit_map)
-                .map_err(|e| Error::bpf(BpfErrorType::MapFileDescriptor(e.to_string())))?;
+                .map_err(|e| Error::Bpf(BpfErrorType::MapFileDescriptor(e.to_string())))?;
 
             // query by source port.
             let key = sock_addr_audit_key_t::from_source_port(source_port);
@@ -313,14 +313,14 @@ pub fn lookup_bpf_audit_map(
                 &value as *const AuditEntry as *mut c_void,
             )
             .map_err(|e| {
-                Error::bpf(BpfErrorType::MapLookupElem(
+                Error::Bpf(BpfErrorType::MapLookupElem(
                     source_port.to_string(),
                     format!("Error: {}", e),
                 ))
             })?;
 
             if result != 0 {
-                return Err(Error::bpf(BpfErrorType::MapLookupElem(
+                return Err(Error::Bpf(BpfErrorType::MapLookupElem(
                     source_port.to_string(),
                     format!("Result: {}", result),
                 )));
@@ -328,7 +328,7 @@ pub fn lookup_bpf_audit_map(
 
             Ok(value)
         }
-        None => Err(Error::bpf(BpfErrorType::MapLookupElem(
+        None => Err(Error::Bpf(BpfErrorType::MapLookupElem(
             source_port.to_string(),
             "BPF has not loaded".to_string(),
         ))),


### PR DESCRIPTION
This PR is addressing feedback from #117.

In my previous PRs, I introduced the custom error as a struct with a boxed error type enum. However since we have a finite set of error types, it would be more efficient to handle this during compile time via an enum directly instead of requiring dynamically sized error handling with a box.

This PR moves to using an enum for the error type defined in the proxy agent crate. Other crates will use a similar pattern.