### PR TITLE
Pass environment for the linux_ebpf_test

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -176,6 +176,7 @@ norestart
 ntdll
 NTSTATUS
 onscreen
+onebranch
 opencode
 opensource
 percpu

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -38,6 +38,14 @@ then
     runthis rm -rf $out_dir
 fi
 
+BuildEnvironment=$3
+if [ "$BuildEnvironment" = "" ] 
+then
+    BuildEnvironment="normal"
+fi
+echo "======= BuildEnvironment is $BuildEnvironment"
+
+
 echo "======= rustup update to a particular version"
 rustup_version=1.80.0
 rustup update $rustup_version
@@ -113,7 +121,7 @@ runthis cp -f $out_dir/* $out_dir/deps/
 runthis cp -f -r $out_dir/* $root_path/proxy_agent/target/$Configuration/
 
 echo "======= run rust proxy_agent tests"
-runthis cargo test --all-features $release_flag --target $build_target --manifest-path $cargo_toml --target-dir $out_path -- --test-threads=1
+Environment="$BuildEnvironment" runthis cargo test --all-features $release_flag --target $build_target --manifest-path $cargo_toml --target-dir $out_path -- --test-threads=1
 error_code=$?
 if [ $error_code -ne 0 ]
 then 

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -543,7 +543,7 @@ mod tests {
     /// This test requires root permission and BPF capability to run
     /// This test will fail if the current user does not have root permission
     /// So far, we know some container build environments do not have BPF capability
-    /// This test will skip if the current envioronment does not have the capability to load BPF programs
+    /// This test will skip if the current environment does not have the capability to load BPF programs
     #[test]
     fn linux_ebpf_test() {
         let logger_key = "linux_ebpf_test";
@@ -574,11 +574,11 @@ mod tests {
                 bpf_file_path.display(),
                 bpf.err().unwrap()
             );
-            let envriorment = env::var("Environment")
+            let environment = env::var("Environment")
                 .unwrap_or("normal".to_string())
                 .to_lowercase();
-            if envriorment == "onebranch/cbl-mariner" {
-                println!("This is known: onebranch/cbl-mariner container image does not have the BPF capabilty, skip this test.");
+            if environment == "onebranch/cbl-mariner" {
+                println!("This is known: onebranch/cbl-mariner container image does not have the BPF capability, skip this test.");
                 return;
             }
 


### PR DESCRIPTION
linux_ebpf_test requires root permission and BPF capability to run, so far, we know some container build environments do not have BPF capability, this test will skip if the current environment does not have the capability to load BPF programs.
It used to be determined by the /.dockerenv file exists, it apparently not always true.