### PR TITLE
let execute_command and start_service return error if failed

### DIFF
--- a/proxy_agent_extension/src/windows/service_ext.rs
+++ b/proxy_agent_extension/src/windows/service_ext.rs
@@ -64,12 +64,33 @@ pub async fn uninstall_extension_service() {
 }
 
 pub async fn start_extension_service() {
-    service::start_service(
+    match service::start_service(
         constants::EXTENSION_SERVICE_NAME,
         constants::SERVICE_START_RETRY_COUNT,
         std::time::Duration::from_secs(15),
     )
-    .await;
+    .await
+    {
+        Ok(_) => {
+            logger::write(format!(
+                "Service {} successfully started",
+                constants::EXTENSION_SERVICE_NAME
+            ));
+        }
+        Err(e) => {
+            logger::write(format!(
+                "Service {} start failed: {}",
+                constants::EXTENSION_SERVICE_NAME,
+                e
+            ));
+            eprintln!(
+                "Service {} start failed: {}",
+                constants::EXTENSION_SERVICE_NAME,
+                e
+            );
+            process::exit(constants::EXIT_CODE_SERVICE_START_ERR);
+        }
+    }
 }
 
 pub async fn stop_extension_service() {

--- a/proxy_agent_extension/src/windows/service_ext.rs
+++ b/proxy_agent_extension/src/windows/service_ext.rs
@@ -64,11 +64,31 @@ pub fn uninstall_extension_service() {
 }
 
 pub fn start_extension_service() {
-    service::start_service(
+    match service::start_service(
         constants::EXTENSION_SERVICE_NAME,
         constants::SERVICE_START_RETRY_COUNT,
         std::time::Duration::from_secs(15),
-    );
+    ) {
+        Ok(_) => {
+            logger::write(format!(
+                "Service {} successfully started",
+                constants::EXTENSION_SERVICE_NAME
+            ));
+        }
+        Err(e) => {
+            logger::write(format!(
+                "Service {} start failed: {}",
+                constants::EXTENSION_SERVICE_NAME,
+                e
+            ));
+            eprintln!(
+                "Service {} start failed: {}",
+                constants::EXTENSION_SERVICE_NAME,
+                e
+            );
+            process::exit(constants::EXIT_CODE_SERVICE_START_ERR);
+        }
+    }
 }
 
 pub fn stop_extension_service() {

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -248,8 +248,18 @@ fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folder_path
         }
     }
 
-    service::start_service(SERVICE_NAME, 5, Duration::from_secs(15));
-    logger::write(format!("Service {} start successfully", SERVICE_NAME));
+    match service::start_service(SERVICE_NAME, 5, Duration::from_secs(15)) {
+        Ok(_) => {
+            logger::write(format!("Service {} start successfully", SERVICE_NAME));
+        }
+        Err(e) => {
+            logger::write(format!(
+                "Service {} start failed, error: {:?}",
+                SERVICE_NAME, e
+            ));
+            process::exit(1);
+        }
+    }
 }
 
 fn check_backup_exists() -> bool {

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -224,7 +224,7 @@ async fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folde
         let ebpf_setup_script_file = setup::ebpf_setup_script_file();
         if ebpf_setup_script_file.exists() && ebpf_setup_script_file.is_file() {
             let setup_script_file_str = misc_helpers::path_to_string(&ebpf_setup_script_file);
-            let output = misc_helpers::execute_command(
+            match misc_helpers::execute_command(
                 "powershell.exe",
                 vec![
                     "-ExecutionPolicy",
@@ -233,15 +233,36 @@ async fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folde
                     &setup_script_file_str,
                 ],
                 1,
-            );
-            logger::write(format!(
-                "ebpf_setup: invoked script file '{}' with result: '{}'-'{}'-'{}'.",
-                setup_script_file_str, output.0, output.1, output.2
-            ));
+            ) {
+                Ok(output) => {
+                    logger::write(format!(
+                        "ebpf_setup: invoked script file '{}' with result: '{}'.",
+                        setup_script_file_str,
+                        output.message()
+                    ));
+                }
+                Err(e) => {
+                    logger::write(format!(
+                        "ebpf_setup: failed to invoke script file '{}', error: '{:?}'.",
+                        setup_script_file_str, e
+                    ));
+                }
+            }
         }
     }
 
-    service::start_service(SERVICE_NAME, 5, Duration::from_secs(15)).await;
+    match service::start_service(SERVICE_NAME, 5, Duration::from_secs(15)).await {
+        Ok(_) => {
+            logger::write(format!("Service {} start successfully", SERVICE_NAME));
+        }
+        Err(e) => {
+            logger::write(format!(
+                "Service {} start failed, error: {:?}",
+                SERVICE_NAME, e
+            ));
+            process::exit(1);
+        }
+    }
     logger::write(format!("Service {} start successfully", SERVICE_NAME));
 }
 

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -221,7 +221,7 @@ fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folder_path
         let ebpf_setup_script_file = setup::ebpf_setup_script_file();
         if ebpf_setup_script_file.exists() && ebpf_setup_script_file.is_file() {
             let setup_script_file_str = misc_helpers::path_to_string(&ebpf_setup_script_file);
-            let output = misc_helpers::execute_command(
+            match misc_helpers::execute_command(
                 "powershell.exe",
                 vec![
                     "-ExecutionPolicy",
@@ -230,11 +230,21 @@ fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folder_path
                     &setup_script_file_str,
                 ],
                 1,
-            );
-            logger::write(format!(
-                "ebpf_setup: invoked script file '{}' with result: '{}'-'{}'-'{}'.",
-                setup_script_file_str, output.0, output.1, output.2
-            ));
+            ) {
+                Ok(output) => {
+                    logger::write(format!(
+                        "ebpf_setup: invoked script file '{}' with result: '{}'.",
+                        setup_script_file_str,
+                        output.message()
+                    ));
+                }
+                Err(e) => {
+                    logger::write(format!(
+                        "ebpf_setup: failed to invoke script file '{}', error: '{:?}'.",
+                        setup_script_file_str, e
+                    ));
+                }
+            }
         }
     }
 

--- a/proxy_agent_setup/src/running.rs
+++ b/proxy_agent_setup/src/running.rs
@@ -35,12 +35,21 @@ pub fn proxy_agent_parent_folder() -> PathBuf {
 }
 
 pub fn proxy_agent_version_target_folder(proxy_agent_exe: &Path) -> PathBuf {
-    let proxy_agent_version = misc_helpers::get_proxy_agent_version(proxy_agent_exe);
+    let proxy_agent_version = match misc_helpers::get_proxy_agent_version(proxy_agent_exe) {
+        Ok(v) => v,
+        Err(e) => {
+            // This should not happen, if failed to get version, we should not proceed
+            logger::write(format!(
+                "Failed to get proxy agent version with error: {}",
+                e
+            ));
+            panic!("Failed to get proxy agent version with error: {}", e);
+        }
+    };
     logger::write(format!("Proxy agent version: {}", &proxy_agent_version));
     #[cfg(windows)]
     {
         let path = proxy_agent_parent_folder();
-
         path.join(format!("Package_{}", proxy_agent_version))
     }
     #[cfg(not(windows))]

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -39,6 +39,8 @@ pub enum ParseVersionErrorType {
 pub enum CommandErrorType {
     #[error("Findmnt")]
     Findmnt,
+    #[error("{0}")]
+    CommandName(String),
 }
 
 #[cfg(test)]

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -99,10 +99,7 @@ pub fn get_processor_arch() -> String {
 pub fn get_cgroup2_mount_path() -> Result<PathBuf> {
     let output = misc_helpers::execute_command("findmnt", vec!["-t", "cgroup2", "--json"], -1)?;
     if !output.is_success() {
-        return Err(Error::Command(
-            CommandErrorType::Findmnt,
-            output.message(),
-        ));
+        return Err(Error::Command(CommandErrorType::Findmnt, output.message()));
     }
 
     let mount: FileMount = serde_json::from_str(&output.stdout())?;

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -257,11 +257,11 @@ pub fn execute_command(
 ) -> Result<CommandOutput> {
     let output = Command::new(program).args(args).output()?;
 
-    return Ok(CommandOutput::new(
+    Ok(CommandOutput::new(
         output.status.code().unwrap_or(default_error_code),
         String::from_utf8_lossy(&output.stdout).to_string(),
         String::from_utf8_lossy(&output.stderr).to_string(),
-    ));
+    ))
 }
 
 pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> Result<String> {

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::result::Result;
+use crate::{
+    error::{CommandErrorType, Error},
+    result::Result,
+};
 use regex::bytes::Regex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -208,37 +211,81 @@ pub fn search_files(dir: &Path, search_regex_pattern: &str) -> Result<Vec<PathBu
     Ok(files)
 }
 
+pub struct CommandOutput {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+impl CommandOutput {
+    pub fn new(exit_code: i32, stdout: String, stderr: String) -> Self {
+        Self {
+            exit_code,
+            stdout,
+            stderr,
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.exit_code == 0
+    }
+
+    pub fn stdout(&self) -> String {
+        self.stdout.to_string()
+    }
+
+    pub fn stderr(&self) -> String {
+        self.stderr.to_string()
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+
+    pub fn message(&self) -> String {
+        format!(
+            "exit code: '{}', stdout: '{}', stderr: '{}'",
+            self.exit_code, self.stdout, self.stderr
+        )
+    }
+}
+
 pub fn execute_command(
     program: &str,
     args: Vec<&str>,
     default_error_code: i32,
-) -> (i32, String, String) {
-    match Command::new(program).args(args).output() {
-        Ok(output) => (
-            output.status.code().unwrap_or(default_error_code),
-            String::from_utf8_lossy(&output.stdout).to_string(),
-            String::from_utf8_lossy(&output.stderr).to_string(),
-        ),
-        Err(e) => {
-            let error = format!("Failed to execute command {} with error {}", program, e);
-            (default_error_code, String::new(), error)
-        }
-    }
+) -> Result<CommandOutput> {
+    let output = Command::new(program).args(args).output()?;
+    Ok(CommandOutput::new(
+        output.status.code().unwrap_or(default_error_code),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    ))
 }
 
-pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> String {
+pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> Result<String> {
+    let proxy_agent_exe_str = path_to_string(proxy_agent_exe);
     if !proxy_agent_exe.exists() {
-        return "Unknown".to_string();
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("File '{}' does not found", proxy_agent_exe_str),
+        )));
     }
     if !proxy_agent_exe.is_file() {
-        return "Unknown".to_string();
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("'{}' is not a file", proxy_agent_exe_str),
+        )));
     }
 
-    let output = execute_command(&path_to_string(proxy_agent_exe), vec!["--version"], -1);
-    if output.0 != 0 {
-        "Unknown".to_string()
+    let output = execute_command(&path_to_string(proxy_agent_exe), vec!["--version"], -1)?;
+    if output.is_success() {
+        Ok(output.stdout().trim().to_string())
     } else {
-        output.1.trim().to_string()
+        Err(Error::Command(
+            CommandErrorType::CommandName(proxy_agent_exe_str),
+            output.message(),
+        ))
     }
 }
 
@@ -344,15 +391,16 @@ mod tests {
             program,
             vec![&super::path_to_string(&script_file_path)],
             default_error_code,
-        );
-        assert_eq!(1, output.0, "exit code mismatch");
+        )
+        .unwrap();
+        assert_eq!(1, output.exit_code(), "exit code mismatch");
         assert_eq!(
             "this is stdout message",
-            output.1.trim(),
+            output.stdout().trim(),
             "stdout message mismatch"
         );
         assert!(
-            output.2.contains("This is stderr message"),
+            output.stderr().contains("This is stderr message"),
             "stderr message mismatch"
         );
 

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::result::Result;
+use crate::{
+    error::{CommandErrorType, Error},
+    result::Result,
+};
 use regex::bytes::Regex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -208,39 +211,82 @@ pub fn search_files(dir: &Path, search_regex_pattern: &str) -> Result<Vec<PathBu
     Ok(files)
 }
 
+pub struct CommandOutput {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+impl CommandOutput {
+    pub fn new(exit_code: i32, stdout: String, stderr: String) -> Self {
+        Self {
+            exit_code,
+            stdout,
+            stderr,
+        }
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.exit_code == 0
+    }
+
+    pub fn stdout(&self) -> String {
+        self.stdout.to_string()
+    }
+
+    pub fn stderr(&self) -> String {
+        self.stderr.to_string()
+    }
+
+    pub fn exit_code(&self) -> i32 {
+        self.exit_code
+    }
+
+    pub fn message(&self) -> String {
+        format!(
+            "exit code: '{}', stdout: '{}', stderr: '{}'",
+            self.exit_code, self.stdout, self.stderr
+        )
+    }
+}
+
 pub fn execute_command(
     program: &str,
     args: Vec<&str>,
     default_error_code: i32,
-) -> (i32, String, String) {
-    match Command::new(program).args(args).output() {
-        Ok(output) => {
-            return (
-                output.status.code().unwrap_or(default_error_code),
-                String::from_utf8_lossy(&output.stdout).to_string(),
-                String::from_utf8_lossy(&output.stderr).to_string(),
-            );
-        }
-        Err(e) => {
-            let error = format!("Failed to execute command {} with error {}", program, e);
-            (default_error_code, String::new(), error)
-        }
-    }
+) -> Result<CommandOutput> {
+    let output = Command::new(program).args(args).output()?;
+
+    return Ok(CommandOutput::new(
+        output.status.code().unwrap_or(default_error_code),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    ));
 }
 
-pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> String {
+pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> Result<String> {
+    let proxy_agent_exe_str = path_to_string(proxy_agent_exe);
     if !proxy_agent_exe.exists() {
-        return "Unknown".to_string();
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("File '{}' does not found", proxy_agent_exe_str),
+        )));
     }
     if !proxy_agent_exe.is_file() {
-        return "Unknown".to_string();
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("'{}' is not a file", proxy_agent_exe_str),
+        )));
     }
 
-    let output = execute_command(&path_to_string(proxy_agent_exe), vec!["--version"], -1);
-    if output.0 != 0 {
-        "Unknown".to_string()
+    let output = execute_command(&path_to_string(proxy_agent_exe), vec!["--version"], -1)?;
+    if output.is_success() {
+        Ok(output.stdout().trim().to_string())
     } else {
-        return output.1.trim().to_string();
+        Err(Error::Command(
+            CommandErrorType::CommandName(proxy_agent_exe_str),
+            output.message(),
+        ))
     }
 }
 
@@ -346,15 +392,16 @@ mod tests {
             program,
             vec![&super::path_to_string(&script_file_path)],
             default_error_code,
-        );
-        assert_eq!(1, output.0, "exit code mismatch");
+        )
+        .unwrap();
+        assert_eq!(1, output.exit_code(), "exit code mismatch");
         assert_eq!(
             "this is stdout message",
-            output.1.trim(),
+            output.stdout().trim(),
             "stdout message mismatch"
         );
         assert!(
-            output.2.contains("This is stderr message"),
+            output.stderr().contains("This is stderr message"),
             "stderr message mismatch"
         );
 

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -28,8 +28,7 @@ pub fn install_service(
     }
     #[cfg(not(windows))]
     {
-        linux_service::install_or_update_service(service_name);
-        Ok(())
+        linux_service::install_or_update_service(service_name)
     }
 }
 
@@ -40,9 +39,8 @@ pub fn stop_and_delete_service(service_name: &str) -> Result<()> {
     }
     #[cfg(not(windows))]
     {
-        linux_service::stop_service(service_name);
-        linux_service::uninstall_service(service_name);
-        Ok(())
+        linux_service::stop_service(service_name)?;
+        linux_service::uninstall_service(service_name)
     }
 }
 
@@ -68,8 +66,7 @@ pub fn stop_service(service_name: &str) -> Result<()> {
     }
     #[cfg(not(windows))]
     {
-        linux_service::stop_service(service_name);
-        Ok(())
+        linux_service::stop_service(service_name)
     }
 }
 

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -46,14 +46,18 @@ pub fn stop_and_delete_service(service_name: &str) -> Result<()> {
     }
 }
 
-pub fn start_service(service_name: &str, _retry_count: u32, _duration: std::time::Duration) {
+pub fn start_service(
+    service_name: &str,
+    _retry_count: u32,
+    _duration: std::time::Duration,
+) -> Result<()> {
     #[cfg(windows)]
     {
-        windows_service::start_service_with_retry(service_name, _retry_count, _duration);
+        windows_service::start_service_with_retry(service_name, _retry_count, _duration)
     }
     #[cfg(not(windows))]
     {
-        linux_service::start_service(service_name);
+        linux_service::start_service(service_name)
     }
 }
 

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -28,8 +28,7 @@ pub fn install_service(
     }
     #[cfg(not(windows))]
     {
-        linux_service::install_or_update_service(service_name);
-        Ok(())
+        linux_service::install_or_update_service(service_name)
     }
 }
 
@@ -40,20 +39,23 @@ pub async fn stop_and_delete_service(service_name: &str) -> Result<()> {
     }
     #[cfg(not(windows))]
     {
-        linux_service::stop_service(service_name);
-        linux_service::uninstall_service(service_name);
-        Ok(())
+        linux_service::stop_service(service_name)?;
+        linux_service::uninstall_service(service_name)
     }
 }
 
-pub async fn start_service(service_name: &str, _retry_count: u32, _duration: std::time::Duration) {
+pub async fn start_service(
+    service_name: &str,
+    _retry_count: u32,
+    _duration: std::time::Duration,
+) -> Result<()> {
     #[cfg(windows)]
     {
-        windows_service::start_service_with_retry(service_name, _retry_count, _duration).await;
+        windows_service::start_service_with_retry(service_name, _retry_count, _duration).await
     }
     #[cfg(not(windows))]
     {
-        linux_service::start_service(service_name);
+        linux_service::start_service(service_name)
     }
 }
 
@@ -66,8 +68,7 @@ pub async fn stop_service(service_name: &str) -> Result<()> {
     }
     #[cfg(not(windows))]
     {
-        linux_service::stop_service(service_name);
-        Ok(())
+        linux_service::stop_service(service_name)
     }
 }
 

--- a/proxy_agent_shared/src/service/linux_service.rs
+++ b/proxy_agent_shared/src/service/linux_service.rs
@@ -3,81 +3,86 @@
 use crate::linux;
 use crate::logger_manager;
 use crate::misc_helpers;
-
+use crate::result::Result;
 use std::fs;
 use std::path::PathBuf;
 
-pub fn stop_service(service_name: &str) {
-    let output = misc_helpers::execute_command("systemctl", vec!["stop", service_name], -1);
-    let message = format!(
-        "stop_service: {}  result: '{}'-'{}'-'{}'.",
-        service_name, output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+pub fn stop_service(service_name: &str) -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["stop", service_name], -1)?;
+    logger_manager::write_info(format!(
+        "stop_service: {}  result: {}",
+        service_name,
+        output.message()
+    ));
+    Ok(())
 }
 
-pub fn start_service(service_name: &str) {
-    let output = misc_helpers::execute_command("systemctl", vec!["start", service_name], -1);
-    let message = format!(
-        "start_service: {}  result: '{}'-'{}'-'{}'.",
-        service_name, output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+pub fn start_service(service_name: &str) -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["start", service_name], -1)?;
+    logger_manager::write_info(format!(
+        "start_service: {}  result: {}",
+        service_name,
+        output.message()
+    ));
+    Ok(())
 }
 
-pub fn install_or_update_service(service_name: &str) {
-    unmask_service(service_name);
-    reload_systemd_daemon();
-    enable_service(service_name);
+pub fn install_or_update_service(service_name: &str) -> Result<()> {
+    unmask_service(service_name)?;
+    reload_systemd_daemon()?;
+    enable_service(service_name)
 }
 
-fn unmask_service(service_name: &str) {
-    let output = misc_helpers::execute_command("systemctl", vec!["unmask", service_name], -1);
-    let message = format!(
-        "unmask_service: {}  result: '{}'-'{}'-'{}'.",
-        service_name, output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+fn unmask_service(service_name: &str) -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["unmask", service_name], -1)?;
+    logger_manager::write_info(format!(
+        "unmask_service: {}  result: {}",
+        service_name,
+        output.message()
+    ));
+    Ok(())
 }
 
-pub fn uninstall_service(service_name: &str) {
-    disable_service(service_name);
-    delete_service_config_file(service_name);
+pub fn uninstall_service(service_name: &str) -> Result<()> {
+    disable_service(service_name)?;
+    delete_service_config_file(service_name)
 }
 
-fn disable_service(service_name: &str) {
-    let output = misc_helpers::execute_command("systemctl", vec!["disable", service_name], -1);
-    let message = format!(
-        "disable_service: {}  result: '{}'-'{}'-'{}'.",
-        service_name, output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+fn disable_service(service_name: &str) -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["disable", service_name], -1)?;
+    logger_manager::write_info(format!(
+        "disable_service: {}  result: {}",
+        service_name,
+        output.message()
+    ));
+    Ok(())
 }
 
-fn reload_systemd_daemon() {
-    let output = misc_helpers::execute_command("systemctl", vec!["daemon-reload"], -1);
-    let message = format!(
-        "reload_systemd_daemon: result: '{}'-'{}'-'{}'.",
-        output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+fn reload_systemd_daemon() -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["daemon-reload"], -1)?;
+    logger_manager::write_info(format!(
+        "reload_systemd_daemon result: {}",
+        output.message()
+    ));
+    Ok(())
 }
 
-fn enable_service(service_name: &str) {
-    let output = misc_helpers::execute_command("systemctl", vec!["enable", service_name], -1);
-    let message = format!(
-        "enable_service: {}  result: '{}'-'{}'-'{}'.",
-        service_name, output.0, output.1, output.2
-    );
-    logger_manager::write_info(message);
+fn enable_service(service_name: &str) -> Result<()> {
+    let output = misc_helpers::execute_command("systemctl", vec!["enable", service_name], -1)?;
+    logger_manager::write_info(format!(
+        "enable_service: {}  result: {}",
+        service_name,
+        output.message()
+    ));
+    Ok(())
 }
 
-fn delete_service_config_file(service_name: &str) {
+fn delete_service_config_file(service_name: &str) -> Result<()> {
     let config_file_path =
         PathBuf::from(linux::SERVICE_CONFIG_FOLDER_PATH).join(format!("{}.service", service_name));
     match fs::remove_file(&config_file_path) {
         Ok(_) => {
-            reload_systemd_daemon();
+            reload_systemd_daemon()?;
         }
         Err(e) => {
             let message = format!(
@@ -89,4 +94,5 @@ fn delete_service_config_file(service_name: &str) {
             logger_manager::write_info(message);
         }
     }
+    Ok(())
 }

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -16,7 +16,7 @@ pub async fn start_service_with_retry(
     service_name: &str,
     retry_count: u32,
     duration: std::time::Duration,
-) {
+) -> Result<()> {
     for i in 0..retry_count {
         logger_manager::write_info(format!("Starting service {} attempt {}", service_name, i));
 
@@ -27,7 +27,7 @@ pub async fn start_service_with_retry(
                         "Service {} is at Running state",
                         service_name
                     ));
-                    return;
+                    return Ok(());
                 }
 
                 logger_manager::write_info(
@@ -39,18 +39,28 @@ pub async fn start_service_with_retry(
                 );
             }
             Err(e) => {
-                logger_manager::write_info(
+                logger_manager::write_warn(
                     format!(
                         "Extension service {} start failed with error: {}",
                         service_name, e
                     )
                     .to_string(),
                 );
+                if (i + 1) == retry_count {
+                    logger_manager::write_err(
+                        format!(
+                            "Service {} failed to start after {} attempts",
+                            service_name, i
+                        )
+                        .to_string(),
+                    );
+                    return Err(e);
+                }
             }
         }
-
         tokio::time::sleep(duration).await;
     }
+    Ok(())
 }
 
 async fn start_service_once(service_name: &str) -> Result<ServiceStatus> {
@@ -297,8 +307,13 @@ mod tests {
             !output_str.contains("The specified service does not exist as an installed service")
         );
 
-        super::start_service_with_retry(TEST_SERVICE_NAME, 2, std::time::Duration::from_millis(15))
-            .await;
+        let result = super::start_service_with_retry(
+            TEST_SERVICE_NAME,
+            2,
+            std::time::Duration::from_millis(15),
+        )
+        .await;
+        assert!(result.is_err(), "Test Service should not be able to start");
         let service_status = super::query_service_status(TEST_SERVICE_NAME).unwrap();
         assert_ne!(
             service_status.current_state,


### PR DESCRIPTION
It is fixing `Sometimes values where the type system (correctly) expresses invalid values get converted to valid-looking ones with invalid values` from https://github.com/Azure/GuestProxyAgent/issues/117