### PR TITLE
Support keep-alive between client app and GPA web server

### DIFF
--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -45,6 +45,9 @@ pub enum Error {
 
     #[error("Failed to receive '{0}' action response with error {1}")]
     RecvError(String, tokio::sync::oneshot::error::RecvError),
+
+    #[error("{0}")]
+    FindAuditEntryError(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -109,6 +112,9 @@ pub enum BpfErrorType {
     #[error("Failed to lookup element '{0}' in BPF map 'audit_map'. {1}")]
     MapLookupElem(String, String),
 
+    #[error("Failed to delete element '{0}' in BPF map 'audit_map'. {1}")]
+    MapDeleteElem(String, String),
+
     #[error("Failed to retrieve file descriptor of the BPF map 'audit_map' with error: {0}")]
     MapFileDescriptor(String),
 
@@ -161,8 +167,8 @@ pub enum WindowsApiErrorType {
     #[error("LsaGetLogonSessionData {0}")]
     LsaGetLogonSessionData(String),
 
-    #[error("WinSock::WSAIoctl - SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT: {0}")]
-    WSAIoctl(i32),
+    #[error("WinSock::WSAIoctl - {0}")]
+    WSAIoctl(String),
 
     #[error("GlobalMemoryStatusEx failed: {0}")]
     GlobalMemoryStatusEx(std::io::Error),

--- a/proxy_agent/src/common/windows.rs
+++ b/proxy_agent/src/common/windows.rs
@@ -6,7 +6,6 @@ use crate::common::{
     result::Result,
 };
 use std::mem::MaybeUninit;
-use windows_sys::Win32::Networking::WinSock;
 use windows_sys::Win32::System::SystemInformation::{
     GetSystemInfo,        // kernel32.dll
     GlobalMemoryStatusEx, // kernel32.dll
@@ -35,15 +34,6 @@ pub fn get_memory_in_mb() -> Result<u64> {
         let memory_in_mb = (*data).ullTotalPhys / 1024 / 1024;
         Ok(memory_in_mb)
     }
-}
-
-pub fn check_winsock_last_error() -> Result<()> {
-    let error = unsafe { WinSock::WSAGetLastError() };
-    if error != 0 {
-        return Err(Error::WindowsApi(WindowsApiErrorType::WSAIoctl(error)));
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -573,7 +573,7 @@ impl ProvisionQuery {
 mod tests {
     use crate::common::logger;
     use crate::provision::ProvisionFlags;
-    use crate::proxy::proxy_connection::Connection;
+    use crate::proxy::proxy_connection::ConnectionLogger;
     use crate::proxy::proxy_server;
     use crate::shared_state::SharedState;
     use proxy_agent_shared::logger_manager;
@@ -598,7 +598,7 @@ mod tests {
             20,
         )
         .await;
-        Connection::init_logger(temp_test_path.to_path_buf()).await;
+        ConnectionLogger::init_logger(temp_test_path.to_path_buf()).await;
 
         // start listener, the port must different from the one used in production code
         let shared_state = SharedState::start_all();

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -3,46 +3,217 @@
 
 //! This module contains the connection context struct for the proxy listener, and write proxy processing logs to local file.
 
+use crate::common::error::Error;
+use crate::common::result::Result;
 use crate::common::{constants, hyper_client};
 use crate::proxy::Claims;
+use crate::redirector::{self, AuditEntry};
+use crate::shared_state::proxy_server_wrapper::ProxyServerSharedState;
+use crate::shared_state::redirector_wrapper::RedirectorSharedState;
 use proxy_agent_shared::logger_manager::{self, LoggerLevel};
-use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-pub struct ConnectionContext {
+#[derive(Clone)]
+pub struct TcpConnectionContext {
     pub id: u128,
-    pub stream: Arc<Mutex<TcpStream>>,
     pub client_addr: SocketAddr,
-    pub now: Instant,
     pub claims: Option<Claims>,
-    pub method: hyper::Method,
-    pub url: hyper::Uri,
-    pub ip: Option<Ipv4Addr>, // currently, we only support IPv4
-    pub port: u16,
+    pub destination_ip: Option<Ipv4Addr>, // currently, we only support IPv4
+    pub destination_port: u16,
+    logger: ConnectionLogger,
 }
 
-impl ConnectionContext {
-    pub fn should_skip_sig(&self) -> bool {
-        hyper_client::should_skip_sig(&self.method, &self.url)
+impl TcpConnectionContext {
+    pub async fn new(
+        id: u128,
+        client_addr: SocketAddr,
+        redirector_shared_state: RedirectorSharedState,
+        proxy_server_shared_state: ProxyServerSharedState,
+        #[cfg(windows)] raw_socket_id: usize, // windows only, it is the raw socket id, used to get audit entry from socket stream
+    ) -> Self {
+        let client_source_ip = client_addr.ip();
+        let client_source_port = client_addr.port();
+        let logger = ConnectionLogger {
+            tcp_connection_id: id,
+            http_connection_id: 0,
+        };
+
+        let (claims, destination_ip, destination_port) = match Self::get_audit_entry(
+            &client_addr,
+            &redirector_shared_state,
+            &logger,
+            #[cfg(windows)]
+            raw_socket_id,
+        )
+        .await
+        {
+            Ok(audit_entry) => {
+                let claims = match Claims::from_audit_entry(
+                    &audit_entry,
+                    client_source_ip,
+                    client_source_port,
+                    proxy_server_shared_state,
+                )
+                .await
+                {
+                    Ok(claims) => Some(claims),
+                    Err(e) => {
+                        logger.write(
+                            LoggerLevel::Error,
+                            format!("Failed to get claims from audit entry: {}", e),
+                        );
+                        // return None for claims
+                        None
+                    }
+                };
+
+                (
+                    claims,
+                    Some(audit_entry.destination_ipv4_addr()),
+                    audit_entry.destination_port_in_host_byte_order(),
+                )
+            }
+            Err(_) => {
+                logger.write(
+                    LoggerLevel::Warning,
+                    "This tcp connection may send to proxy agent tcp listener directly".to_string(),
+                );
+                (None, None, 0)
+            }
+        };
+
+        Self {
+            id,
+            client_addr,
+            claims,
+            destination_ip,
+            destination_port,
+            logger,
+        }
+    }
+
+    async fn get_audit_entry(
+        client_addr: &SocketAddr,
+        redirector_shared_state: &RedirectorSharedState,
+        logger: &ConnectionLogger,
+        #[cfg(windows)] raw_socket_id: usize,
+    ) -> Result<AuditEntry> {
+        let client_source_port = client_addr.port();
+        match redirector::lookup_audit(client_source_port, redirector_shared_state).await {
+            Ok(data) => {
+                logger.write(
+                    LoggerLevel::Information,
+                    format!(
+                        "Found audit entry with client_source_port '{}' successfully",
+                        client_source_port
+                    ),
+                );
+                match redirector::remove_audit(client_source_port, redirector_shared_state).await {
+                    Ok(_) => logger.write(
+                        LoggerLevel::Information,
+                        format!(
+                            "Removed audit entry with client_source_port '{}' successfully",
+                            client_source_port
+                        ),
+                    ),
+                    Err(e) => {
+                        logger.write(
+                            LoggerLevel::Warning,
+                            format!("Failed to remove audit entry: {}", e),
+                        );
+                    }
+                }
+
+                Ok(data)
+            }
+            Err(e) => {
+                let message = format!(
+                    "Failed to find audit entry with client_source_port '{}' with error: {}",
+                    client_source_port, e
+                );
+                logger.write(LoggerLevel::Warning, message.clone());
+
+                #[cfg(not(windows))]
+                {
+                    Err(Error::FindAuditEntryError(message))
+                }
+
+                #[cfg(windows)]
+                {
+                    logger.write(
+                        LoggerLevel::Information,
+                        "Try to get audit entry from socket stream".to_string(),
+                    );
+
+                    match redirector::get_audit_from_stream_socket(raw_socket_id) {
+                        Ok(data) => {
+                            logger.write(
+                                LoggerLevel::Information,
+                                "Found audit entry from socket stream successfully".to_string(),
+                            );
+                            Ok(data)
+                        }
+                        Err(e) => {
+                            logger.write(
+                                LoggerLevel::Warning,
+                                format!("Failed to get lookup_audit_from_stream with error: {}", e),
+                            );
+                            Err(Error::FindAuditEntryError(message))
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Get the target server ip address in string for logging purpose.
     pub fn get_ip_string(&self) -> String {
-        if let Some(ip) = &self.ip {
+        if let Some(ip) = &self.destination_ip {
             return ip.to_string();
         }
         "None".to_string()
     }
+
+    pub fn log(&self, logger_level: LoggerLevel, message: String) {
+        self.logger.write(logger_level, message)
+    }
 }
 
-pub struct Connection {}
-impl Connection {
+pub struct HttpConnectionContext {
+    pub id: u128,
+    pub now: Instant,
+    pub method: hyper::Method,
+    pub url: hyper::Uri,
+    pub tcp_connection_context: TcpConnectionContext,
+    pub logger: ConnectionLogger,
+}
+
+impl HttpConnectionContext {
+    pub fn should_skip_sig(&self) -> bool {
+        hyper_client::should_skip_sig(&self.method, &self.url)
+    }
+
+    pub fn log(&self, logger_level: LoggerLevel, message: String) {
+        self.logger.write(logger_level, message)
+    }
+
+    pub fn get_logger(&self) -> ConnectionLogger {
+        self.logger.clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct ConnectionLogger {
+    pub tcp_connection_id: u128,
+    pub http_connection_id: u128,
+}
+impl ConnectionLogger {
     pub const CONNECTION_LOGGER_KEY: &'static str = "Connection_Logger";
     pub async fn init_logger(log_folder: PathBuf) {
         logger_manager::init_logger(
-            Connection::CONNECTION_LOGGER_KEY.to_string(),
+            Self::CONNECTION_LOGGER_KEY.to_string(),
             log_folder,
             "ProxyAgent.Connection.log".to_string(),
             constants::MAX_LOG_FILE_SIZE,
@@ -51,35 +222,14 @@ impl Connection {
         .await;
     }
 
-    pub fn write(connection_id: u128, message: String) {
+    pub fn write(&self, logger_level: LoggerLevel, message: String) {
         logger_manager::log(
-            Connection::CONNECTION_LOGGER_KEY.to_string(),
-            LoggerLevel::Verbeose,
-            format!("Connection:{} - {}", connection_id, message),
-        )
-    }
-
-    pub fn write_information(connection_id: u128, message: String) {
-        logger_manager::log(
-            Connection::CONNECTION_LOGGER_KEY.to_string(),
-            LoggerLevel::Information,
-            format!("Connection:{} - {}", connection_id, message),
-        )
-    }
-
-    pub fn write_warning(connection_id: u128, message: String) {
-        logger_manager::log(
-            Connection::CONNECTION_LOGGER_KEY.to_string(),
-            LoggerLevel::Warning,
-            format!("Connection:{} - {}", connection_id, message),
-        )
-    }
-
-    pub fn write_error(connection_id: u128, message: String) {
-        logger_manager::log(
-            Connection::CONNECTION_LOGGER_KEY.to_string(),
-            LoggerLevel::Error,
-            format!("Connection:{} - {}", connection_id, message),
+            Self::CONNECTION_LOGGER_KEY.to_string(),
+            logger_level,
+            format!(
+                "Connection:{}_{} - {}",
+                self.tcp_connection_id, self.http_connection_id, message
+            ),
         )
     }
 }

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -227,8 +227,8 @@ impl ConnectionLogger {
             Self::CONNECTION_LOGGER_KEY.to_string(),
             logger_level,
             format!(
-                "Connection:{}_{} - {}",
-                self.tcp_connection_id, self.http_connection_id, message
+                "Connection:{}[{}] - {}",
+                self.http_connection_id, self.tcp_connection_id, message
             ),
         )
     }

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -241,7 +241,7 @@ impl ProxyServer {
         };
         tcp_connection_logger.write(
             LoggerLevel::Information,
-            "Accepted new tcp connection.".to_string(),
+            format!("Accepted new tcp connection [{}].", tcp_connection_id),
         );
 
         tokio::spawn({

--- a/proxy_agent/src/proxy/proxy_summary.rs
+++ b/proxy_agent/src/proxy/proxy_summary.rs
@@ -14,6 +14,7 @@ pub struct ProxySummary {
     pub method: String,
     pub url: String,
     pub clientIp: String,
+    pub clientPort: u16,
     pub ip: String,
     pub port: u16,
     pub userId: u64,

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -270,10 +270,24 @@ pub fn get_ebpf_file_path() -> PathBuf {
 
 pub async fn lookup_audit(
     source_port: u16,
-    redirector_shared_state: RedirectorSharedState,
+    redirector_shared_state: &RedirectorSharedState,
 ) -> Result<AuditEntry> {
     if let Ok(Some(bpf_object)) = redirector_shared_state.get_bpf_object().await {
         bpf_object.lock().unwrap().lookup_audit(source_port)
+    } else {
+        Err(Error::Bpf(BpfErrorType::GetBpfObject))
+    }
+}
+
+pub async fn remove_audit(
+    source_port: u16,
+    redirector_shared_state: &RedirectorSharedState,
+) -> Result<()> {
+    if let Ok(Some(bpf_object)) = redirector_shared_state.get_bpf_object().await {
+        bpf_object
+            .lock()
+            .unwrap()
+            .remove_audit_map_entry(source_port)
     } else {
         Err(Error::Bpf(BpfErrorType::GetBpfObject))
     }

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -431,4 +431,51 @@ impl BpfObject {
             }
         }
     }
+
+    pub fn remove_audit_map_entry(&self, source_port: u16) -> Result<()> {
+        if self.is_null() {
+            return Err(Error::Bpf(BpfErrorType::MapLookupElem(
+                source_port.to_string(),
+                "BPF has not loaded".to_string(),
+            )));
+        }
+
+        let audit_map_name = "audit_map";
+        let audit_map = bpf_object__find_map_by_name(self.0, audit_map_name).map_err(|e| {
+            Error::Bpf(BpfErrorType::GetBpfMap(
+                audit_map_name.to_string(),
+                e.to_string(),
+            ))
+        })?;
+        if audit_map.is_null() {
+            return Err(Error::Bpf(BpfErrorType::GetBpfMap(
+                audit_map_name.to_string(),
+                "bpf_object__find_map_by_name returns null pointer".to_string(),
+            )));
+        }
+
+        let map_fd = bpf_map__fd(audit_map)
+            .map_err(|e| Error::Bpf(BpfErrorType::MapFileDescriptor(e.to_string())))?;
+
+        let key = sock_addr_audit_key_t::from_source_port(source_port);
+        let result = bpf_map_delete_elem(
+            map_fd,
+            &key as *const sock_addr_audit_key_t as *const c_void,
+        )
+        .map_err(|e| {
+            Error::Bpf(BpfErrorType::MapDeleteElem(
+                source_port.to_string(),
+                format!("Error: {}", e),
+            ))
+        })?;
+
+        if result != 0 {
+            return Err(Error::Bpf(BpfErrorType::MapDeleteElem(
+                source_port.to_string(),
+                format!("Result: {}", result),
+            )));
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
* Break down ConnectionContext into TcpConnectionContext and HttpConnectionContext.

* Move lookup audit entry at tcp Connection level 
* Remove audit entry from eBPF map once it is retrieved.

* Refactoring ConnectionLogger

* Check the returned context size even SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT returned success