### PR TITLE
update status for key_keeper and proxy_server

### DIFF
--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -146,6 +146,14 @@ impl ProxyServer {
                 {
                     logger::write_warning(format!("Failed to set module status message: {}", e));
                 }
+                if let Err(e) = self
+                    .agent_status_shared_state
+                    .set_module_state(ModuleState::STOPPED, AgentStatusModule::ProxyServer)
+                    .await
+                {
+                    logger::write_warning(format!("Failed to set module state: {}", e));
+                }
+
                 // send this critical error to event logger
                 event_logger::write_event(
                     event_logger::WARN_LEVEL,


### PR DESCRIPTION
- proxyListenerStatus must show as "STOPPED" if failed to start.
- key_keeper: Set status message when acquire key failed
- key_keeper: set status message when save key locally failed
- key_keeper: update message when the get keystatus transient error is gone.