### PR TITLE
Fix cargo clippy error from rust version 1.84.0

### DIFF
--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -105,7 +105,7 @@ impl KeyKeeper {
     }
 
     /// poll secure channel status at interval from the WireServer endpoint
-    pub async fn poll_secure_channel_status<'a>(&self) {
+    pub async fn poll_secure_channel_status(&self) {
         self.update_status_message("poll secure channel status task started.".to_string(), true)
             .await;
 

--- a/proxy_agent/src/telemetry/telemetry_event.rs
+++ b/proxy_agent/src/telemetry/telemetry_event.rs
@@ -85,7 +85,7 @@ impl TelemetryData {
 
     /// Get the size of the telemetry data in bytes.
     pub fn get_size(&self) -> usize {
-        self.to_xml().as_bytes().len()
+        self.to_xml().len()
     }
 
     pub fn add_event(&mut self, event: TelemetryEvent) {


### PR DESCRIPTION
Fixed the errors

```
error: this lifetime isn't used in the function definition
   --> proxy_agent/src/key_keeper.rs:108:45
    |
108 |     pub async fn poll_secure_channel_status<'a>(&self) {
    |                                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
    = note: `-D clippy::extra-unused-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::extra_unused_lifetimes)]`

error: needless call to `as_bytes()`
  --> proxy_agent/src/telemetry/telemetry_event.rs:88:9
   |
88 |         self.to_xml().as_bytes().len()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: `len()` can be called directly on strings: `self.to_xml().len()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes
   = note: `-D clippy::needless-as-bytes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_as_bytes)]`



```