### PR TITLE
Fixes for less permissive identity matching

### DIFF
--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -47,7 +47,7 @@ pub enum Error {
     RecvError(String, tokio::sync::oneshot::error::RecvError),
 
     #[error("{0}")]
-    FindAuditEntryError(String),
+    FindAuditEntryError(String)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/proxy_agent/src/common/error.rs
+++ b/proxy_agent/src/common/error.rs
@@ -47,7 +47,7 @@ pub enum Error {
     RecvError(String, tokio::sync::oneshot::error::RecvError),
 
     #[error("{0}")]
-    FindAuditEntryError(String)
+    FindAuditEntryError(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -300,7 +300,7 @@ impl Identity {
             format!("Start to match identity '{}'", self.name),
         );
         if let Some(ref user_name) = self.userName {
-            if user_name.to_lowercase() == claims.userName.to_lowercase() {
+            if user_name.to_string() == claims.userName {
                 logger.write(
                     LoggerLevel::Verbose,
                     format!(
@@ -364,7 +364,7 @@ impl Identity {
         if let Some(ref group_name) = self.groupName {
             let mut matched = false;
             for claims_user_group_name in &claims.userGroups {
-                if claims_user_group_name.to_lowercase() == group_name.to_lowercase() {
+                if claims_user_group_name == group_name {
                     logger.write(
                         LoggerLevel::Verbose,
                         format!(
@@ -788,7 +788,6 @@ mod tests {
     use crate::key_keeper::key::Identity;
     use crate::key_keeper::key::Privilege;
     use crate::proxy::proxy_connection::ConnectionLogger;
-    use clap::builder::OsStr;
     use hyper::Uri;
 
     #[test]
@@ -1323,6 +1322,15 @@ mod tests {
         );
         let identity3 = r#"{
             "name": "test",
+            "processName": "Test"
+        }"#;
+        let identity3: Identity = serde_json::from_str(identity3).unwrap();
+        assert!(
+            !identity3.is_match(&logger, &claims),
+            "identity should not be matched"
+        );
+        let identity3 = r#"{
+            "name": "test",
             "processName": "test"
         }"#;
         let identity3: Identity = serde_json::from_str(identity3).unwrap();
@@ -1335,6 +1343,15 @@ mod tests {
         let identity4 = r#"{
             "name": "test",
             "exePath": "test1"
+        }"#;
+        let identity4: Identity = serde_json::from_str(identity4).unwrap();
+        assert!(
+            !identity4.is_match(&logger, &claims),
+            "identity should not be matched"
+        );
+        let identity4 = r#"{
+            "name": "test",
+            "exePath": "tesT"
         }"#;
         let identity4: Identity = serde_json::from_str(identity4).unwrap();
         assert!(

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -35,9 +35,9 @@ use http::{Method, StatusCode};
 use hyper::Uri;
 use proxy_agent_shared::logger_manager::LoggerLevel;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
-use std::fmt::{Display, Formatter};
 use std::ffi::OsString;
+use std::fmt::{Display, Formatter};
+use std::{collections::HashMap, path::PathBuf};
 
 const AUDIT_MODE: &str = "audit";
 const ENFORCE_MODE: &str = "enforce";
@@ -299,7 +299,7 @@ impl Identity {
             format!("Start to match identity '{}'", self.name),
         );
         if let Some(ref user_name) = self.userName {
-            if user_name.to_string() == claims.userName {
+            if *user_name == claims.userName {
                 logger.write(
                     LoggerLevel::Verbose,
                     format!(
@@ -319,8 +319,8 @@ impl Identity {
             }
         }
         if let Some(ref process_name) = self.processName {
-            let process_name_osstr: OsString = process_name.into();
-            if process_name_osstr == claims.processName {
+            let process_name_os: OsString = process_name.into();
+            if process_name_os == claims.processName {
                 logger.write(
                     LoggerLevel::Verbose,
                     format!(
@@ -1350,7 +1350,7 @@ mod tests {
         );
         let identity4 = r#"{
             "name": "test",
-            "exePath": "tesT"
+            "exePath": "TEST"
         }"#;
         let identity4: Identity = serde_json::from_str(identity4).unwrap();
         assert!(

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -31,7 +31,6 @@ use crate::{
     },
     proxy::{proxy_connection::ConnectionLogger, Claims},
 };
-use clap::builder::OsStr;
 use http::{Method, StatusCode};
 use hyper::Uri;
 use proxy_agent_shared::logger_manager::LoggerLevel;

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -164,8 +164,7 @@ impl Process {
             let base_info = windows::query_basic_process_info(handler);
             match base_info {
                 Ok(_) => {
-                    process_full_path = 
-                        windows::get_process_full_name(handler).unwrap_or_default();
+                    process_full_path = windows::get_process_full_name(handler).unwrap_or_default();
                     cmd = windows::get_process_cmd(handler).unwrap_or(UNDEFINED.to_string());
                 }
                 Err(e) => {
@@ -182,8 +181,10 @@ impl Process {
             cmd = process_info.1;
         }
 
-        let process_name = process_full_path.file_name()
-            .unwrap_or_default().to_os_string();
+        let process_name = process_full_path
+            .file_name()
+            .unwrap_or_default()
+            .to_os_string();
 
         Process {
             command_line: cmd,
@@ -338,7 +339,8 @@ mod tests {
             "processFullPath cannot be empty."
         );
         assert_ne!(
-            claims.processName, claims.processFullPath.as_os_str(),
+            claims.processName,
+            claims.processFullPath.as_os_str(),
             "processName and processFullPath should not be the same."
         );
         assert_ne!(

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -348,6 +348,8 @@ mod tests {
     use crate::proxy::authorization_rules::{AuthorizationMode, ComputedAuthorizationItem};
     use crate::proxy::{proxy_connection::ConnectionLogger, Claims};
     use proxy_agent_shared::{logger_manager, misc_helpers};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
     use std::str::FromStr;
 
     #[tokio::test]
@@ -403,10 +405,10 @@ mod tests {
             userName: "test".to_string(),
             userGroups: vec!["test".to_string()],
             processId: 0,
-            processFullPath: "test".to_string(),
+            processFullPath: PathBuf::from("test"),
             clientIp: "0".to_string(),
             clientPort: 0, // doesn't matter for this test
-            processName: "test".to_string(),
+            processName: OsString::from("test"),
             processCmdLine: "test".to_string(),
             runAsElevated: true,
         };

--- a/proxy_agent/src/proxy/proxy_authorizer.rs
+++ b/proxy_agent/src/proxy/proxy_authorizer.rs
@@ -80,7 +80,8 @@ impl Authorizer for WireServer {
     fn to_string(&self) -> String {
         format!(
             "WireServer {{ runAsElevated: {}, processName: {} }}",
-            self.claims.runAsElevated, self.claims.processName.to_string_lossy()
+            self.claims.runAsElevated,
+            self.claims.processName.to_string_lossy()
         )
     }
 }
@@ -145,7 +146,8 @@ impl Authorizer for GAPlugin {
     fn to_string(&self) -> String {
         format!(
             "GAPlugin {{ runAsElevated: {}, processName: {} }}",
-            self.claims.runAsElevated, self.claims.processName.to_string_lossy()
+            self.claims.runAsElevated,
+            self.claims.processName.to_string_lossy()
         )
     }
 }

--- a/proxy_agent/src/proxy/proxy_authorizer.rs
+++ b/proxy_agent/src/proxy/proxy_authorizer.rs
@@ -141,7 +141,7 @@ impl Authorizer for WireServer {
     fn to_string(&self) -> String {
         format!(
             "WireServer {{ runAsElevated: {}, processName: {} }}",
-            self.claims.runAsElevated, self.claims.processName
+            self.claims.runAsElevated, self.claims.processName.to_string_lossy()
         )
     }
 }
@@ -211,7 +211,7 @@ impl Authorizer for GAPlugin {
     fn to_string(&self) -> String {
         format!(
             "GAPlugin {{ runAsElevated: {}, processName: {} }}",
-            self.claims.runAsElevated, self.claims.processName
+            self.claims.runAsElevated, self.claims.processName.to_string_lossy()
         )
     }
 }
@@ -297,7 +297,7 @@ mod tests {
         proxy::{proxy_authorizer::AuthorizeResult, proxy_connection::ConnectionLogger},
         shared_state::key_keeper_wrapper::KeyKeeperSharedState,
     };
-    use std::str::FromStr;
+    use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
     #[test]
     fn get_authenticate_test() {
@@ -306,8 +306,8 @@ mod tests {
             userName: "test".to_string(),
             userGroups: vec!["test".to_string()],
             processId: std::process::id(),
-            processName: "test".to_string(),
-            processFullPath: "test".to_string(),
+            processName: OsString::from("test"),
+            processFullPath: PathBuf::from("test"),
             processCmdLine: "test".to_string(),
             runAsElevated: true,
             clientIp: "127.0.0.1".to_string(),
@@ -387,8 +387,8 @@ mod tests {
             userName: "test".to_string(),
             userGroups: vec!["test".to_string()],
             processId: std::process::id(),
-            processName: "test".to_string(),
-            processFullPath: "test".to_string(),
+            processName: OsString::from("test"),
+            processFullPath: PathBuf::from("test"),
             processCmdLine: "test".to_string(),
             runAsElevated: true,
             clientIp: "127.0.0.1".to_string(),
@@ -519,8 +519,8 @@ mod tests {
             userName: "test".to_string(),
             userGroups: vec!["test".to_string()],
             processId: std::process::id(),
-            processName: "test".to_string(),
-            processFullPath: "test".to_string(),
+            processName: OsString::from("test"),
+            processFullPath: PathBuf::from("test"),
             processCmdLine: "test".to_string(),
             runAsElevated: true,
             clientIp: "127.0.0.1".to_string(),
@@ -628,8 +628,8 @@ mod tests {
             userName: "test".to_string(),
             userGroups: vec!["test".to_string()],
             processId: std::process::id(),
-            processName: "test".to_string(),
-            processFullPath: "test".to_string(),
+            processName: OsString::from("test"),
+            processFullPath: PathBuf::from("test"),
             processCmdLine: "test".to_string(),
             runAsElevated: true,
             clientIp: "127.0.0.1".to_string(),
@@ -645,7 +645,7 @@ mod tests {
                 "immediateruncommandservice.exe",
             ];
             for process in windows_process_names.iter() {
-                claims.processName = process.to_string();
+                claims.processName = OsString::from(process);
                 assert!(
                     super::default::is_platform_process(&claims),
                     "{process} should be built-in process"

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -742,7 +742,7 @@ impl ProxyServer {
             userGroups: claims.userGroups.clone(),
             clientIp: claims.clientIp.to_string(),
             clientPort: claims.clientPort,
-            processFullPath: claims.processFullPath.to_string(),
+            processFullPath: claims.processFullPath,
             processCmdLine: claims.processCmdLine.to_string(),
             runAsElevated: claims.runAsElevated,
             method: http_connection_context.method.to_string(),

--- a/proxy_agent/src/proxy/proxy_summary.rs
+++ b/proxy_agent/src/proxy/proxy_summary.rs
@@ -4,6 +4,8 @@
 //! This module contains the proxy summary struct.
 //! The proxy summary struct is used to store the summary of the proxied connections.
 
+use std::path::PathBuf;
+
 use proxy_agent_shared::proxy_agent_aggregate_status::ProxyConnectionSummary;
 use serde_derive::{Deserialize, Serialize};
 
@@ -20,7 +22,7 @@ pub struct ProxySummary {
     pub userId: u64,
     pub userName: String,
     pub userGroups: Vec<String>,
-    pub processFullPath: String,
+    pub processFullPath: PathBuf,
     pub processCmdLine: String,
     pub runAsElevated: bool,
     pub responseStatus: String,
@@ -36,7 +38,7 @@ impl ProxySummary {
             self.clientIp,
             self.ip,
             self.port,
-            self.processFullPath,
+            self.processFullPath.to_string_lossy(),
             self.processCmdLine,
             self.responseStatus
         )
@@ -50,7 +52,7 @@ impl From<ProxySummary> for ProxyConnectionSummary {
             userGroups: Some(proxy_summary.userGroups.clone()),
             ip: proxy_summary.ip.to_string(),
             port: proxy_summary.port,
-            processFullPath: Some(proxy_summary.processFullPath.to_string()),
+            processFullPath: Some(proxy_summary.processFullPath.to_string_lossy().to_string()),
             processCmdLine: proxy_summary.processCmdLine.to_string(),
             responseStatus: proxy_summary.responseStatus.to_string(),
             count: 1,

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -8,7 +8,7 @@ use crate::common::{
 };
 use libloading::{Library, Symbol};
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::{collections::HashMap, ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 use windows_sys::Win32::Foundation::{BOOL, HANDLE, LUID, NTSTATUS, UNICODE_STRING};
@@ -323,7 +323,7 @@ pub fn get_process_cmd(handler: isize) -> Result<String> {
 }
 
 #[allow(dead_code)]
-pub fn get_process_name(handler: isize) -> Result<String> {
+pub fn get_process_name(handler: isize) -> Result<PathBuf> {
     unsafe {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleBaseNameW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
@@ -332,12 +332,11 @@ pub fn get_process_name(handler: isize) -> Result<String> {
                 std::io::Error::last_os_error(),
             )));
         }
-        let name = String::from_utf16_lossy(&buffer[..size as usize]);
-        Ok(name)
+        Ok(PathBuf::from(OsString::from_wide(&buffer[..size as usize])))
     }
 }
 
-pub fn get_process_full_name(handler: isize) -> Result<String> {
+pub fn get_process_full_name(handler: isize) -> Result<PathBuf> {
     unsafe {
         let mut buffer = [0u16; MAX_PATH + 1];
         let size = K32GetModuleFileNameExW(handler, 0, buffer.as_mut_ptr(), buffer.len() as u32);
@@ -346,8 +345,7 @@ pub fn get_process_full_name(handler: isize) -> Result<String> {
                 std::io::Error::last_os_error(),
             )));
         }
-        let name = String::from_utf16_lossy(&buffer[..size as usize]);
-        Ok(name)
+        Ok(PathBuf::from(OsString::from_wide(&buffer[..size as usize])))
     }
 }
 
@@ -405,9 +403,9 @@ mod tests {
         let base_info = super::query_basic_process_info(handler);
         assert!(base_info.is_ok(), "base_info must be ok");
 
-        assert!(!name.is_empty(), "process name should not be empty");
+        assert!(!name.as_os_str().is_empty(), "process name should not be empty");
         assert!(
-            !full_name.is_empty(),
+            !full_name.as_os_str().is_empty(),
             "process full name should not be empty"
         );
         assert!(!cmd.is_empty(), "process cmd should not be empty");

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -8,9 +8,9 @@ use crate::common::{
 };
 use libloading::{Library, Symbol};
 use once_cell::sync::Lazy;
-use std::{collections::HashMap, ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
 use std::mem::MaybeUninit;
 use std::ptr::null_mut;
+use std::{collections::HashMap, ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
 use windows_sys::Win32::Foundation::{BOOL, HANDLE, LUID, NTSTATUS, UNICODE_STRING};
 use windows_sys::Win32::Security::Authentication::Identity;
 use windows_sys::Win32::Security::Authentication::Identity::SECURITY_LOGON_SESSION_DATA;
@@ -403,7 +403,10 @@ mod tests {
         let base_info = super::query_basic_process_info(handler);
         assert!(base_info.is_ok(), "base_info must be ok");
 
-        assert!(!name.as_os_str().is_empty(), "process name should not be empty");
+        assert!(
+            !name.as_os_str().is_empty(),
+            "process name should not be empty"
+        );
         assert!(
             !full_name.as_os_str().is_empty(),
             "process full name should not be empty"


### PR DESCRIPTION
- Removes case insensitive checks
- Stores process name and path in OsString and PathBuf (OsString underlying) respectively, which are designed to hold data that does not necessarily conform to UTF-8. This prevents the need for lossy conversion which could potentially result in incorrect identity matching