### PR TITLE
Accept and persist HostGA access control rules

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -113,6 +113,7 @@ guestproxyagentmsis
 guiddef
 hklm
 hlist
+hostga
 httpwg
 Iaa
 idstepsrun

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -1009,7 +1009,7 @@ mod tests {
                 "hostga": {
                     "defaultAccess": "allow",
                     "mode": "enforce",
-                    "id": "hostgasigid",
+                    "id": "sigid",
                     "rules": {
                         "privileges": [
                             {
@@ -1235,7 +1235,7 @@ mod tests {
             "defaultAccess mismatch"
         );
         assert_eq!(
-            "hostgasigid",
+            "sigid",
             status.get_hostga_rule_id(),
             "HostGA rule id mismatch"
         );
@@ -1266,13 +1266,7 @@ mod tests {
         );
 
         // Retrieve and validate second role for HostGA
-        let role = &hostga_rules
-            .rules
-            .as_ref()
-            .unwrap()
-            .roles
-            .as_ref()
-            .unwrap()[1];
+        let role = &hostga_rules.rules.as_ref().unwrap().roles.as_ref().unwrap()[1];
         assert_eq!("test6", role.name, "role name mismatch");
         assert_eq!("test4", role.privileges[0], "role privilege mismatch");
         assert_eq!("test5", role.privileges[1], "role privilege mismatch");

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -80,6 +80,8 @@ pub struct AuthorizationRules {
     pub imds: Option<AuthorizationItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireserver: Option<AuthorizationItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostga: Option<AuthorizationItem>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -539,6 +541,13 @@ impl KeyStatus {
         }
     }
 
+    pub fn get_hostga_rule_id(&self) -> String {
+        match self.get_hostga_rules() {
+            Some(item) => item.id.to_string(),
+            None => String::new(),
+        }
+    }
+
     pub fn get_wireserver_rules(&self) -> Option<AuthorizationItem> {
         match &self.authorizationRules {
             Some(rules) => rules.wireserver.clone(),
@@ -549,6 +558,13 @@ impl KeyStatus {
     pub fn get_imds_rules(&self) -> Option<AuthorizationItem> {
         match &self.authorizationRules {
             Some(rules) => rules.imds.clone(),
+            None => None,
+        }
+    }
+
+    pub fn get_hostga_rules(&self) -> Option<AuthorizationItem> {
+        match &self.authorizationRules {
+            Some(rules) => rules.hostga.clone(),
             None => None,
         }
     }
@@ -594,6 +610,13 @@ impl KeyStatus {
             } else {
                 AUDIT_MODE.to_string()
             }
+        }
+    }
+
+    pub fn get_hostga_mode(&self) -> String {
+        match self.get_hostga_rules() {
+            Some(item) => item.mode.to_lowercase(),
+            None => "disabled".to_string(),
         }
     }
 }
@@ -982,6 +1005,79 @@ mod tests {
                             }
                         ]
                     }
+                },
+                "hostga": {
+                    "defaultAccess": "allow",
+                    "mode": "enforce",
+                    "id": "hostgasigid",
+                    "rules": {
+                        "privileges": [
+                            {
+                                "name": "test",
+                                "path": "/test",
+                                "queryParameters": {
+                                    "key1": "value1",
+                                    "key2": "value2"
+                                }
+                            },
+                            {
+                                "name": "test2",
+                                "path": "/test2",
+                                "queryParameters": {
+                                    "key1": "value3",
+                                    "key2": "value4"
+                                }
+                            }
+                        ],
+                        "roles": [
+                            {
+                                "name": "test3",
+                                "privileges": [
+                                    "test1",
+                                    "test2"
+                                ]
+                            },
+                            {
+                                "name": "test6",
+                                "privileges": [
+                                    "test4",
+                                    "test5"
+                                ]
+                            }
+                        ],
+                        "identities": [
+                            {
+                                "name": "test",
+                                "userName": "test",
+                                "groupName": "test",
+                                "exePath": "test",
+                                "processName": "test"
+                            },
+                            {
+                                "name": "test1",
+                                "userName": "test1",
+                                "groupName": "test1",
+                                "exePath": "test1",
+                                "processName": "test1"
+                            }
+                        ],
+                        "roleAssignments": [
+                            {
+                                "role": "test4",
+                                "identities": [
+                                    "test",
+                                    "test1"
+                                ]
+                            },
+                            {
+                                "role": "test5",
+                                "identities": [
+                                    "test",
+                                    "test1"
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         }"#;
@@ -1129,6 +1225,102 @@ mod tests {
         );
         assert_eq!(
             "test", first_role_assignment.identities[0],
+            "roleAssignment identities mismatch"
+        );
+
+        // Validate HostGA rules
+        let hostga_rules = status.get_hostga_rules().unwrap();
+        assert_eq!(
+            "allow", hostga_rules.defaultAccess,
+            "defaultAccess mismatch"
+        );
+        assert_eq!(
+            "hostgasigid",
+            status.get_hostga_rule_id(),
+            "HostGA rule id mismatch"
+        );
+        assert_eq!("enforce", status.get_hostga_mode(), "HostGA mode mismatch");
+
+        // Validate HostGA rule details
+        // Retrieve and validate second privilege for HostGA
+        let privilege = &hostga_rules
+            .rules
+            .as_ref()
+            .unwrap()
+            .privileges
+            .as_ref()
+            .unwrap()[1];
+
+        assert_eq!("test2", privilege.name, "privilege name mismatch");
+        assert_eq!("/test2", privilege.path, "privilege path mismatch");
+
+        assert_eq!(
+            "value3",
+            privilege.queryParameters.as_ref().unwrap()["key1"],
+            "privilege queryParameters mismatch"
+        );
+        assert_eq!(
+            "value4",
+            privilege.queryParameters.as_ref().unwrap()["key2"],
+            "privilege queryParameters mismatch"
+        );
+
+        // Retrieve and validate second role for HostGA
+        let role = &hostga_rules
+            .rules
+            .as_ref()
+            .unwrap()
+            .roles
+            .as_ref()
+            .unwrap()[1];
+        assert_eq!("test6", role.name, "role name mismatch");
+        assert_eq!("test4", role.privileges[0], "role privilege mismatch");
+        assert_eq!("test5", role.privileges[1], "role privilege mismatch");
+
+        // Retrieve and validate first identity for HostGA
+        let identity = &hostga_rules
+            .rules
+            .as_ref()
+            .unwrap()
+            .identities
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!("test", identity.name, "identity name mismatch");
+        assert_eq!(
+            "test",
+            identity.userName.as_ref().unwrap(),
+            "identity userName mismatch"
+        );
+        assert_eq!(
+            "test",
+            identity.groupName.as_ref().unwrap(),
+            "identity groupName mismatch"
+        );
+        assert_eq!(
+            "test",
+            identity.exePath.as_ref().unwrap(),
+            "identity exePath mismatch"
+        );
+        assert_eq!(
+            "test",
+            identity.processName.as_ref().unwrap(),
+            "identity processName mismatch"
+        );
+
+        // Retrieve and validate first role assignment for HostGA
+        let role_assignment = &hostga_rules
+            .rules
+            .as_ref()
+            .unwrap()
+            .roleAssignments
+            .as_ref()
+            .unwrap()[0];
+        assert_eq!(
+            "test4", role_assignment.role,
+            "roleAssignment role mismatch"
+        );
+        assert_eq!(
+            "test", role_assignment.identities[0],
             "roleAssignment identities mismatch"
         );
     }

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -254,6 +254,8 @@ pub struct ComputedAuthorizationRules {
     pub imds: Option<ComputedAuthorizationItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireserver: Option<ComputedAuthorizationItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostga: Option<ComputedAuthorizationItem>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -600,10 +602,12 @@ mod tests {
             Some(AuthorizationRules {
                 imds: Some(authorization_item.clone()),
                 wireserver: Some(authorization_item.clone()),
+                hostga: Some(authorization_item.clone()),
             }),
             ComputedAuthorizationRules {
                 imds: Some(computed_authorization_item.clone()),
                 wireserver: Some(computed_authorization_item.clone()),
+                hostga: Some(computed_authorization_item.clone()),
             },
         );
 

--- a/proxy_agent/src/shared_state/key_keeper_wrapper.rs
+++ b/proxy_agent/src/shared_state/key_keeper_wrapper.rs
@@ -502,7 +502,7 @@ impl KeyKeeperSharedState {
             .map_err(|e| Error::RecvError("KeyKeeperAction::GetHostGARuleId".to_string(), e))
     }
 
-    pub async fn set_hostga_rule_id(&self, rule_id: String) -> Result<()> {
+    async fn set_hostga_rule_id(&self, rule_id: String) -> Result<()> {
         let (response, receiver) = oneshot::channel();
         self.0
             .send(KeyKeeperAction::SetHostGARuleId { rule_id, response })

--- a/proxy_agent/src/shared_state/key_keeper_wrapper.rs
+++ b/proxy_agent/src/shared_state/key_keeper_wrapper.rs
@@ -74,6 +74,13 @@ enum KeyKeeperAction {
     GetImdsRuleId {
         response: oneshot::Sender<String>,
     },
+    GetHostGARuleId {
+        response: oneshot::Sender<String>,
+    },
+    SetHostGARuleId {
+        rule_id: String,
+        response: oneshot::Sender<()>,
+    },
     SetWireServerRules {
         rules: Option<ComputedAuthorizationItem>,
         response: oneshot::Sender<()>,
@@ -86,6 +93,13 @@ enum KeyKeeperAction {
         response: oneshot::Sender<()>,
     },
     GetImdsRules {
+        response: oneshot::Sender<Option<ComputedAuthorizationItem>>,
+    },
+    SetHostGARules {
+        rules: Option<ComputedAuthorizationItem>,
+        response: oneshot::Sender<()>,
+    },
+    GetHostGARules {
         response: oneshot::Sender<Option<ComputedAuthorizationItem>>,
     },
     GetNotify {
@@ -110,10 +124,14 @@ impl KeyKeeperSharedState {
             let mut wireserver_rule_id: String = String::new();
             // The rule ID for the IMDS endpoints
             let mut imds_rule_id: String = String::new();
+            // The rule ID for the HostGA endpoints
+            let mut hostga_rule_id: String = String::new();
             // The authorization rules for the WireServer endpoints
             let mut wireserver_rules: Option<ComputedAuthorizationItem> = None;
             // The authorization rules for the IMDS endpoints
             let mut imds_rules: Option<ComputedAuthorizationItem> = None;
+            // The authorization rules for the HostGAPlugin endpoints
+            let mut hostga_rules: Option<ComputedAuthorizationItem> = None;
 
             let notify = Arc::new(Notify::new());
             loop {
@@ -189,6 +207,23 @@ impl KeyKeeperSharedState {
                             ));
                         }
                     }
+                    Some(KeyKeeperAction::GetHostGARuleId { response }) => {
+                        if let Err(rule_id) = response.send(hostga_rule_id.clone()) {
+                            logger::write_warning(format!(
+                                "Failed to send response to KeyKeeperAction::GetHostGARuleId '{}'",
+                                rule_id
+                            ));
+                        }
+                    }
+                    Some(KeyKeeperAction::SetHostGARuleId { rule_id, response }) => {
+                        hostga_rule_id = rule_id.to_string();
+                        if response.send(()).is_err() {
+                            logger::write_warning(format!(
+                                "Failed to send response to KeyKeeperAction::SetHostGARuleId '{}'",
+                                rule_id
+                            ));
+                        }
+                    }
                     Some(KeyKeeperAction::SetWireServerRules { rules, response }) => {
                         wireserver_rules = rules;
                         if response.send(()).is_err() {
@@ -219,6 +254,23 @@ impl KeyKeeperSharedState {
                         if response.send(imds_rules.clone()).is_err() {
                             logger::write_warning(
                                 "Failed to send response to KeyKeeperAction::GetImdsRules"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(KeyKeeperAction::SetHostGARules { rules, response }) => {
+                        hostga_rules = rules;
+                        if response.send(()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to KeyKeeperAction::SetHostGARules"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(KeyKeeperAction::GetHostGARules { response }) => {
+                        if response.send(hostga_rules.clone()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to KeyKeeperAction::GetHostGARules"
                                     .to_string(),
                             );
                         }
@@ -434,6 +486,56 @@ impl KeyKeeperSharedState {
         }
     }
 
+    pub async fn get_hostga_rule_id(&self) -> Result<String> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(KeyKeeperAction::GetHostGARuleId { response })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "KeyKeeperAction::GetHostGARuleId".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("KeyKeeperAction::GetHostGARuleId".to_string(), e))
+    }
+
+    pub async fn set_hostga_rule_id(&self, rule_id: String) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(KeyKeeperAction::SetHostGARuleId { rule_id, response })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "KeyKeeperAction::SetHostGARuleId".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("KeyKeeperAction::SetHostGARuleId".to_string(), e))
+    }
+
+    /// Update the HostGA rule ID
+    /// # Arguments
+    /// * `rule_id` - String
+    /// # Returns
+    /// * `bool` - true if the rule ID is update successfully
+    /// *        - false if rule ID is the same as the current state  
+    /// * `String` - the rule Id before the update operation
+    /// * `Error` - Error if the rule ID is not read or updated successfully
+    pub async fn update_hostga_rule_id(&self, rule_id: String) -> Result<(bool, String)> {
+        let old_rule_id = self.get_hostga_rule_id().await?;
+        if old_rule_id == rule_id {
+            Ok((false, old_rule_id))
+        } else {
+            self.set_hostga_rule_id(rule_id).await?;
+            Ok((true, old_rule_id))
+        }
+    }
+
     pub async fn set_wireserver_rules(&self, rules: Option<AuthorizationItem>) -> Result<()> {
         let (response, receiver) = oneshot::channel();
         self.0
@@ -496,6 +598,35 @@ impl KeyKeeperSharedState {
         receiver
             .await
             .map_err(|e| Error::RecvError("KeyKeeperAction::GetImdsRules".to_string(), e))
+    }
+
+    pub async fn set_hostga_rules(&self, rules: Option<AuthorizationItem>) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(KeyKeeperAction::SetHostGARules {
+                rules: rules.map(ComputedAuthorizationItem::from_authorization_item),
+                response,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError("KeyKeeperAction::SetHostGARules".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("KeyKeeperAction::SetHostGARules".to_string(), e))
+    }
+
+    pub async fn get_hostga_rules(&self) -> Result<Option<ComputedAuthorizationItem>> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(KeyKeeperAction::GetHostGARules { response })
+            .await
+            .map_err(|e| {
+                Error::SendError("KeyKeeperAction::GetHostGARules".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("KeyKeeperAction::GetHostGARules".to_string(), e))
     }
 
     pub async fn get_notify(&self) -> Result<Arc<Notify>> {


### PR DESCRIPTION
- Changes in KeyKeeper to accept HostGA access control rules from WireServer
- Persist HostGA access control rules information in KeyKeeperSharedState