### PR TITLE
stop service GuestProxyAgentVMExtension to avoid os auto-start it in 15 seconds.

### DIFF
--- a/e2etest/GuestProxyAgentTest/Scripts/InstallGuestProxyAgentExtension.ps1
+++ b/e2etest/GuestProxyAgentTest/Scripts/InstallGuestProxyAgentExtension.ps1
@@ -87,8 +87,11 @@ Remove-Item -Path $PIRExtensionFolderZIPLocation -Force
 wget $decodedUrlString -OutFile $PIRExtensionFolderZIPLocation
 Write-Output "$((Get-Date).ToUniversalTime()) - downloaded the proxyagent extension file to path: " $PIRExtensionFolderZIPLocation
 
-TASKKILL /F /IM ProxyAgentExt.exe
+Write-Output "$((Get-Date).ToUniversalTime()) - net stop $serviceName"
+net stop $serviceName
+
 Write-Output "$((Get-Date).ToUniversalTime()) - TASKKILL /F /IM ProxyAgentExt.exe"
+TASKKILL /F /IM ProxyAgentExt.exe
 
 Write-Output "$((Get-Date).ToUniversalTime()) - Delete registry key at $registrykeyPath"
 Remove-Item -Path $registrykeyPath -Recurse


### PR DESCRIPTION
With this change https://github.com/Azure/GuestProxyAgent/pull/166, OS would auto-start our Windows GPA VM Extension service in 15 seconds if our test script killed it.