### PR TITLE
Adjust and fix logging infra in shared crate

### DIFF
--- a/proxy_agent/src/acl/linux_acl.rs
+++ b/proxy_agent/src/acl/linux_acl.rs
@@ -49,7 +49,7 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::common::logger;
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
     use std::fs;

--- a/proxy_agent/src/acl/windows_acl.rs
+++ b/proxy_agent/src/acl/windows_acl.rs
@@ -127,7 +127,7 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::common::logger;
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
     use std::fs;

--- a/proxy_agent/src/common/config.rs
+++ b/proxy_agent/src/common/config.rs
@@ -18,7 +18,7 @@
 
 use crate::common::constants;
 use once_cell::sync::Lazy;
-use proxy_agent_shared::{logger_manager::LoggerLevel, misc_helpers};
+use proxy_agent_shared::{logger::LoggerLevel, misc_helpers};
 use serde_derive::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
 

--- a/proxy_agent/src/common/logger.rs
+++ b/proxy_agent/src/common/logger.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use crate::common::cli;
 use proxy_agent_shared::{
-    logger_manager::{self, LoggerLevel},
+    logger::{logger_manager, LoggerLevel},
     misc_helpers,
 };
 

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -803,7 +803,7 @@ mod tests {
     use crate::key_keeper;
     use crate::key_keeper::KeyKeeper;
     use crate::test_mock::server_mock;
-    use proxy_agent_shared::{logger_manager, misc_helpers};
+    use proxy_agent_shared::{logger::logger_manager, misc_helpers};
     use std::env;
     use std::fs;
     use std::time::Duration;

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use http::{Method, StatusCode};
 use hyper::Uri;
-use proxy_agent_shared::logger_manager::LoggerLevel;
+use proxy_agent_shared::logger::LoggerLevel;
 use serde_derive::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -595,7 +595,7 @@ mod tests {
     use crate::proxy::proxy_connection::ConnectionLogger;
     use crate::proxy::proxy_server;
     use crate::shared_state::SharedState;
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
     use std::env;
     use std::fs;
     use std::time::Duration;

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -244,7 +244,7 @@ impl User {
 
 #[cfg(test)]
 mod tests {
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
 
     use super::Claims;
     use crate::{

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -20,7 +20,7 @@
 use super::{proxy_connection::ConnectionLogger, Claims};
 use crate::common::logger;
 use crate::key_keeper::key::{AuthorizationItem, AuthorizationRules, Identity, Privilege, Role};
-use proxy_agent_shared::logger_manager::LoggerLevel;
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -349,7 +349,7 @@ mod tests {
     };
     use crate::proxy::authorization_rules::{AuthorizationMode, ComputedAuthorizationItem};
     use crate::proxy::{proxy_connection::ConnectionLogger, Claims};
-    use proxy_agent_shared::{logger_manager, misc_helpers};
+    use proxy_agent_shared::{logger::logger_manager, misc_helpers};
     use std::ffi::OsString;
     use std::path::PathBuf;
     use std::str::FromStr;

--- a/proxy_agent/src/proxy/proxy_authorizer.rs
+++ b/proxy_agent/src/proxy/proxy_authorizer.rs
@@ -19,12 +19,11 @@
 //! authorizer.authorize(logger, url, vm_metadata);
 //!  
 
-use proxy_agent_shared::logger_manager::LoggerLevel;
-
 use super::authorization_rules::{AuthorizationMode, ComputedAuthorizationItem};
 use super::proxy_connection::ConnectionLogger;
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::{common::constants, common::result::Result, proxy::Claims};
+use proxy_agent_shared::logger::LoggerLevel;
 
 #[derive(PartialEq)]
 pub enum AuthorizeResult {

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -14,7 +14,7 @@ use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::client::conn::http1;
 use hyper::Request;
-use proxy_agent_shared::logger_manager::{self, LoggerLevel};
+use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -45,7 +45,7 @@ use hyper::service::service_fn;
 use hyper::StatusCode;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use proxy_agent_shared::logger_manager::LoggerLevel;
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::ModuleState;
 use proxy_agent_shared::telemetry::event_logger;
@@ -910,7 +910,7 @@ mod tests {
     use crate::proxy::proxy_server;
     use crate::shared_state;
     use http::Method;
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
     use std::collections::HashMap;
     use std::env;
     use std::fs;

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -485,7 +485,7 @@ mod tests {
     use crate::redirector::linux::ebpf_obj::sock_addr_audit_entry;
     use crate::redirector::linux::ebpf_obj::sock_addr_audit_key;
     use aya::maps::HashMap;
-    use proxy_agent_shared::logger_manager;
+    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
 

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -8,7 +8,7 @@ use crate::key_keeper::KeyKeeper;
 use crate::proxy::proxy_server::ProxyServer;
 use crate::redirector;
 use crate::shared_state::SharedState;
-use proxy_agent_shared::logger_manager;
+use proxy_agent_shared::logger::logger_manager;
 use proxy_agent_shared::telemetry::event_logger;
 
 #[cfg(not(windows))]

--- a/proxy_agent/src/telemetry/event_reader.rs
+++ b/proxy_agent/src/telemetry/event_reader.rs
@@ -382,7 +382,7 @@ mod tests {
     use crate::common::logger;
     use crate::key_keeper::key::Key;
     use crate::test_mock::server_mock;
-    use proxy_agent_shared::{logger_manager, misc_helpers};
+    use proxy_agent_shared::{logger::logger_manager, misc_helpers};
     use std::{env, fs};
 
     #[tokio::test]

--- a/proxy_agent_extension/src/logger.rs
+++ b/proxy_agent_extension/src/logger.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use proxy_agent_shared::logger_manager::{self, LoggerLevel};
+use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
 use std::path::PathBuf;
 
 static LOGGER_KEY: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();

--- a/proxy_agent_setup/src/logger.rs
+++ b/proxy_agent_setup/src/logger.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use proxy_agent_shared::{
-    logger_manager::{self, LoggerLevel},
-    misc_helpers,
-};
+use proxy_agent_shared::{logger::logger_manager, logger::LoggerLevel, misc_helpers};
 use std::path::PathBuf;
 
 const LOGGER_KEY: &str = "setup.log";

--- a/proxy_agent_shared/src/lib.rs
+++ b/proxy_agent_shared/src/lib.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 pub mod error;
-pub mod logger_manager;
+pub mod logger;
 pub mod misc_helpers;
 pub mod proxy_agent_aggregate_status;
 pub mod result;
-pub mod rolling_logger;
 pub mod service;
 pub mod telemetry;
 pub mod version;

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use crate::error::{CommandErrorType, Error};
-use crate::logger_manager;
+use crate::logger::logger_manager;
 use crate::misc_helpers;
 use crate::result::Result;
 use once_cell::sync::Lazy;

--- a/proxy_agent_shared/src/logger.rs
+++ b/proxy_agent_shared/src/logger.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+pub mod logger_manager;
+pub mod rolling_logger;
+
+#[derive(PartialEq, PartialOrd, Debug)]
+pub enum LoggerLevel {
+    Verbose,
+    Information,
+    Warning,
+    Error,
+}
+
+impl LoggerLevel {
+    pub fn from_string(level: &str) -> Self {
+        match level {
+            "Verb" => LoggerLevel::Verbose,
+            "Info" => LoggerLevel::Information,
+            "Warn" => LoggerLevel::Warning,
+            "Err" => LoggerLevel::Error,
+            _ => LoggerLevel::Information,
+        }
+    }
+}

--- a/proxy_agent_shared/src/logger/logger_manager.rs
+++ b/proxy_agent_shared/src/logger/logger_manager.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 
-enum TelemetryLoggerAction {
+enum LoggerAction {
     InitLogger {
         logger_key: String,
         log_folder: PathBuf,
@@ -27,9 +27,9 @@ enum TelemetryLoggerAction {
 }
 
 #[derive(Clone, Debug)]
-struct TelemetryLogger(mpsc::Sender<TelemetryLoggerAction>);
+struct Logger(mpsc::Sender<LoggerAction>);
 
-impl TelemetryLogger {
+impl Logger {
     pub fn start_new() -> Self {
         let (tx, mut rx) = mpsc::channel(100);
         tokio::spawn(async move {
@@ -38,7 +38,7 @@ impl TelemetryLogger {
             let mut file_logger_level = LoggerLevel::Verbose;
             while let Some(action) = rx.recv().await {
                 match action {
-                    TelemetryLoggerAction::InitLogger {
+                    LoggerAction::InitLogger {
                         logger_key,
                         log_folder,
                         log_name,
@@ -59,10 +59,10 @@ impl TelemetryLogger {
                             first_logger_key = Some(logger_key);
                         }
                     }
-                    TelemetryLoggerAction::SetLoggerLevel { log_level } => {
+                    LoggerAction::SetLoggerLevel { log_level } => {
                         file_logger_level = log_level;
                     }
-                    TelemetryLoggerAction::WriteLog {
+                    LoggerAction::WriteLog {
                         logger_key,
                         log_level,
                         message,
@@ -115,7 +115,7 @@ impl TelemetryLogger {
     ) {
         if let Err(e) = self
             .0
-            .send(TelemetryLoggerAction::InitLogger {
+            .send(LoggerAction::InitLogger {
                 logger_key,
                 log_folder,
                 log_name,
@@ -131,7 +131,7 @@ impl TelemetryLogger {
     async fn set_logger_level(&self, log_level: LoggerLevel) {
         if let Err(e) = self
             .0
-            .send(TelemetryLoggerAction::SetLoggerLevel { log_level })
+            .send(LoggerAction::SetLoggerLevel { log_level })
             .await
         {
             eprintln!("Error in set_logger_level: {}", e);
@@ -140,7 +140,7 @@ impl TelemetryLogger {
     async fn write_log(&self, logger_key: Option<String>, log_level: LoggerLevel, message: String) {
         if let Err(e) = self
             .0
-            .send(TelemetryLoggerAction::WriteLog {
+            .send(LoggerAction::WriteLog {
                 logger_key,
                 log_level,
                 message,
@@ -152,7 +152,7 @@ impl TelemetryLogger {
     }
 }
 
-static TELEMETRY_LOGGER: Lazy<TelemetryLogger> = Lazy::new(TelemetryLogger::start_new);
+static LOGGER: Lazy<Logger> = Lazy::new(Logger::start_new);
 
 pub async fn init_logger(
     logger_key: String,
@@ -161,18 +161,18 @@ pub async fn init_logger(
     log_size: u64,
     log_count: u16,
 ) {
-    TELEMETRY_LOGGER
+    LOGGER
         .init_logger(logger_key, log_folder, log_name, log_size, log_count)
         .await;
 }
 
 pub async fn set_logger_level(log_level: LoggerLevel) {
-    TELEMETRY_LOGGER.set_logger_level(log_level).await;
+    LOGGER.set_logger_level(log_level).await;
 }
 
 pub fn log(logger_key: String, log_level: LoggerLevel, message: String) {
     tokio::spawn(async move {
-        TELEMETRY_LOGGER
+        LOGGER
             .write_log(Some(logger_key), log_level, message)
             .await;
     });
@@ -180,7 +180,7 @@ pub fn log(logger_key: String, log_level: LoggerLevel, message: String) {
 
 fn write_log(log_level: LoggerLevel, message: String) {
     tokio::spawn(async move {
-        TELEMETRY_LOGGER.write_log(None, log_level, message).await;
+        LOGGER.write_log(None, log_level, message).await;
     });
 }
 

--- a/proxy_agent_shared/src/logger/logger_manager.rs
+++ b/proxy_agent_shared/src/logger/logger_manager.rs
@@ -172,9 +172,7 @@ pub async fn set_logger_level(log_level: LoggerLevel) {
 
 pub fn log(logger_key: String, log_level: LoggerLevel, message: String) {
     tokio::spawn(async move {
-        LOGGER
-            .write_log(Some(logger_key), log_level, message)
-            .await;
+        LOGGER.write_log(Some(logger_key), log_level, message).await;
     });
 }
 

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -51,7 +51,9 @@ impl RollingLogger {
             initialized: false,
             log_writer: None, // will initialize later
         };
-        logger.init().unwrap();
+        if let Err(e) = logger.init() {
+            eprintln!("Failed to initialize logger: {:?}", e);
+        }
 
         logger
     }
@@ -111,6 +113,11 @@ impl RollingLogger {
 
     pub fn write_line(&mut self, message: String) -> Result<()> {
         self.roll_if_needed()?;
+        if self.log_writer.is_none() {
+            self.open_file()?;
+        }
+
+        // below unwrap is safe because we have checked the log_writer is not None above
         self.log_writer
             .as_mut()
             .unwrap()
@@ -162,7 +169,7 @@ impl RollingLogger {
                 continue;
             }
 
-            let file_name = entry.file_name().into_string().unwrap();
+            let file_name: String = entry.file_name().into_string().Into;
             if !file_name.starts_with(&self.log_file_name) {
                 continue;
             }

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -6,6 +6,8 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{LineWriter, Write};
 use std::path::PathBuf;
 
+use super::LoggerLevel;
+
 pub struct RollingLogger {
     log_dir: PathBuf,
     log_file_name: String,
@@ -78,7 +80,16 @@ impl RollingLogger {
         Ok(())
     }
 
-    pub fn write(&mut self, message: String) -> Result<()> {
+    pub fn write(&mut self, logger_level: LoggerLevel, message: String) -> Result<()> {
+        match logger_level {
+            LoggerLevel::Verbose => self.write_verb(message),
+            LoggerLevel::Information => self.write_information(message),
+            LoggerLevel::Warning => self.write_warning(message),
+            LoggerLevel::Error => self.write_error(message),
+        }
+    }
+
+    pub fn write_verb(&mut self, message: String) -> Result<()> {
         let header = get_log_header("[VERB]    ");
         self.write_line(header + &message)
     }
@@ -210,7 +221,7 @@ mod tests {
             RollingLogger::create_new(temp_test_path.clone(), String::from("proxyagent"), 1024, 10);
 
         logger
-            .write(String::from("This is a test message"))
+            .write_verb(String::from("This is a test message"))
             .unwrap();
 
         // clean up and ignore the clean up errors
@@ -231,7 +242,7 @@ mod tests {
         // test without deleting old files
         for _ in [0; 10] {
             logger
-                .write(String::from("This is a test message"))
+                .write_verb(String::from("This is a test message"))
                 .unwrap();
         }
         let file_count = logger.get_log_files().unwrap();
@@ -240,7 +251,7 @@ mod tests {
         // test with deleting old files
         for _ in [0; 10] {
             logger
-                .write(String::from("This is a test message"))
+                .write_verb(String::from("This is a test message"))
                 .unwrap();
         }
         let file_count = logger.get_log_files().unwrap();

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -169,7 +169,7 @@ impl RollingLogger {
                 continue;
             }
 
-            let file_name: String = entry.file_name().into_string().Into;
+            let file_name: String = entry.file_name().into_string()?;
             if !file_name.starts_with(&self.log_file_name) {
                 continue;
             }

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -169,9 +169,11 @@ impl RollingLogger {
                 continue;
             }
 
-            let file_name: String = entry.file_name().into_string()?;
-            if !file_name.starts_with(&self.log_file_name) {
-                continue;
+            // log file name should able convert to string safely; if not, ignore this file entry
+            if let Ok(file_name) = entry.file_name().into_string() {
+                if !file_name.starts_with(&self.log_file_name) {
+                    continue;
+                }
             }
 
             log_files.push(file_full_path);

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -8,7 +8,7 @@ mod windows_service;
 use std::path::PathBuf;
 
 #[cfg(windows)]
-use crate::logger_manager;
+use crate::logger::logger_manager;
 use crate::result::Result;
 
 pub fn install_service(

--- a/proxy_agent_shared/src/service/linux_service.rs
+++ b/proxy_agent_shared/src/service/linux_service.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use crate::linux;
-use crate::logger_manager;
+use crate::logger::logger_manager;
 use crate::misc_helpers;
 use crate::result::Result;
 use std::fs;

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use crate::error::Error;
-use crate::logger_manager;
+use crate::logger::logger_manager;
 use crate::result::Result;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -308,7 +308,7 @@ pub fn set_default_failure_actions(service_name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::logger_manager;
+    use crate::logger::logger_manager;
     use std::env;
     use std::{path::PathBuf, process::Command};
 

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::logger_manager;
-use crate::logger_manager::LoggerLevel;
+
+use crate::logger::{logger_manager, LoggerLevel};
 use crate::misc_helpers;
 use crate::telemetry::Event;
 use concurrent_queue::ConcurrentQueue;
@@ -181,7 +181,7 @@ pub fn write_event(
 
 #[cfg(test)]
 mod tests {
-    use crate::logger_manager;
+    use crate::logger::logger_manager;
     use crate::misc_helpers;
     use std::env;
     use std::fs;


### PR DESCRIPTION
- move logger_manager and rolling_logger under mod logger
- add write (logger_level, message) function in rolling_logger
- rename TelemetryLogger to Logger
- not crash `Logger` thread when write failed.
- fix unwrap in rolling_logger