### PR TITLE
Logging Infra refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "ProxyAgentExt"
 version = "9.9.9"
 dependencies = [
  "clap",
+ "ctor",
  "nix",
  "once_cell",
  "proxy_agent_shared",
@@ -162,6 +163,7 @@ dependencies = [
  "aya",
  "bitflags",
  "clap",
+ "ctor",
  "hex",
  "hmac-sha256",
  "http",
@@ -343,6 +345,21 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "ctor"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d960ecacd0a1bf55e73144b72de745e7bf275c7952c50e36e8af0a0cb7ab1f"
+dependencies = [
+ "ctor-proc-macro",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c426d2ba3e525b39c1f0a9ba41b9fe61878dee11fa4e4a76b6ab440f46c5db5d"
 
 [[package]]
 name = "deranged"
@@ -627,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "memchr"
@@ -786,6 +803,8 @@ name = "proxy_agent_shared"
 version = "9.9.9"
 dependencies = [
  "concurrent-queue",
+ "ctor",
+ "log",
  "once_cell",
  "os_info",
  "regex",

--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -27,6 +27,7 @@ tower = { version = "0.5.2", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["limit"] }
 clap = { version = "4.5.17", features =["derive"] } # Command Line Argument Parser 
 thiserror = "1.0.64"
+ctor = "0.3.6"                # used for test setup and clean up
 
 [dependencies.uuid]
 version = "1.3.0"

--- a/proxy_agent/config/GuestProxyAgent.linux.json
+++ b/proxy_agent/config/GuestProxyAgent.linux.json
@@ -7,5 +7,5 @@
     "hostGAPluginSupport": 1,
     "ebpfProgramName": "ebpf_cgroup.o",
     "cgroupRoot": "/sys/fs/cgroup",
-    "fileLogLevel": "Info"
+    "fileLogLevel": "Trace"
 }

--- a/proxy_agent/config/GuestProxyAgent.windows.json
+++ b/proxy_agent/config/GuestProxyAgent.windows.json
@@ -6,5 +6,5 @@
     "pollKeyStatusIntervalInSeconds": 15,
     "hostGAPluginSupport": 1,
     "ebpfProgramName": "redirect.bpf.sys",
-    "fileLogLevel": "Info"
+    "fileLogLevel": "Trace"
 }

--- a/proxy_agent/src/acl/linux_acl.rs
+++ b/proxy_agent/src/acl/linux_acl.rs
@@ -62,14 +62,6 @@ mod tests {
         temp_test_path.push(logger_key);
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            temp_test_path.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
         _ = misc_helpers::try_create_folder(&temp_test_path);
 
         let output = super::acl_directory(temp_test_path.to_path_buf());

--- a/proxy_agent/src/acl/linux_acl.rs
+++ b/proxy_agent/src/acl/linux_acl.rs
@@ -48,8 +48,6 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
 #[cfg(feature = "test-with-root")]
 #[cfg(test)]
 mod tests {
-    use crate::common::logger;
-    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
     use std::fs;

--- a/proxy_agent/src/acl/windows_acl.rs
+++ b/proxy_agent/src/acl/windows_acl.rs
@@ -126,8 +126,6 @@ pub fn acl_directory(dir_to_acl: PathBuf) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::logger;
-    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
     use std::fs;
@@ -145,14 +143,6 @@ mod tests {
         temp_test_path.push(logger_key);
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            temp_test_path.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
         _ = misc_helpers::try_create_folder(&temp_test_path);
 
         // test when dir_to_acl does not exist

--- a/proxy_agent/src/common/config.rs
+++ b/proxy_agent/src/common/config.rs
@@ -20,6 +20,7 @@ use crate::common::constants;
 use once_cell::sync::Lazy;
 use proxy_agent_shared::{logger::LoggerLevel, misc_helpers};
 use serde_derive::{Deserialize, Serialize};
+use std::str::FromStr;
 use std::{path::PathBuf, time::Duration};
 
 #[cfg(not(windows))]
@@ -159,7 +160,7 @@ impl Config {
 
     pub fn get_file_log_level(&self) -> LoggerLevel {
         let file_log_level = self.fileLogLevel.clone().unwrap_or("Info".to_string());
-        LoggerLevel::from_string(&file_log_level)
+        LoggerLevel::from_str(&file_log_level).unwrap_or(LoggerLevel::Info)
     }
 
     #[cfg(not(windows))]

--- a/proxy_agent/src/common/logger.rs
+++ b/proxy_agent/src/common/logger.rs
@@ -9,15 +9,15 @@ use proxy_agent_shared::{
 pub const AGENT_LOGGER_KEY: &str = "Agent_Logger";
 
 pub fn write(message: String) {
-    log(LoggerLevel::Verbose, message);
+    log(LoggerLevel::Trace, message);
 }
 
 pub fn write_information(message: String) {
-    log(LoggerLevel::Information, message);
+    log(LoggerLevel::Info, message);
 }
 
 pub fn write_warning(message: String) {
-    log(LoggerLevel::Warning, message);
+    log(LoggerLevel::Warn, message);
 }
 
 pub fn write_error(message: String) {
@@ -25,7 +25,7 @@ pub fn write_error(message: String) {
 }
 
 fn log(log_level: LoggerLevel, message: String) {
-    if log_level != LoggerLevel::Verbose {
+    if log_level != LoggerLevel::Trace {
         write_console_log(message.to_string());
     };
     logger_manager::log(AGENT_LOGGER_KEY.to_string(), log_level, message);

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -214,18 +214,18 @@ impl Clone for Privilege {
 impl Privilege {
     pub fn is_match(&self, logger: &ConnectionLogger, request_url: &Uri) -> bool {
         logger.write(
-            LoggerLevel::Verbose,
+            LoggerLevel::Trace,
             format!("Start to match privilege '{}'", self.name),
         );
         if request_url.path().to_lowercase().starts_with(&self.path) {
             logger.write(
-                LoggerLevel::Verbose,
+                LoggerLevel::Trace,
                 format!("Matched privilege path '{}'", self.path),
             );
 
             if let Some(query_parameters) = &self.queryParameters {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Start to match query_parameters from privilege '{}'",
                         self.name
@@ -240,7 +240,7 @@ impl Privilege {
                         Some((_, v)) => {
                             if v.to_lowercase() == value.to_lowercase() {
                                 logger.write(
-                                    LoggerLevel::Verbose,
+                                    LoggerLevel::Trace,
                                     format!(
                                         "Matched query_parameters '{}:{}' from privilege '{}'",
                                         key, v, self.name
@@ -248,7 +248,7 @@ impl Privilege {
                                 );
                             } else {
                                 logger.write(
-                                    LoggerLevel::Verbose,
+                                    LoggerLevel::Trace,
                                         format!("Not matched query_parameters value '{}' from privilege '{}'", key, self.name),
                                     );
                                 return false;
@@ -256,7 +256,7 @@ impl Privilege {
                         }
                         None => {
                             logger.write(
-                                LoggerLevel::Verbose,
+                                LoggerLevel::Trace,
                                 format!(
                                     "Not matched query_parameters key '{}' from privilege '{}'",
                                     key, self.name
@@ -297,13 +297,13 @@ impl Clone for Identity {
 impl Identity {
     pub fn is_match(&self, logger: &ConnectionLogger, claims: &Claims) -> bool {
         logger.write(
-            LoggerLevel::Verbose,
+            LoggerLevel::Trace,
             format!("Start to match identity '{}'", self.name),
         );
         if let Some(ref user_name) = self.userName {
             if *user_name == claims.userName {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Matched user name '{}' from identity '{}'",
                         user_name, self.name
@@ -311,7 +311,7 @@ impl Identity {
                 );
             } else {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Not matched user name '{}' from identity '{}'",
                         user_name, self.name
@@ -324,7 +324,7 @@ impl Identity {
             let process_name_os: OsString = process_name.into();
             if process_name_os == claims.processName {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Matched process name '{}' from identity '{}'",
                         process_name, self.name
@@ -332,7 +332,7 @@ impl Identity {
                 );
             } else {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Not matched process name '{}' from identity '{}'",
                         process_name, self.name
@@ -345,7 +345,7 @@ impl Identity {
             let process_path_buf: PathBuf = exe_path.into();
             if process_path_buf == claims.processFullPath {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Matched process full path '{}' from identity '{}'",
                         exe_path, self.name
@@ -353,7 +353,7 @@ impl Identity {
                 );
             } else {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Not matched process full path '{}' from identity '{}'",
                         exe_path, self.name
@@ -367,7 +367,7 @@ impl Identity {
             for claims_user_group_name in &claims.userGroups {
                 if claims_user_group_name == group_name {
                     logger.write(
-                        LoggerLevel::Verbose,
+                        LoggerLevel::Trace,
                         format!(
                             "Matched user group name '{}' from identity '{}'",
                             group_name, self.name
@@ -379,7 +379,7 @@ impl Identity {
             }
             if !matched {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Not matched user group name '{}' from identity '{}'",
                         group_name, self.name
@@ -1370,10 +1370,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_privilege_is_match() {
-        let logger_key = "test_privilege_is_match";
-        let mut temp_test_path = std::env::temp_dir();
-        temp_test_path.push(logger_key);
-        ConnectionLogger::init_logger(temp_test_path.to_path_buf()).await;
         let logger = ConnectionLogger {
             tcp_connection_id: 1,
             http_connection_id: 1,
@@ -1439,17 +1435,10 @@ mod tests {
             !privilege2.is_match(&logger, &url),
             "privilege should not be matched"
         );
-
-        // clean up and ignore the clean up errors
-        _ = std::fs::remove_dir_all(temp_test_path);
     }
 
     #[tokio::test]
     async fn test_identity_is_match() {
-        let logger_key = "test_identity_is_match";
-        let mut temp_test_path = std::env::temp_dir();
-        temp_test_path.push(logger_key);
-        ConnectionLogger::init_logger(temp_test_path.to_path_buf()).await;
         let logger = ConnectionLogger {
             tcp_connection_id: 1,
             http_connection_id: 1,
@@ -1623,7 +1612,5 @@ mod tests {
             replacement_char, process_name_lossy,
             "process name after lossy conversion should be equal to replacement char"
         );
-        // clean up and ignore the clean up errors
-        _ = std::fs::remove_dir_all(temp_test_path);
     }
 }

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -345,7 +345,6 @@ pub async fn start_event_threads(
                 config::get_events_dir(),
                 Duration::default(),
                 config::get_max_event_file_count(),
-                logger::AGENT_LOGGER_KEY,
                 move |status: String| {
                     let cloned_agent_status_shared_state = cloned_agent_status_shared_state.clone();
                     async move {
@@ -590,12 +589,9 @@ impl ProvisionQuery {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::logger;
     use crate::provision::ProvisionFlags;
-    use crate::proxy::proxy_connection::ConnectionLogger;
     use crate::proxy::proxy_server;
     use crate::shared_state::SharedState;
-    use proxy_agent_shared::logger::logger_manager;
     use std::env;
     use std::fs;
     use std::time::Duration;
@@ -608,16 +604,6 @@ mod tests {
 
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            temp_test_path.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
-        ConnectionLogger::init_logger(temp_test_path.to_path_buf()).await;
 
         // start listener, the port must different from the one used in production code
         let shared_state = SharedState::start_all();

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -244,33 +244,14 @@ impl User {
 
 #[cfg(test)]
 mod tests {
-    use proxy_agent_shared::logger::logger_manager;
-
     use super::Claims;
     use crate::{
-        common::logger, redirector::AuditEntry,
-        shared_state::proxy_server_wrapper::ProxyServerSharedState,
+        redirector::AuditEntry, shared_state::proxy_server_wrapper::ProxyServerSharedState,
     };
-    use std::{env, fs, net::IpAddr};
+    use std::net::IpAddr;
 
     #[tokio::test]
     async fn user_test() {
-        let mut temp_test_path = env::temp_dir();
-        let logger_key = "user_test";
-        temp_test_path.push(logger_key);
-
-        // clean up and ignore the clean up errors
-        _ = fs::remove_dir_all(&temp_test_path);
-
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            temp_test_path.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
-
         let logon_id;
         let expected_user_name;
         #[cfg(windows)]

--- a/proxy_agent/src/proxy/proxy_authorizer.rs
+++ b/proxy_agent/src/proxy/proxy_authorizer.rs
@@ -66,7 +66,7 @@ impl Authorizer for WireServer {
             } else {
                 if rules.mode == AuthorizationMode::Audit {
                     logger.write(
-                            LoggerLevel::Information, format!("WireServer request {} denied in audit mode, continue forward the request", request_url));
+                            LoggerLevel::Info, format!("WireServer request {} denied in audit mode, continue forward the request", request_url));
                     return AuthorizeResult::OkWithAudit;
                 }
                 return AuthorizeResult::Forbidden;
@@ -102,7 +102,7 @@ impl Authorizer for Imds {
             } else {
                 if rules.mode == AuthorizationMode::Audit {
                     logger.write(
-                        LoggerLevel::Information,
+                        LoggerLevel::Info,
                         format!(
                             "IMDS request {} denied in audit mode, continue forward the request",
                             request_url
@@ -143,7 +143,7 @@ impl Authorizer for GAPlugin {
             } else {
                 if rules.mode == AuthorizationMode::Audit {
                     logger.write(
-                            LoggerLevel::Information, format!("HostGAPlugin request {} denied in audit mode, continue forward the request", request_url));
+                            LoggerLevel::Info, format!("HostGAPlugin request {} denied in audit mode, continue forward the request", request_url));
                     return AuthorizeResult::OkWithAudit;
                 }
                 return AuthorizeResult::Forbidden;
@@ -238,7 +238,7 @@ pub fn authorize(
 ) -> AuthorizeResult {
     let auth = get_authorizer(ip, port, claims);
     logger.write(
-        LoggerLevel::Verbose,
+        LoggerLevel::Trace,
         format!("Got auth: {}", auth.to_string()),
     );
     auth.authorize(logger, request_uri, access_control_rules)

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -4,8 +4,8 @@
 //! This module contains the connection context struct for the proxy listener, and write proxy processing logs to local file.
 
 use crate::common::error::{Error, HyperErrorType};
+use crate::common::hyper_client;
 use crate::common::result::Result;
-use crate::common::{constants, hyper_client};
 use crate::proxy::Claims;
 use crate::redirector::{self, AuditEntry};
 use crate::shared_state::proxy_server_wrapper::ProxyServerSharedState;
@@ -16,7 +16,6 @@ use hyper::client::conn::http1;
 use hyper::Request;
 use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
 use std::net::{Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Mutex;
@@ -106,12 +105,12 @@ impl TcpConnectionContext {
                 let host_port = audit_entry.destination_port_in_host_byte_order();
                 let cloned_logger = logger.clone();
                 let fun = move |message: String| {
-                    cloned_logger.write(LoggerLevel::Warning, message);
+                    cloned_logger.write(LoggerLevel::Warn, message);
                 };
                 let sender = match hyper_client::build_http_sender(&host_ip, host_port, fun).await {
                     Ok(sender) => {
                         logger.write(
-                            LoggerLevel::Verbose,
+                            LoggerLevel::Trace,
                             "Successfully created http sender".to_string(),
                         );
                         Ok(Arc::new(Mutex::new(Client { sender })))
@@ -128,7 +127,7 @@ impl TcpConnectionContext {
             }
             Err(e) => {
                 logger.write(
-                    LoggerLevel::Warning,
+                    LoggerLevel::Warn,
                     "This tcp connection may send to proxy agent tcp listener directly".to_string(),
                 );
                 (None, None, 0, Err(e.to_string()))
@@ -156,7 +155,7 @@ impl TcpConnectionContext {
         match redirector::lookup_audit(client_source_port, redirector_shared_state).await {
             Ok(data) => {
                 logger.write(
-                    LoggerLevel::Verbose,
+                    LoggerLevel::Trace,
                     format!(
                         "Found audit entry with client_source_port '{}' successfully",
                         client_source_port
@@ -164,7 +163,7 @@ impl TcpConnectionContext {
                 );
                 match redirector::remove_audit(client_source_port, redirector_shared_state).await {
                     Ok(_) => logger.write(
-                        LoggerLevel::Verbose,
+                        LoggerLevel::Trace,
                         format!(
                             "Removed audit entry with client_source_port '{}' successfully",
                             client_source_port
@@ -172,7 +171,7 @@ impl TcpConnectionContext {
                     ),
                     Err(e) => {
                         logger.write(
-                            LoggerLevel::Warning,
+                            LoggerLevel::Warn,
                             format!("Failed to remove audit entry: {}", e),
                         );
                     }
@@ -185,7 +184,7 @@ impl TcpConnectionContext {
                     "Failed to find audit entry with client_source_port '{}' with error: {}",
                     client_source_port, e
                 );
-                logger.write(LoggerLevel::Warning, message.clone());
+                logger.write(LoggerLevel::Warn, message.clone());
 
                 #[cfg(not(windows))]
                 {
@@ -195,21 +194,21 @@ impl TcpConnectionContext {
                 #[cfg(windows)]
                 {
                     logger.write(
-                        LoggerLevel::Information,
+                        LoggerLevel::Info,
                         "Try to get audit entry from socket stream".to_string(),
                     );
 
                     match redirector::get_audit_from_stream_socket(raw_socket_id) {
                         Ok(data) => {
                             logger.write(
-                                LoggerLevel::Information,
+                                LoggerLevel::Info,
                                 "Found audit entry from socket stream successfully".to_string(),
                             );
                             Ok(data)
                         }
                         Err(e) => {
                             logger.write(
-                                LoggerLevel::Warning,
+                                LoggerLevel::Warn,
                                 format!("Failed to get lookup_audit_from_stream with error: {}", e),
                             );
                             Err(Error::FindAuditEntryError(message))
@@ -284,17 +283,6 @@ pub struct ConnectionLogger {
 }
 impl ConnectionLogger {
     pub const CONNECTION_LOGGER_KEY: &'static str = "Connection_Logger";
-    pub async fn init_logger(log_folder: PathBuf) {
-        logger_manager::init_logger(
-            Self::CONNECTION_LOGGER_KEY.to_string(),
-            log_folder,
-            "ProxyAgent.Connection.log".to_string(),
-            constants::MAX_LOG_FILE_SIZE,
-            constants::MAX_LOG_FILE_COUNT as u16,
-        )
-        .await;
-    }
-
     pub fn write(&self, logger_level: LoggerLevel, message: String) {
         logger_manager::log(
             Self::CONNECTION_LOGGER_KEY.to_string(),

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -32,6 +32,7 @@ use crate::common::logger;
 use crate::key_keeper::UNKNOWN_STATE;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::{
     GuestProxyAgentAggregateStatus, ModuleState, OverallState, ProxyAgentDetailStatus,
@@ -93,7 +94,7 @@ impl ProxyAgentStatusTask {
                     Err(e) => format!("Error serializing proxy agent status: {}", e),
                 };
                 event_logger::write_event(
-                    event_logger::INFO_LEVEL,
+                    LoggerLevel::Info,
                     status,
                     "loop_status",
                     "proxy_agent_status",

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -55,6 +55,7 @@ use crate::proxy::authorization_rules::AuthorizationMode;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::ModuleState;
 use proxy_agent_shared::telemetry::event_logger;
@@ -122,8 +123,8 @@ impl Redirector {
 
     pub async fn start(&self) {
         let level = match self.start_impl().await {
-            Ok(_) => event_logger::INFO_LEVEL,
-            Err(_) => event_logger::ERROR_LEVEL,
+            Ok(_) => LoggerLevel::Info,
+            Err(_) => LoggerLevel::Error,
         };
         event_logger::write_event(
             level,
@@ -280,7 +281,7 @@ impl Redirector {
             ));
         }
         event_logger::write_event(
-            event_logger::ERROR_LEVEL,
+            LoggerLevel::Error,
             message,
             "start",
             "redirector",

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -19,8 +19,8 @@ use aya::{Btf, Ebpf, EbpfLoader};
 use ebpf_obj::{
     destination_entry, sock_addr_audit_entry, sock_addr_audit_key, sock_addr_skip_process_entry,
 };
-use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
+use proxy_agent_shared::{logger::LoggerLevel, misc_helpers};
 use std::convert::TryFrom;
 use std::path::PathBuf;
 
@@ -291,7 +291,7 @@ impl BpfObject {
                         match policy_map.remove(&key.to_array()) {
                             Ok(_) => {
                                 event_logger::write_event(
-                                    event_logger::INFO_LEVEL,
+                                    LoggerLevel::Info,
                                     format!(
                                         "policy_map removed for destination: {}:{}",
                                         ip_to_string(dest_ipv4),
@@ -309,7 +309,7 @@ impl BpfObject {
                     } else {
                         let local_ip = constants::PROXY_AGENT_IP.to_string();
                         event_logger::write_event(
-                            event_logger::INFO_LEVEL,
+                            LoggerLevel::Info,
                             format!(
                                 "update_redirect_policy_internal with local ip address: {}, dest_ipv4: {}, dest_port: {}, local_port: {}",
                                 local_ip, ip_to_string(dest_ipv4), dest_port, local_port
@@ -322,7 +322,7 @@ impl BpfObject {
                         let value = destination_entry::from_ipv4(local_ip, local_port);
                         match policy_map.insert(key.to_array(), value.to_array(), 0) {
                             Ok(_) => event_logger::write_event(
-                                event_logger::INFO_LEVEL,
+                                LoggerLevel::Info,
                                 format!(
                                     "policy_map updated for destination: {}:{}",
                                     ip_to_string(dest_ipv4),
@@ -401,7 +401,7 @@ impl super::Redirector {
             }
             Err(e) => {
                 event_logger::write_event(
-                    event_logger::WARN_LEVEL,
+                    LoggerLevel::Warn,
                     format!("Failed to get the cgroup2 mount path {}, fallback to use the cgroup2 path from config file.", e),
                     "start",
                     "redirector/linux",
@@ -413,7 +413,7 @@ impl super::Redirector {
         if let Err(e) = bpf_object.attach_cgroup_program(cgroup2_path) {
             let message = format!("Failed to attach cgroup program for redirection. {}", e);
             event_logger::write_event(
-                event_logger::WARN_LEVEL,
+                LoggerLevel::Warn,
                 message.to_string(),
                 "start",
                 "redirector",
@@ -481,11 +481,9 @@ pub async fn update_hostga_redirect_policy(
 mod tests {
     use crate::common::config;
     use crate::common::constants;
-    use crate::common::logger;
     use crate::redirector::linux::ebpf_obj::sock_addr_audit_entry;
     use crate::redirector::linux::ebpf_obj::sock_addr_audit_key;
     use aya::maps::HashMap;
-    use proxy_agent_shared::logger::logger_manager;
     use proxy_agent_shared::misc_helpers;
     use std::env;
 

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -499,14 +499,6 @@ mod tests {
         let logger_key = "linux_ebpf_test";
         let mut temp_test_path = env::temp_dir();
         temp_test_path.push(logger_key);
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            temp_test_path.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
 
         let mut bpf_file_path = misc_helpers::get_current_exe_dir();
         bpf_file_path.push("config::get_ebpf_program_name()");

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -63,7 +63,7 @@ pub async fn start_service(shared_state: SharedState) {
     });
 }
 
-pub fn setup_loggers(log_folder: PathBuf, max_logger_level: LoggerLevel) {
+fn setup_loggers(log_folder: PathBuf, max_logger_level: LoggerLevel) {
     logger_manager::set_logger_level(max_logger_level);
 
     let agent_logger = RollingLogger::create_new(

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -5,12 +5,15 @@ pub mod windows;
 
 use crate::common::{config, constants, helpers, logger};
 use crate::key_keeper::KeyKeeper;
+use crate::proxy::proxy_connection::ConnectionLogger;
 use crate::proxy::proxy_server::ProxyServer;
 use crate::redirector;
 use crate::shared_state::SharedState;
-use proxy_agent_shared::logger::logger_manager;
+use proxy_agent_shared::logger::rolling_logger::RollingLogger;
+use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
 use proxy_agent_shared::telemetry::event_logger;
 
+use std::path::PathBuf;
 #[cfg(not(windows))]
 use std::time::Duration;
 
@@ -24,15 +27,7 @@ use std::time::Duration;
 /// service::start_service(shared_state).await;
 /// ```
 pub async fn start_service(shared_state: SharedState) {
-    logger_manager::set_logger_level(config::get_file_log_level()).await;
-    logger_manager::init_logger(
-        logger::AGENT_LOGGER_KEY.to_string(),
-        config::get_logs_dir(),
-        "ProxyAgent.log".to_string(),
-        constants::MAX_LOG_FILE_SIZE,
-        constants::MAX_LOG_FILE_COUNT as u16,
-    )
-    .await;
+    setup_loggers(config::get_logs_dir(), config::get_file_log_level());
 
     let start_message = format!(
         "============== GuestProxyAgent ({}) is starting on {}({}), elapsed: {}",
@@ -66,6 +61,30 @@ pub async fn start_service(shared_state: SharedState) {
             proxy_server.start().await;
         }
     });
+}
+
+pub fn setup_loggers(log_folder: PathBuf, max_logger_level: LoggerLevel) {
+    logger_manager::set_logger_level(max_logger_level);
+
+    let agent_logger = RollingLogger::create_new(
+        log_folder.clone(),
+        "ProxyAgent.log".to_string(),
+        constants::MAX_LOG_FILE_SIZE,
+        constants::MAX_LOG_FILE_COUNT as u16,
+    );
+    let connection_logger = RollingLogger::create_new(
+        log_folder.clone(),
+        "ProxyAgent.Connection.log".to_string(),
+        constants::MAX_LOG_FILE_SIZE,
+        constants::MAX_LOG_FILE_COUNT as u16,
+    );
+    let mut loggers = std::collections::HashMap::new();
+    loggers.insert(logger::AGENT_LOGGER_KEY.to_string(), agent_logger);
+    loggers.insert(
+        ConnectionLogger::CONNECTION_LOGGER_KEY.to_string(),
+        connection_logger,
+    );
+    logger_manager::set_loggers(loggers, logger::AGENT_LOGGER_KEY.to_string());
 }
 
 /// Start the service and wait until the service is stopped.
@@ -114,4 +133,32 @@ pub fn stop_service(shared_state: SharedState) {
     });
 
     event_logger::stop();
+}
+
+#[cfg(test)]
+mod tests {
+    use ctor::{ctor, dtor};
+    use proxy_agent_shared::logger::LoggerLevel;
+    use std::env;
+    use std::fs;
+
+    const TEST_LOGGER_KEY: &str = "proxy_agent_test";
+
+    fn get_temp_test_dir() -> std::path::PathBuf {
+        let mut temp_test_path = env::temp_dir();
+        temp_test_path.push(TEST_LOGGER_KEY);
+        temp_test_path
+    }
+
+    #[ctor]
+    fn setup() {
+        // Setup logger_manager for unit tests
+        super::setup_loggers(get_temp_test_dir(), LoggerLevel::Trace);
+    }
+
+    #[dtor]
+    fn cleanup() {
+        // clean up and ignore the clean up errors
+        _ = fs::remove_dir_all(&get_temp_test_dir());
+    }
 }

--- a/proxy_agent/src/shared_state/agent_status_wrapper.rs
+++ b/proxy_agent/src/shared_state/agent_status_wrapper.rs
@@ -58,6 +58,7 @@
 use crate::common::logger;
 use crate::common::result::Result;
 use crate::{common::error::Error, proxy::proxy_summary::ProxySummary};
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::proxy_agent_aggregate_status::{
     ModuleState, ProxyAgentDetailStatus, ProxyConnectionSummary,
 };
@@ -574,7 +575,7 @@ impl AgentStatusSharedState {
         };
         if message.len() > MAX_STATUS_MESSAGE_LENGTH {
             event_logger::write_event(
-                event_logger::WARN_LEVEL,
+                LoggerLevel::Warn,
                 format!(
                     "Status message is too long, truncating to {} characters. Message: {}",
                     MAX_STATUS_MESSAGE_LENGTH, message

--- a/proxy_agent/src/telemetry/event_reader.rs
+++ b/proxy_agent/src/telemetry/event_reader.rs
@@ -382,7 +382,7 @@ mod tests {
     use crate::common::logger;
     use crate::key_keeper::key::Key;
     use crate::test_mock::server_mock;
-    use proxy_agent_shared::{logger::logger_manager, misc_helpers};
+    use proxy_agent_shared::misc_helpers;
     use std::{env, fs};
 
     #[tokio::test]
@@ -391,20 +391,8 @@ mod tests {
         temp_dir.push("test_event_reader_thread");
 
         _ = fs::remove_dir_all(&temp_dir);
-
-        let mut log_dir = temp_dir.to_path_buf();
-        log_dir.push("Logs");
         let mut events_dir = temp_dir.to_path_buf();
         events_dir.push("Events");
-
-        logger_manager::init_logger(
-            logger::AGENT_LOGGER_KEY.to_string(), // production code uses 'Agent_Log' to write.
-            log_dir.clone(),
-            "logger_key".to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
 
         // start wire_server listener
         let ip = "127.0.0.1";

--- a/proxy_agent_extension/Cargo.toml
+++ b/proxy_agent_extension/Cargo.toml
@@ -13,6 +13,7 @@ proxy_agent_shared = { path ="../proxy_agent_shared"}
 clap = { version = "4.5.17", features =["derive"] } # Command Line Argument Parser
 thiserror = "1.0.64"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros", "sync"] }
+ctor = "0.3.6"                # used for test setup and clean up
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7.0"     # windows NT 

--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -221,27 +221,20 @@ pub fn report_status_enable_command(
     report_status(status_folder, config_seq_no, &handler_status);
 }
 
-pub async fn start_event_logger(logger_key: &str) {
+pub async fn start_event_logger() {
     logger::write("starting event logger".to_string());
     tokio::spawn({
-        let logger_key = logger_key.to_string();
         async move {
             let interval: std::time::Duration = std::time::Duration::from_secs(60);
             let max_event_file_count: usize = 50;
             let exe_path = misc_helpers::get_current_exe_dir();
             let event_folder =
                 PathBuf::from(get_handler_environment(&exe_path).eventsFolder.to_string());
-            telemetry::event_logger::start(
-                event_folder,
-                interval,
-                max_event_file_count,
-                &logger_key,
-                |_| {
-                    async {
-                        // do nothing
-                    }
-                },
-            )
+            telemetry::event_logger::start(event_folder, interval, max_event_file_count, |_| {
+                async {
+                    // do nothing
+                }
+            })
             .await;
         }
     });
@@ -443,8 +436,6 @@ mod tests {
 
         //Clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-        let log_folder: String = temp_test_path.to_str().unwrap().to_string();
-        super::logger::init_logger(log_folder, "log.txt").await;
         _ = misc_helpers::try_create_folder(&temp_test_path);
 
         // test invalid dir_path
@@ -492,8 +483,8 @@ mod tests {
         //Clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
         _ = misc_helpers::try_create_folder(&temp_test_path);
-
         let status_folder: PathBuf = temp_test_path.join("status");
+
         let config_seq_no = "0";
         let expected_status_file: &PathBuf = &temp_test_path.join("status").join("0.status");
 
@@ -514,8 +505,6 @@ mod tests {
 
         //Clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-        let log_folder: String = temp_test_path.to_str().unwrap().to_string();
-        super::logger::init_logger(log_folder, "log.txt").await;
         _ = misc_helpers::try_create_folder(&temp_test_path);
 
         let expected_heartbeat_file: PathBuf = temp_test_path.join("heartbeat.json");

--- a/proxy_agent_extension/src/handler_main.rs
+++ b/proxy_agent_extension/src/handler_main.rs
@@ -37,7 +37,7 @@ static HANDLER_ENVIRONMENT: Lazy<structs::HandlerEnvironment> = Lazy::new(|| {
 pub async fn program_start(command: ExtensionCommand, config_seq_no: String) {
     //Set up Logger instance
     let log_folder = HANDLER_ENVIRONMENT.logFolder.to_string();
-    logger::init_logger(log_folder, constants::HANDLER_LOG_FILE).await;
+    logger::init_logger(log_folder, constants::HANDLER_LOG_FILE);
 
     logger::write(format!(
         "GuestProxyAgentExtension Version: {}, OS Arch: {}, OS Version: {}",
@@ -405,22 +405,14 @@ async fn update_handler() {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
-    use std::fs::{self};
 
     #[cfg(windows)]
     use crate::handler_main;
     #[cfg(windows)]
     use proxy_agent_shared::version::Version;
 
-    #[tokio::test]
-    async fn test_check_os_supported() {
-        let mut temp_test_path = env::temp_dir();
-        temp_test_path.push("test_check_os_supported");
-
-        let log_folder: String = temp_test_path.to_str().unwrap().to_string();
-        super::logger::init_logger(log_folder, "log.txt").await;
-
+    #[test]
+    fn test_check_os_supported() {
         #[cfg(windows)]
         {
             let version = Version {
@@ -448,6 +440,5 @@ mod tests {
             };
             assert!(!handler_main::check_windows_os_version(version));
         }
-        _ = fs::remove_dir_all(&temp_test_path);
     }
 }

--- a/proxy_agent_extension/src/logger.rs
+++ b/proxy_agent_extension/src/logger.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
+use proxy_agent_shared::logger::{logger_manager, rolling_logger::RollingLogger, LoggerLevel};
 use std::path::PathBuf;
-
 static LOGGER_KEY: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
 pub fn get_logger_key() -> String {
     LOGGER_KEY
@@ -11,15 +10,16 @@ pub fn get_logger_key() -> String {
         .to_string()
 }
 
-pub async fn init_logger(log_folder: String, log_name: &str) {
-    logger_manager::init_logger(
-        log_name.to_string(),
+pub fn init_logger(log_folder: String, log_name: &str) {
+    let logger = RollingLogger::create_new(
         PathBuf::from(log_folder),
         log_name.to_string(),
         20 * 1024 * 1024,
         30,
-    )
-    .await;
+    );
+    let mut loggers = std::collections::HashMap::new();
+    loggers.insert(log_name.to_string(), logger);
+    logger_manager::set_loggers(loggers, log_name.to_string());
 
     if !LOGGER_KEY.initialized() {
         if let Err(e) = LOGGER_KEY.set(log_name.to_string()) {
@@ -29,5 +29,35 @@ pub async fn init_logger(log_folder: String, log_name: &str) {
 }
 
 pub fn write(message: String) {
-    logger_manager::log(get_logger_key(), LoggerLevel::Information, message);
+    logger_manager::write_log(LoggerLevel::Info, message);
+}
+
+#[cfg(test)]
+mod tests {
+    use ctor::{ctor, dtor};
+    use std::env;
+    use std::fs;
+
+    const TEST_LOGGER_KEY: &str = "proxy_agent_extension_test";
+
+    fn get_temp_test_dir() -> std::path::PathBuf {
+        let mut temp_test_path = env::temp_dir();
+        temp_test_path.push(TEST_LOGGER_KEY);
+        temp_test_path
+    }
+
+    #[ctor]
+    fn setup() {
+        // Setup logger_manager for unit tests
+        super::init_logger(
+            get_temp_test_dir().to_string_lossy().to_string(),
+            "test.log",
+        );
+    }
+
+    #[dtor]
+    fn cleanup() {
+        // clean up and ignore the clean up errors
+        _ = fs::remove_dir_all(&get_temp_test_dir());
+    }
 }

--- a/proxy_agent_extension/src/main.rs
+++ b/proxy_agent_extension/src/main.rs
@@ -81,8 +81,8 @@ async fn main() {
         let log_folder = common::get_handler_environment(&exe_path)
             .logFolder
             .to_string();
-        logger::init_logger(log_folder, constants::SERVICE_LOG_FILE).await;
-        common::start_event_logger(constants::SERVICE_LOG_FILE).await;
+        logger::init_logger(log_folder, constants::SERVICE_LOG_FILE);
+        common::start_event_logger().await;
         #[cfg(windows)]
         {
             if let Err(e) = service_dispatcher::start(constants::PLUGIN_NAME, ffi_service_main) {

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -740,16 +740,15 @@ mod tests {
     use proxy_agent_shared::misc_helpers;
     use proxy_agent_shared::proxy_agent_aggregate_status::*;
 
-    #[cfg(windows)]
-    use std::io::Write;
-    #[cfg(windows)]
-    use std::path::PathBuf;
-    #[cfg(windows)]
-    use std::process::Command;
-
     #[test]
     #[cfg(windows)]
     fn report_proxy_agent_service_status() {
+        use std::env;
+        use std::fs;
+        use std::io::Write;
+        use std::path::PathBuf;
+        use std::process::Command;
+
         // Create temp directory for status folder
         let mut temp_test_path = env::temp_dir();
         temp_test_path.push("test_status_file");

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -739,8 +739,6 @@ mod tests {
     use crate::structs::*;
     use proxy_agent_shared::misc_helpers;
     use proxy_agent_shared::proxy_agent_aggregate_status::*;
-    use std::env;
-    use std::fs;
 
     #[cfg(windows)]
     use std::io::Write;

--- a/proxy_agent_setup/src/logger.rs
+++ b/proxy_agent_setup/src/logger.rs
@@ -1,25 +1,24 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use proxy_agent_shared::{logger::logger_manager, logger::LoggerLevel, misc_helpers};
+use proxy_agent_shared::{
+    logger::{logger_manager, rolling_logger::RollingLogger, LoggerLevel},
+    misc_helpers,
+};
 use std::path::PathBuf;
 
 const LOGGER_KEY: &str = "setup.log";
-pub async fn init_logger() {
-    force_init_logger(misc_helpers::get_current_exe_dir(), LOGGER_KEY).await;
+pub fn init_logger() {
+    force_init_logger(misc_helpers::get_current_exe_dir(), LOGGER_KEY);
 }
 
-async fn force_init_logger(log_folder: PathBuf, log_name: &str) {
-    logger_manager::init_logger(
-        log_name.to_string(),
-        log_folder,
-        log_name.to_string(),
-        20 * 1024 * 1024,
-        30,
-    )
-    .await;
+fn force_init_logger(log_folder: PathBuf, log_name: &str) {
+    let logger = RollingLogger::create_new(log_folder, log_name.to_string(), 20 * 1024 * 1024, 30);
+    let mut loggers = std::collections::HashMap::new();
+    loggers.insert(log_name.to_string(), logger);
+    logger_manager::set_loggers(loggers, log_name.to_string());
 }
 
 pub fn write(message: String) {
     println!("{}", message);
-    logger_manager::log(LOGGER_KEY.to_string(), LoggerLevel::Information, message);
+    logger_manager::log(LOGGER_KEY.to_string(), LoggerLevel::Info, message);
 }

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -28,7 +28,7 @@ const SERVICE_NAME: &str = "azure-proxy-agent";
 
 #[tokio::main]
 async fn main() {
-    logger::init_logger().await;
+    logger::init_logger();
     let cli = args::Cli::parse();
     logger::write(format!(
         "\r\n\r\n============== ProxyAgent Setup Tool ({}) is starting with args: {} ==============",

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -16,6 +16,8 @@ serde_json = "1.0.91"         # json Deserializer
 regex = "1.9.5"               # match file name 
 thiserror = "1.0.64"
 tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
+log = { version = "0.4.26", features = ["std"] }
+ctor = "0.3.6"                # used for test setup and clean up
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7.0"     # windows NT service

--- a/proxy_agent_shared/src/logger.rs
+++ b/proxy_agent_shared/src/logger.rs
@@ -4,22 +4,28 @@
 pub mod logger_manager;
 pub mod rolling_logger;
 
-#[derive(PartialEq, PartialOrd, Debug)]
-pub enum LoggerLevel {
-    Verbose,
-    Information,
-    Warning,
-    Error,
-}
+pub type LoggerLevel = log::Level;
 
-impl LoggerLevel {
-    pub fn from_string(level: &str) -> Self {
-        match level {
-            "Verb" => LoggerLevel::Verbose,
-            "Info" => LoggerLevel::Information,
-            "Warn" => LoggerLevel::Warning,
-            "Err" => LoggerLevel::Error,
-            _ => LoggerLevel::Information,
-        }
+#[cfg(test)]
+mod tests {
+    use log::Level;
+    use std::str::FromStr;
+
+    #[test]
+    fn logger_level_test() {
+        let info_level = Level::Info;
+        assert_eq!(Level::from_str("Info").unwrap(), Level::Info);
+
+        let trace_level = Level::from_str("Trace").unwrap();
+        assert_eq!(trace_level, Level::Trace);
+        assert!(
+            info_level < trace_level,
+            "Info level should be lower than Trace level"
+        );
+
+        assert!(
+            Level::from_str("Trace").unwrap() >= trace_level,
+            "Trace level should be greater than or equal to Trace level"
+        );
     }
 }

--- a/proxy_agent_shared/src/logger/logger_manager.rs
+++ b/proxy_agent_shared/src/logger/logger_manager.rs
@@ -49,6 +49,14 @@ fn get_logger(logger_key: Option<String>) -> Option<&'static RollingLogger> {
 }
 
 pub fn log(logger_key: String, log_level: Level, message: String) {
+    let level = match MAX_LOG_LEVEL.get() {
+        Some(l) => *l, // No need to use `clone` on type `Level` which implements the `Copy` trait
+        None => Level::Trace,
+    };
+    if log_level > level {
+        return;
+    }
+
     if let Some(logger) = get_logger(Some(logger_key)) {
         if let Err(e) = logger.write(log_level, message) {
             eprintln!("Error writing to log: {}", e);
@@ -57,15 +65,15 @@ pub fn log(logger_key: String, log_level: Level, message: String) {
 }
 
 pub fn write_log(log_level: Level, message: String) {
-    if let Some(logger) = get_logger(None) {
-        let level = match MAX_LOG_LEVEL.get() {
-            Some(l) => *l, // No need to use `clone` on type `Level` which implements the `Copy` trait
-            None => Level::Trace,
-        };
-        if log_level > level {
-            return;
-        }
+    let level = match MAX_LOG_LEVEL.get() {
+        Some(l) => *l, // No need to use `clone` on type `Level` which implements the `Copy` trait
+        None => Level::Trace,
+    };
+    if log_level > level {
+        return;
+    }
 
+    if let Some(logger) = get_logger(None) {
         if let Err(e) = logger.write(log_level, message) {
             eprintln!("Error writing to log: {}", e);
         }

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -161,25 +161,6 @@ impl RollingLogger {
         Ok(())
     }
 }
-/*
-impl log::Log for RollingLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let log_header = Self::get_log_header(&format!("[{}]    ", record.level()));
-            let message = format!("{}{}", log_header, record.args());
-            if let Err(e) = self.write_line(message) {
-                eprintln!("Error writing to log: {}", e);
-            }
-        }
-    }
-
-    fn flush(&self) {}
-}
-*/
 
 #[cfg(test)]
 mod tests {

--- a/proxy_agent_shared/src/logger/rolling_logger.rs
+++ b/proxy_agent_shared/src/logger/rolling_logger.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 use crate::misc_helpers;
 use crate::result::Result;
+use log::Level;
 use std::fs::{self, File, OpenOptions};
 use std::io::{LineWriter, Write};
 use std::path::PathBuf;
 
-use super::LoggerLevel;
-
+#[derive(Debug)]
 pub struct RollingLogger {
     log_dir: PathBuf,
     log_file_name: String,
@@ -15,20 +15,6 @@ pub struct RollingLogger {
 
     max_log_file_size: u64,  // max log file size in KB
     max_log_file_count: u16, // max log file count, if exceed the count, the older log files will be removed.
-
-    initialized: bool,
-
-    //log_file: File,
-    log_writer: Option<LineWriter<File>>,
-}
-
-fn get_log_header(severity: &str) -> String {
-    format!(
-        "{} {} {}",
-        misc_helpers::get_thread_identity(),
-        misc_helpers::get_date_time_string_with_milliseconds(),
-        severity
-    )
 }
 
 impl RollingLogger {
@@ -42,32 +28,24 @@ impl RollingLogger {
         log_size: u64,
         log_count: u16,
     ) -> RollingLogger {
-        let mut logger = RollingLogger {
+        RollingLogger {
             log_dir: dir,
             log_file_name: file_name,
             log_file_extension: String::from("log"),
             max_log_file_size: log_size,
             max_log_file_count: log_count,
-            initialized: false,
-            log_writer: None, // will initialize later
-        };
-        if let Err(e) = logger.init() {
-            eprintln!("Failed to initialize logger: {:?}", e);
         }
-
-        logger
     }
 
-    fn init(&mut self) -> Result<()> {
-        if !self.initialized {
-            self.open_file()?;
-            self.initialized = true;
-        }
-
-        Ok(())
+    fn get_log_header(severity: &str) -> String {
+        format!(
+            "{} {}",
+            misc_helpers::get_date_time_string_with_milliseconds(),
+            severity
+        )
     }
 
-    fn open_file(&mut self) -> Result<()> {
+    fn open_file(&self) -> Result<LineWriter<File>> {
         misc_helpers::try_create_folder(&self.log_dir)?;
 
         let file_full_path = self.get_current_file_full_path(None);
@@ -77,59 +55,28 @@ impl RollingLogger {
             File::create(file_full_path)?
         };
 
-        self.log_writer = Some(LineWriter::new(f));
+        Ok(LineWriter::new(f))
+    }
+
+    pub fn write(&self, level: Level, message: String) -> Result<()> {
+        let log_header = Self::get_log_header(&format!("[{}]    ", level))[..34].to_string();
+        let message = format!("{}{}", log_header, message);
+        self.write_line(message)
+    }
+
+    fn write_line(&self, message: String) -> Result<()> {
+        self.roll_if_needed()?;
+
+        if let Ok(mut writer) = self.open_file() {
+            writer.write_all(message.as_bytes())?;
+            writer.write_all(b"\n")?;
+            writer.flush()?;
+        }
 
         Ok(())
     }
 
-    pub fn write(&mut self, logger_level: LoggerLevel, message: String) -> Result<()> {
-        match logger_level {
-            LoggerLevel::Verbose => self.write_verb(message),
-            LoggerLevel::Information => self.write_information(message),
-            LoggerLevel::Warning => self.write_warning(message),
-            LoggerLevel::Error => self.write_error(message),
-        }
-    }
-
-    pub fn write_verb(&mut self, message: String) -> Result<()> {
-        let header = get_log_header("[VERB]    ");
-        self.write_line(header + &message)
-    }
-
-    pub fn write_information(&mut self, message: String) -> Result<()> {
-        let header = get_log_header("[INFO]    ");
-        self.write_line(header + &message)
-    }
-
-    pub fn write_warning(&mut self, message: String) -> Result<()> {
-        let header = get_log_header("[WARN]    ");
-        self.write_line(header + &message)
-    }
-
-    pub fn write_error(&mut self, message: String) -> Result<()> {
-        let header = get_log_header("[ERROR]   ");
-        self.write_line(header + &message)
-    }
-
-    pub fn write_line(&mut self, message: String) -> Result<()> {
-        self.roll_if_needed()?;
-        if self.log_writer.is_none() {
-            self.open_file()?;
-        }
-
-        // below unwrap is safe because we have checked the log_writer is not None above
-        self.log_writer
-            .as_mut()
-            .unwrap()
-            .write_all(message.as_bytes())?;
-        self.log_writer
-            .as_mut()
-            .unwrap()
-            .write_all(b"\n")
-            .map_err(Into::into)
-    }
-
-    fn archive_file(&mut self) -> Result<()> {
+    fn archive_file(&self) -> Result<()> {
         let new_file_name = self.get_current_file_full_path(Some(format!(
             "{}-{}",
             misc_helpers::get_date_time_string_with_milliseconds(),
@@ -199,8 +146,8 @@ impl RollingLogger {
         full_path
     }
 
-    fn roll_if_needed(&mut self) -> Result<()> {
-        self.init()?;
+    fn roll_if_needed(&self) -> Result<()> {
+        self.open_file()?;
 
         let file = self.get_current_file_full_path(None);
         let file_length = file.metadata()?.len();
@@ -214,6 +161,25 @@ impl RollingLogger {
         Ok(())
     }
 }
+/*
+impl log::Log for RollingLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let log_header = Self::get_log_header(&format!("[{}]    ", record.level()));
+            let message = format!("{}{}", log_header, record.args());
+            if let Err(e) = self.write_line(message) {
+                eprintln!("Error writing to log: {}", e);
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+*/
 
 #[cfg(test)]
 mod tests {
@@ -226,11 +192,10 @@ mod tests {
         let mut temp_test_path = env::temp_dir();
         temp_test_path.push("logger_new_tests");
 
-        let mut logger =
+        let logger =
             RollingLogger::create_new(temp_test_path.clone(), String::from("proxyagent"), 1024, 10);
-
         logger
-            .write_verb(String::from("This is a test message"))
+            .write(log::Level::Info, String::from("This is a test message"))
             .unwrap();
 
         // clean up and ignore the clean up errors
@@ -245,13 +210,13 @@ mod tests {
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
 
-        let mut logger =
+        let logger =
             RollingLogger::create_new(temp_test_path.clone(), String::from("proxyagent"), 100, 6);
 
         // test without deleting old files
         for _ in [0; 10] {
             logger
-                .write_verb(String::from("This is a test message"))
+                .write(log::Level::Info, String::from("This is a test message"))
                 .unwrap();
         }
         let file_count = logger.get_log_files().unwrap();
@@ -260,7 +225,7 @@ mod tests {
         // test with deleting old files
         for _ in [0; 10] {
             logger
-                .write_verb(String::from("This is a test message"))
+                .write(log::Level::Trace, String::from("This is a test message"))
                 .unwrap();
         }
         let file_count = logger.get_log_files().unwrap();

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -308,29 +308,11 @@ pub fn set_default_failure_actions(service_name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::logger::logger_manager;
-    use std::env;
     use std::{path::PathBuf, process::Command};
 
     #[tokio::test]
     async fn test_install_service() {
         const TEST_SERVICE_NAME: &str = "test_nt_service";
-        let mut temp_test_path = env::temp_dir();
-        temp_test_path.push("test_install_service");
-
-        let log_folder: PathBuf = temp_test_path.to_path_buf();
-        let log_key: &str = "test_install_service";
-        let log_name: String = "test_install_service.log".to_string();
-        let log_size: u64 = 20 * 1024 * 1024;
-        let log_count: u16 = 30;
-        logger_manager::init_logger(
-            log_key.to_string(),
-            log_folder,
-            log_name,
-            log_size,
-            log_count,
-        )
-        .await;
 
         // Delete Service if it exists
         _ = super::stop_and_delete_service(TEST_SERVICE_NAME).await;
@@ -408,7 +390,7 @@ mod tests {
             .expect("Failed to execute command");
 
         let output_str = String::from_utf8_lossy(&output.stdout);
-        print!("SC query output: {}", output_str);
+        println!("SC query output: {}", output_str);
 
         // Check if the output contains the desired information indicating the service is running
         assert!(output_str.contains("The specified service does not exist as an installed service"));

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -1,20 +1,17 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-use crate::logger::{logger_manager, LoggerLevel};
+use crate::logger::logger_manager;
 use crate::misc_helpers;
 use crate::telemetry::Event;
 use concurrent_queue::ConcurrentQueue;
+use log::Level;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-pub const INFO_LEVEL: &str = "Informational";
-pub const WARN_LEVEL: &str = "Warning";
-pub const ERROR_LEVEL: &str = "Error";
-pub const CRITICAL_LEVEL: &str = "Critical";
 pub const MAX_MESSAGE_LENGTH: usize = 1024 * 4; // 4KB
 
 static EVENT_QUEUE: Lazy<ConcurrentQueue<Event>> =
@@ -25,7 +22,6 @@ pub async fn start<F, Fut>(
     event_dir: PathBuf,
     mut interval: Duration,
     max_event_file_count: usize,
-    logger_key: &str,
     set_status_fn: F,
 ) where
     F: Fn(String) -> Fut,
@@ -34,11 +30,7 @@ pub async fn start<F, Fut>(
     let message = "Telemetry event logger thread started.";
     set_status_fn(message.to_string());
 
-    logger_manager::log(
-        logger_key.to_string(),
-        LoggerLevel::Information,
-        message.to_string(),
-    );
+    logger_manager::write_log(Level::Info, message.to_string());
 
     if let Err(e) = misc_helpers::try_create_folder(&event_dir) {
         let message = format!("Failed to create event folder with error: {}", e);
@@ -53,11 +45,7 @@ pub async fn start<F, Fut>(
         if EVENT_QUEUE.is_closed() {
             let message = "Event queue already closed, stop processing events.";
             set_status_fn(message.to_string());
-            logger_manager::log(
-                logger_key.to_string(),
-                LoggerLevel::Information,
-                message.to_string(),
-            );
+            logger_manager::write_log(Level::Info, message.to_string());
             break;
         }
         tokio::time::sleep(interval).await;
@@ -66,11 +54,7 @@ pub async fn start<F, Fut>(
             let message = "Stop signal received, exiting the event logger thread.";
             set_status_fn(message.to_string());
 
-            logger_manager::log(
-                logger_key.to_string(),
-                LoggerLevel::Information,
-                message.to_string(),
-            );
+            logger_manager::write_log(Level::Info, message.to_string());
             EVENT_QUEUE.close();
         }
 
@@ -91,7 +75,7 @@ pub async fn start<F, Fut>(
         match misc_helpers::get_files(&event_dir) {
             Ok(files) => {
                 if files.len() >= max_event_file_count {
-                    logger_manager::log(logger_key.to_string(), LoggerLevel::Warning,format!(
+                    logger_manager::write_log( Level::Warn,format!(
                         "Event files exceed the max file count {}, drop and skip the write to disk.",
                         max_event_file_count
                     ));
@@ -99,9 +83,8 @@ pub async fn start<F, Fut>(
                 }
             }
             Err(e) => {
-                logger_manager::log(
-                    logger_key.to_string(),
-                    LoggerLevel::Warning,
+                logger_manager::write_log(
+                    Level::Warn,
                     format!("Failed to get event files with error: {}", e),
                 );
             }
@@ -112,9 +95,8 @@ pub async fn start<F, Fut>(
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
         match misc_helpers::json_write_to_file(&events, &file_path) {
             Ok(()) => {
-                logger_manager::log(
-                    logger_key.to_string(),
-                    LoggerLevel::Verbose,
+                logger_manager::write_log(
+                    Level::Trace,
                     format!(
                         "Write events to the file {} successfully",
                         file_path.display()
@@ -122,9 +104,8 @@ pub async fn start<F, Fut>(
                 );
             }
             Err(e) => {
-                logger_manager::log(
-                    logger_key.to_string(),
-                    LoggerLevel::Warning,
+                logger_manager::write_log(
+                    Level::Warn,
                     format!(
                         "Failed to write events to the file {} with error: {}",
                         file_path.display(),
@@ -141,7 +122,7 @@ pub fn stop() {
 }
 
 pub fn write_event(
-    level: &str,
+    level: Level,
     message: String,
     method_name: &str,
     module_name: &str,
@@ -161,18 +142,12 @@ pub fn write_event(
     )) {
         Ok(()) => {
             // wrap file log within event log
-            if level == INFO_LEVEL {
-                logger_manager::log(logger_key, LoggerLevel::Information, message);
-            } else if level == WARN_LEVEL {
-                logger_manager::log(logger_key, LoggerLevel::Warning, message);
-            } else {
-                logger_manager::log(logger_key, LoggerLevel::Error, message);
-            }
+            logger_manager::log(logger_key, level, message);
         }
         Err(e) => {
             logger_manager::log(
                 logger_key,
-                LoggerLevel::Warning,
+                Level::Warn,
                 format!("Failed to push event to the queue with error: {}", e),
             );
         }
@@ -181,7 +156,6 @@ pub fn write_event(
 
 #[cfg(test)]
 mod tests {
-    use crate::logger::logger_manager;
     use crate::misc_helpers;
     use std::env;
     use std::fs;
@@ -194,33 +168,16 @@ mod tests {
         temp_test_path.push(logger_key);
         // clean up and ignore the clean up errors
         _ = fs::remove_dir_all(&temp_test_path);
-
-        let mut log_dir = temp_test_path.to_path_buf();
-        log_dir.push("Logs");
         let mut events_dir: std::path::PathBuf = temp_test_path.to_path_buf();
         events_dir.push("Events");
-        logger_manager::init_logger(
-            logger_key.to_string(), // production code uses 'Agent_Log' to write.
-            log_dir.clone(),
-            logger_key.to_string(),
-            10 * 1024 * 1024,
-            20,
-        )
-        .await;
 
         let cloned_events_dir = events_dir.to_path_buf();
         tokio::spawn(async {
-            super::start(
-                cloned_events_dir,
-                Duration::from_millis(100),
-                3,
-                logger_key,
-                |_| {
-                    async {
-                        // do nothing
-                    }
-                },
-            )
+            super::start(cloned_events_dir, Duration::from_millis(100), 3, |_| {
+                async {
+                    // do nothing
+                }
+            })
             .await;
         });
 
@@ -266,7 +223,7 @@ mod tests {
     async fn write_events(logger_key: &str) {
         for _ in [0; 10] {
             super::write_event(
-                "Informational",
+                log::Level::Info,
                 "This is test event".to_string(),
                 "event_logger_test",
                 "event_logger_test",

--- a/proxy_agent_shared/src/telemetry/span.rs
+++ b/proxy_agent_shared/src/telemetry/span.rs
@@ -71,7 +71,7 @@ impl SimpleSpan {
         let elapsed_massage =
             ElapsedMessage::new(self.get_elapsed_time_in_millisec(), message.to_string());
         event_logger::write_event(
-            event_logger::INFO_LEVEL,
+            log::Level::Info,
             elapsed_massage.to_json_string(),
             method_name,
             module_name,


### PR DESCRIPTION
- Introduce `log` crate for logging level
- Introduce `ctor` crate to setup and clean up loggers once, no need to setup the logger for every unit tests
- Removed the mpsc/async mode file logging.
- Instead of Acl all ProxyAgent folders in windows, acl keys and executable folders
- Change file log level in config to `Trace` to log all logs for E2E tests.