### PR TITLE
UpdateTestCaseResults if execution timedout

### DIFF
--- a/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
+++ b/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
@@ -20,7 +20,7 @@ namespace GuestProxyAgentTest.Extensions
                 else if (testCase.Result == TestCaseResult.NotStarted)
                 {
                     testCase.Result = TestCaseResult.Aborted;
-                    junitTestResultBuilder.AddAbortedTestResult(testScenarioName, testCase.TestCaseName, "", "Test case not started.", "", 0);
+                    junitTestResultBuilder.AddAbortedTestResult(testScenarioName, testCase.TestCaseName, "Test case not started.");
                 }
             }
         }

--- a/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
+++ b/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using GuestProxyAgentTest.Models;
+using GuestProxyAgentTest.TestCases;
+using GuestProxyAgentTest.Utilities;
+
+namespace GuestProxyAgentTest.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        public static void UpdateTestCaseResults(this Exception ex, List<TestCaseBase> testCases, JunitTestResultBuilder junitTestResultBuilder, string testScenarioName)
+        {
+            foreach (var testCase in testCases)
+            {
+                if (testCase.Result == TestCaseResult.Running)
+                {
+                    testCase.Result = TestCaseResult.Failed;
+                    junitTestResultBuilder.AddFailureTestResult(testScenarioName, testCase.TestCaseName, "", "Test case timed out.", ex.Message, 0);
+                }
+                else if (testCase.Result == TestCaseResult.NotStarted)
+                {
+                    testCase.Result = TestCaseResult.Aborted;
+                    junitTestResultBuilder.AddAbortedTestResult(testScenarioName, testCase.TestCaseName, "", "Test case not started.", "", 0);
+                }
+            }
+        }
+    }
+}

--- a/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
+++ b/e2etest/GuestProxyAgentTest/Extensions/ExceptionExtensions.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using GuestProxyAgentTest.Models;
 using GuestProxyAgentTest.TestCases;
 using GuestProxyAgentTest.Utilities;
 

--- a/e2etest/GuestProxyAgentTest/Extensions/TaskExtensions.cs
+++ b/e2etest/GuestProxyAgentTest/Extensions/TaskExtensions.cs
@@ -5,14 +5,19 @@ namespace GuestProxyAgentTest.Extensions
 {
     public static class TaskExtensions
     {
-        public static async Task TimeoutAfter(this Task task, int timeoutMilliSeconds)
+        public static async Task TimeoutAfter(this Task task, int timeoutMilliSeconds, CancellationTokenSource cancellationTokenSource = null!)
         {
-            if(task == await Task.WhenAny(task, Task.Delay(timeoutMilliSeconds)))
+            if (task == await Task.WhenAny(task, Task.Delay(timeoutMilliSeconds)))
             {
                 await task;
             }
             else
             {
+                if (cancellationTokenSource != null)
+                {
+                    // Cancel the task
+                    cancellationTokenSource.Cancel();
+                }
                 throw new TimeoutException("task time out.");
             }
         }

--- a/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
+++ b/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
@@ -85,7 +85,7 @@ namespace GuestProxyAgentTest
 
             try
             {
-                await Task.WhenAll(taskList).TimeoutAfter(TestSetting.Instance.testTimeoutMilliseconds);
+                await Task.WhenAll(taskList).TimeoutAfter(TestSetting.Instance.testMapTimeoutMilliseconds);
             }
             catch (Exception ex)
             {

--- a/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
@@ -15,8 +15,7 @@ namespace GuestProxyAgentTest.Settings
         internal string vmImageVersion = "";
         internal string suffixName = new Random().Next(1000).ToString();
         internal string testScenarioClassName = "GuestProxyAgentTest.TestScenarios.BVTScenario";
-        internal int testScenarioTimeoutMilliseconds = 1000 * 60 * 20; // TODO: need update to 120 minutes before merge to official repo
-        
+        internal int testScenarioTimeoutMilliseconds = 1000 * 60 * 120;
 
         internal VMImageDetails VMImageDetails
         {

--- a/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
@@ -15,7 +15,7 @@ namespace GuestProxyAgentTest.Settings
         internal string vmImageVersion = "";
         internal string suffixName = new Random().Next(1000).ToString();
         internal string testScenarioClassName = "GuestProxyAgentTest.TestScenarios.BVTScenario";
-        internal int testScenarioTimeoutMilliseconds = 3000 * 60 * 60;
+        internal int testScenarioTimeoutMilliseconds = 1000 * 60 * 20; // TODO: need update to 120 minutes before merge to official repo
         
 
         internal VMImageDetails VMImageDetails

--- a/e2etest/GuestProxyAgentTest/Settings/TestSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestSetting.cs
@@ -35,7 +35,7 @@ namespace GuestProxyAgentTest.Settings
         internal string zipFilePath = null!;
         internal string sharedStorageAccountUrl = null!;
         internal string testResultFolder = null!;
-        internal int testTimeoutMilliseconds = 1000 * 60 * 120;
+        internal int testMapTimeoutMilliseconds = 1000 * 60 * 180;
         internal string windowsInVmWireServerAccessControlProfileReferenceId = null!;
         internal string windowsInVmIMDSAccessControlProfileReferenceId = null!;
         internal string linuxInVmWireServerAccessControlProfileReferenceId = null!;

--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -41,7 +41,7 @@ namespace GuestProxyAgentTest.TestCases
                     FromBlob = false,
                 };
 
-                var result = await vmr.GetVirtualMachineExtensions().CreateOrUpdateAsync(Azure.WaitUntil.Completed, EXTENSION_NAME, vmExtData);
+                var result = await vmr.GetVirtualMachineExtensions().CreateOrUpdateAsync(Azure.WaitUntil.Completed, EXTENSION_NAME, vmExtData, cancellationToken: context.CancellationToken);
                 var provisioningState = result.Value.Data.ProvisioningState;
                 if (result.HasValue && result.Value.Data != null && result.Value.Data.ProvisioningState == "Succeeded")
                 {
@@ -66,7 +66,7 @@ namespace GuestProxyAgentTest.TestCases
             var startTime = DateTime.UtcNow;
             while (true)
             {
-                var vmExtension = await vmr.GetVirtualMachineExtensionAsync(EXTENSION_NAME, expand: "instanceView");
+                var vmExtension = await vmr.GetVirtualMachineExtensionAsync(EXTENSION_NAME, expand: "instanceView", cancellationToken: context.CancellationToken);
                 var instanceView = vmExtension?.Value?.Data?.InstanceView;
                 if (instanceView?.Statuses?.Count > 0 && instanceView.Statuses[0].DisplayStatus == "Provisioning succeeded")
                 {

--- a/e2etest/GuestProxyAgentTest/TestCases/EnableProxyAgentCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/EnableProxyAgentCase.cs
@@ -47,7 +47,7 @@ namespace GuestProxyAgentTest.TestCases
                 };
             }
 
-            await vmr.UpdateAsync(Azure.WaitUntil.Completed, patch);
+            await vmr.UpdateAsync(Azure.WaitUntil.Completed, patch, cancellationToken: context.CancellationToken);
             var iv = await vmr.InstanceViewAsync();
             context.TestResultDetails = new TestCaseResultDetails
             {

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentCase.cs
@@ -22,6 +22,7 @@ namespace GuestProxyAgentTest.TestCases
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallOrUpdateProxyAgentMsi")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_GUEST_PROXY_AGENT_SCRIPT_NAME))
+                    , context.CancellationToken
                     , (builder) =>
                     {
                         var zipsas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_MSI_CONTAINER_NAME, TestSetting.Instance.zipFilePath, context.ScenarioSetting.TestScenarioStorageFolderPrefix);

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentExtensionCase.cs
@@ -22,6 +22,7 @@ namespace GuestProxyAgentTest.TestCases
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallGuestProxyAgentExtension")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_GUEST_PROXY_AGENT_EXTENSION_SCRIPT_NAME))
+                    , context.CancellationToken
                     , (builder) =>
                     {
                         var devExtensionSas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_MSI_CONTAINER_NAME, TestSetting.Instance.zipFilePath, context.ScenarioSetting.TestScenarioStorageFolderPrefix);

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentPackageCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentPackageCase.cs
@@ -21,6 +21,7 @@ namespace GuestProxyAgentTest.TestCases
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallOrUpdateProxyAgentPackage")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_LINUX_GUEST_PROXY_AGENT_PACKAGE_SCRIPT_NAME))
+                    , context.CancellationToken
                     , (builder) =>
                     {
                         var zipsas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_MSI_CONTAINER_NAME, TestSetting.Instance.zipFilePath, context.ScenarioSetting.TestScenarioStorageFolderPrefix);

--- a/e2etest/GuestProxyAgentTest/TestCases/RebootVMCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/RebootVMCase.cs
@@ -29,7 +29,7 @@ namespace GuestProxyAgentTest.TestCases
             var vmr = context.VirtualMachineResource;
             try
             {
-                await vmr.RestartAsync(Azure.WaitUntil.Completed);
+                await vmr.RestartAsync(Azure.WaitUntil.Completed, cancellationToken: context.CancellationToken);
                 var iv = await vmr.InstanceViewAsync();
                 context.TestResultDetails = new TestCaseResultDetails
                 {
@@ -50,7 +50,7 @@ namespace GuestProxyAgentTest.TestCases
             var startTime = DateTime.UtcNow;
             while (true)
             {
-                var instanceView = await vmr.InstanceViewAsync();
+                var instanceView = await vmr.InstanceViewAsync(cancellationToken: context.CancellationToken);
                 if (instanceView?.Value?.Statuses?.Count > 0 && (instanceView.Value.Statuses[0].DisplayStatus == "Provisioning succeeded"
                     || instanceView.Value.Statuses[0].DisplayStatus == "VM running"))
                 {

--- a/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
@@ -18,7 +18,7 @@ namespace GuestProxyAgentTest.TestCases
         Failed,
         Aborted,
     }
-    
+
     /// <summary>
     /// Base case for each TestCase
     /// </summary>
@@ -69,9 +69,10 @@ namespace GuestProxyAgentTest.TestCases
                 custJsonSas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_E2E_TEST_OUTPUT_CONTAINER_NAME, custJsonPath, "customOutputJson.json", testScenarioSetting.TestScenarioStorageFolderPrefix);
             }
             return await RunCommandRunner.ExecuteRunCommandOnVM(context.VirtualMachineResource, new RunCommandSettingBuilder()
-                    .TestScenarioSetting(testScenarioSetting)
-                    .RunCommandName(TestCaseName)
-                    .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, scriptFileName))
+                                                                                                    .TestScenarioSetting(testScenarioSetting)
+                                                                                                    .RunCommandName(TestCaseName)
+                                                                                                    .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, scriptFileName))
+                    , context.CancellationToken
                     , (builder) => builder
                         .CustomOutputSas(custJsonSas)
                         .AddParameters(parameterList));

--- a/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
@@ -10,6 +10,15 @@ using System.Text;
 
 namespace GuestProxyAgentTest.TestCases
 {
+    public enum TestCaseResult
+    {
+        NotStarted,
+        Running,
+        Succeed,
+        Failed,
+        Aborted,
+    }
+    
     /// <summary>
     /// Base case for each TestCase
     /// </summary>
@@ -22,6 +31,8 @@ namespace GuestProxyAgentTest.TestCases
         {
             get; private set;
         } = null!;
+
+        public TestCaseResult Result { get; set; } = TestCaseResult.NotStarted;
 
         public TestCaseBase(string testCaseName)
         {

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -191,7 +191,7 @@ namespace GuestProxyAgentTest.TestScenarios
             }
 
             testScenarioStatusDetails.Status = ScenarioTestStatus.Completed;
-            ConsoleLog("Test case run finished.");
+            ConsoleLog("Test scenario run finished.");
         }
 
         private async Task ScenarioTestAsync(VirtualMachineResource vmr, TestScenarioStatusDetails testScenarioStatusDetails, CancellationToken cancellationToken)

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -103,6 +103,10 @@ namespace GuestProxyAgentTest.TestScenarios
             catch (Exception ex)
             {
                 ConsoleLog($"Test Scenario {_testScenarioSetting.testScenarioName} Exception: {ex.Message}.");
+
+                // set running test cases to failed
+                // set not started test cases to aborted
+                ex.UpdateTestCaseResults(_testCases, _junitTestResultBuilder, _testScenarioSetting.testScenarioName);
             }
             finally
             {
@@ -213,6 +217,7 @@ namespace GuestProxyAgentTest.TestScenarios
 
                 try
                 {
+                    testCase.Result = TestCaseResult.Running;
                     await testCase.StartAsync(context);
                     sw.Stop();
                     context.TestResultDetails
@@ -239,6 +244,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 }
                 finally
                 {
+                    testCase.Result = context.TestResultDetails.Succeed ? TestCaseResult.Succeed : TestCaseResult.Failed;
                     ConsoleLog($"Scenario case {testCase.TestCaseName} finished with result: {(context.TestResultDetails.Succeed ? "Succeed" : "Failed")} and duration: " + sw.ElapsedMilliseconds + "ms");
                     SaveResultFile(context.TestResultDetails.CustomOut, $"TestCases/{testCase.TestCaseName}", "customOut.txt", context.TestResultDetails.FromBlob);
                     SaveResultFile(context.TestResultDetails.StdErr, $"TestCases/{testCase.TestCaseName}", "stdErr.txt", context.TestResultDetails.FromBlob);

--- a/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
@@ -70,7 +70,6 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
-                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -119,7 +118,6 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
-                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -174,7 +172,6 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
-                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -182,13 +179,13 @@ namespace GuestProxyAgentTest.Utilities
                 doc = testSuiteMap[testScenarioName].Item1;
                 var testSuite = testSuiteMap[testScenarioName].Item2;
                 testSuite.SetAttribute("tests", StringAdd(testSuite.GetAttribute("tests"), 1));
-                testSuite.SetAttribute("aborted", StringAdd(testSuite.GetAttribute("aborted"), 1));
+                testSuite.SetAttribute("skipped", StringAdd(testSuite.GetAttribute("skipped"), 1));
                 XmlElement abortedTestCaseElement = doc.CreateElement("testcase");
                 abortedTestCaseElement.SetAttribute("name", testName);
                 abortedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
                 abortedTestCaseElement.SetAttribute("time", "0");
                 testSuite.AppendChild(abortedTestCaseElement);
-                XmlElement abortedElement = doc.CreateElement("aborted");
+                XmlElement abortedElement = doc.CreateElement("skipped");
                 abortedElement.SetAttribute("message", "Test case aborted.");
                 abortedElement.InnerText = message;
                 abortedTestCaseElement.AppendChild(abortedElement);

--- a/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
@@ -26,7 +26,6 @@ namespace GuestProxyAgentTest.Utilities
             this.testResultFolder = testResultFolder;
         }
 
-        
         /// <summary>
         /// Add success test result, it will merge stdoutput with customoutput.
         /// </summary>
@@ -123,7 +122,7 @@ namespace GuestProxyAgentTest.Utilities
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
                 }
-                doc = testSuiteMap[testScenarioName].Item1; 
+                doc = testSuiteMap[testScenarioName].Item1;
                 var testSuite = testSuiteMap[testScenarioName].Item2;
                 testSuite.SetAttribute("tests", StringAdd(testSuite.GetAttribute("tests"), 1));
                 testSuite.SetAttribute("failures", StringAdd(testSuite.GetAttribute("failures"), 1));
@@ -131,7 +130,7 @@ namespace GuestProxyAgentTest.Utilities
                 XmlElement failedTestCaseElement = doc.CreateElement("testcase");
                 failedTestCaseElement.SetAttribute("name", testName);
                 failedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
-                failedTestCaseElement.SetAttribute("time", ((double)durationInMilliseconds/1000).ToString());
+                failedTestCaseElement.SetAttribute("time", ((double)durationInMilliseconds / 1000).ToString());
                 testSuite.AppendChild(failedTestCaseElement);
 
                 XmlElement systemOutElement = doc.CreateElement("system-out");
@@ -157,8 +156,7 @@ namespace GuestProxyAgentTest.Utilities
             return this;
         }
 
-
-        public JunitTestResultBuilder AddAbortedTestResult(string testScenarioName, string testName, string stdOutMessage, string stdErrMessage, string customOutput, long durationInMilliseconds = 0)
+        public JunitTestResultBuilder AddAbortedTestResult(string testScenarioName, string testName, string message)
         {
             lock (this)
             {
@@ -181,23 +179,16 @@ namespace GuestProxyAgentTest.Utilities
                 doc = testSuiteMap[testScenarioName].Item1;
                 var testSuite = testSuiteMap[testScenarioName].Item2;
                 testSuite.SetAttribute("tests", StringAdd(testSuite.GetAttribute("tests"), 1));
-                testSuite.SetAttribute("failures", StringAdd(testSuite.GetAttribute("failures"), 1));
-                XmlElement failedTestCaseElement = doc.CreateElement("testcase");
-                failedTestCaseElement.SetAttribute("name", testName);
-                failedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
-                failedTestCaseElement.SetAttribute("time", ((double)durationInMilliseconds / 1000).ToString());
-                testSuite.AppendChild(failedTestCaseElement);
-                XmlElement systemOutElement = doc.CreateElement("system-out");
-                systemOutElement.InnerText = stdOutMessage;
-                failedTestCaseElement.AppendChild(systemOutElement);
-                XmlElement systemErrElement = doc.CreateElement("system-err");
-                systemErrElement.InnerText = stdErrMessage;
-                failedTestCaseElement.AppendChild(systemErrElement);
-                XmlElement failureElement = doc.CreateElement("failure");
-                failureElement.SetAttribute("message", "Test case aborted.");
-                failureElement.SetAttribute("type", "Aborted");
-                failureElement.InnerText = stdErrMessage;
-                failedTestCaseElement.AppendChild(failureElement);
+                testSuite.SetAttribute("skipped", StringAdd(testSuite.GetAttribute("skipped"), 1));
+                XmlElement skippedTestCaseElement = doc.CreateElement("testcase");
+                skippedTestCaseElement.SetAttribute("name", testName);
+                skippedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
+                skippedTestCaseElement.SetAttribute("time", "0");
+                testSuite.AppendChild(skippedTestCaseElement);
+                XmlElement skippedElement = doc.CreateElement("skipped");
+                skippedElement.SetAttribute("message", "Test case aborted.");
+                skippedElement.InnerText = message;
+                skippedTestCaseElement.AppendChild(skippedElement);
             }
             return this;
         }
@@ -209,7 +200,7 @@ namespace GuestProxyAgentTest.Utilities
         public List<string> Build()
         {
             List<string> result = new List<string>();
-            foreach(KeyValuePair<string, (XmlDocument, XmlElement)> kv in testSuiteMap)
+            foreach (KeyValuePair<string, (XmlDocument, XmlElement)> kv in testSuiteMap)
             {
                 var doc = kv.Value.Item1;
                 var resultPath = Path.Combine(this.testResultGroupFolder, kv.Key + "-TestResults.xml");

--- a/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/JUnitTestResultBuilder.cs
@@ -70,6 +70,7 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
+                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -118,6 +119,7 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
+                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -172,6 +174,7 @@ namespace GuestProxyAgentTest.Utilities
                     testSuiteElement.SetAttribute("errors", "0");
                     testSuiteElement.SetAttribute("failures", "0");
                     testSuiteElement.SetAttribute("skipped", "0");
+                    testSuiteElement.SetAttribute("aborted", "0");
                     testSuiteElement.SetAttribute("timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss"));
                     testsuites.AppendChild(testSuiteElement);
                     testSuiteMap[testScenarioName] = (doc, testSuiteElement);
@@ -179,16 +182,16 @@ namespace GuestProxyAgentTest.Utilities
                 doc = testSuiteMap[testScenarioName].Item1;
                 var testSuite = testSuiteMap[testScenarioName].Item2;
                 testSuite.SetAttribute("tests", StringAdd(testSuite.GetAttribute("tests"), 1));
-                testSuite.SetAttribute("skipped", StringAdd(testSuite.GetAttribute("skipped"), 1));
-                XmlElement skippedTestCaseElement = doc.CreateElement("testcase");
-                skippedTestCaseElement.SetAttribute("name", testName);
-                skippedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
-                skippedTestCaseElement.SetAttribute("time", "0");
-                testSuite.AppendChild(skippedTestCaseElement);
-                XmlElement skippedElement = doc.CreateElement("skipped");
-                skippedElement.SetAttribute("message", "Test case aborted.");
-                skippedElement.InnerText = message;
-                skippedTestCaseElement.AppendChild(skippedElement);
+                testSuite.SetAttribute("aborted", StringAdd(testSuite.GetAttribute("aborted"), 1));
+                XmlElement abortedTestCaseElement = doc.CreateElement("testcase");
+                abortedTestCaseElement.SetAttribute("name", testName);
+                abortedTestCaseElement.SetAttribute("classname", testGroupName + "." + testScenarioName);
+                abortedTestCaseElement.SetAttribute("time", "0");
+                testSuite.AppendChild(abortedTestCaseElement);
+                XmlElement abortedElement = doc.CreateElement("aborted");
+                abortedElement.SetAttribute("message", "Test case aborted.");
+                abortedElement.InnerText = message;
+                abortedTestCaseElement.AppendChild(abortedElement);
             }
             return this;
         }

--- a/e2etest/GuestProxyAgentTest/Utilities/RunCommandRunner.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/RunCommandRunner.cs
@@ -18,24 +18,25 @@ namespace GuestProxyAgentTest.Utilities
         /// </summary>
         /// <param name="vmr">virtual machine resource, used to specify the azure virtual machine instance</param>
         /// <param name="runCommandSettingBuilder">builder for run command setting</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <param name="runCommandParameterSetter">parameter setter for the run command script</param>
         /// <returns></returns>
         public static async Task<RunCommandOutputDetails> ExecuteRunCommandOnVM(VirtualMachineResource vmr
             , RunCommandSettingBuilder runCommandSettingBuilder
+            , CancellationToken cancellationToken
             , Func<RunCommandSettingBuilder, RunCommandSettingBuilder> runCommandParameterSetter = null!)
         {
             var vmrcs = vmr.GetVirtualMachineRunCommands();
             Console.WriteLine("Creating runcommand on vm.");
 
-            if(null != runCommandParameterSetter)
+            if (null != runCommandParameterSetter)
             {
                 runCommandSettingBuilder = runCommandParameterSetter(runCommandSettingBuilder);
             }
 
             var runCommandSetting = runCommandSettingBuilder.Build();
 
-            await vmrcs.CreateOrUpdateAsync(WaitUntil.Completed, runCommandSetting.runCommandName, toVMRunCommandData(runCommandSetting));
-            
+            await vmrcs.CreateOrUpdateAsync(WaitUntil.Completed, runCommandSetting.runCommandName, toVMRunCommandData(runCommandSetting), cancellationToken: cancellationToken);
             var iv = vmrcs.Get(runCommandSetting.runCommandName, "InstanceView").Value.Data.InstanceView;
             return new RunCommandOutputDetails
             {
@@ -59,13 +60,11 @@ namespace GuestProxyAgentTest.Utilities
                 OutputBlobUri = new Uri(runCommandSetting.outputBlobSAS),
                 ErrorBlobUri = new Uri(runCommandSetting.errorBlobSAS),
             };
-            foreach(var x in runCommandSetting.runCommandParameters.Select(kv => new RunCommandInputParameter(kv.Key, kv.Value)))
+            foreach (var x in runCommandSetting.runCommandParameters.Select(kv => new RunCommandInputParameter(kv.Key, kv.Value)))
             {
                 res.Parameters.Add(x);
             }
             return res;
         }
     }
-
-    
 };

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -49,7 +49,7 @@ namespace GuestProxyAgentTest.Utilities
         /// Build Build and return the VirtualMachine based on the setting
         /// </summary>
         /// <returns></returns>
-        public async Task<VirtualMachineResource> Build(bool enableProxyAgent)
+        public async Task<VirtualMachineResource> Build(bool enableProxyAgent, CancellationToken cancellationToken)
         {
             PreCheck();
             ArmClient client = new(new GuestProxyAgentE2ETokenCredential(), defaultSubscriptionId: TestSetting.Instance.subscriptionId);
@@ -68,7 +68,7 @@ namespace GuestProxyAgentTest.Utilities
 
             VirtualMachineCollection vmCollection = rgr.GetVirtualMachines();
             Console.WriteLine("Creating virtual machine...");
-            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName, await DoCreateVMData(rgr, enableProxyAgent))).Value;
+            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName, await DoCreateVMData(rgr, enableProxyAgent), cancellationToken: cancellationToken)).Value;
             Console.WriteLine("Virtual machine created, with id: " + vmr.Id);
             return vmr;
         }

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -37,7 +37,7 @@ namespace GuestProxyAgentTest.Utilities
         {
             this.testScenarioSetting = testScenarioSetting;
             this.rgName = this.testScenarioSetting.ResourceGroupName;
-            var prefix = "e2e" + testScenarioSetting.suffixName;
+            var prefix = "e2e" + new Random().Next(1000);
             this.vmName = prefix + "vm";
             this.vNetName = prefix + "vNet";
             this.netInfName = prefix + "nInf";

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -37,7 +37,7 @@ namespace GuestProxyAgentTest.Utilities
         {
             this.testScenarioSetting = testScenarioSetting;
             this.rgName = this.testScenarioSetting.ResourceGroupName;
-            var prefix = "e2e" + new Random().Next(1000);
+            var prefix = "e2e" + testScenarioSetting.suffixName;
             this.vmName = prefix + "vm";
             this.vNetName = prefix + "vNet";
             this.netInfName = prefix + "nInf";


### PR DESCRIPTION
- Create and pass cancellationToken for test scenario and its test case execution
- Cancel timedout test case and mark as Failed
- Mark not started test case as Skipped
- Adjust testScenarioTimeout and testMapTmeout values
- Capture VMBuilder result into CreateVM test result
- Move CollectGuestLogs out of test scenario execution.