### PR TITLE
Move redirector async task from key_keeper to service

### DIFF
--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -87,6 +87,7 @@ use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::telemetry_wrapper::TelemetrySharedState;
 use crate::telemetry::event_reader::EventReader;
+use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
 use std::path::PathBuf;
@@ -429,6 +430,15 @@ async fn write_provision_state(
     if !failed_state_message.is_empty() {
         // escape xml characters to allow the message to able be composed into xml payload
         failed_state_message = helpers::xml_escape(failed_state_message);
+
+        // write provision failed error message to event
+        event_logger::write_event(
+            LoggerLevel::Error,
+            failed_state_message.to_string(),
+            "write_provision_state",
+            "provision",
+            logger::AGENT_LOGGER_KEY,
+        );
     }
 
     let status_file: PathBuf = provision_dir.join(STATUS_TAG_TMP_FILE_NAME);

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -51,10 +51,14 @@ use crate::common::error::Error;
 use crate::common::helpers;
 use crate::common::result::Result;
 use crate::common::{config, logger};
+use crate::provision;
 use crate::proxy::authorization_rules::AuthorizationMode;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
+use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
+use crate::shared_state::telemetry_wrapper::TelemetrySharedState;
+use crate::shared_state::SharedState;
 use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::proxy_agent_aggregate_status::ModuleState;
@@ -63,6 +67,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(not(windows))]
 pub use linux::BpfObject;
@@ -104,24 +109,37 @@ pub struct Redirector {
     redirector_shared_state: RedirectorSharedState,
     key_keeper_shared_state: KeyKeeperSharedState,
     agent_status_shared_state: AgentStatusSharedState,
+    cancellation_token: CancellationToken,
+    telemetry_shared_state: TelemetrySharedState,
+    provision_shared_state: ProvisionSharedState,
 }
 
 impl Redirector {
-    pub fn new(
-        local_port: u16,
-        redirector_shared_state: RedirectorSharedState,
-        key_keeper_shared_state: KeyKeeperSharedState,
-        agent_status_shared_state: AgentStatusSharedState,
-    ) -> Self {
+    pub fn new(local_port: u16, shared_state: &SharedState) -> Self {
         Redirector {
             local_port,
-            redirector_shared_state,
-            key_keeper_shared_state,
-            agent_status_shared_state,
+            cancellation_token: shared_state.get_cancellation_token(),
+            key_keeper_shared_state: shared_state.get_key_keeper_shared_state(),
+            telemetry_shared_state: shared_state.get_telemetry_shared_state(),
+            provision_shared_state: shared_state.get_provision_shared_state(),
+            agent_status_shared_state: shared_state.get_agent_status_shared_state(),
+            redirector_shared_state: shared_state.get_redirector_shared_state(),
         }
     }
 
     pub async fn start(&self) {
+        let message = "eBPF redirector is starting";
+        if let Err(e) = self
+            .agent_status_shared_state
+            .set_module_status_message(message.to_string(), AgentStatusModule::Redirector)
+            .await
+        {
+            logger::write_error(format!(
+                "Failed to set error status '{}' for redirector: {}",
+                message, e
+            ));
+        }
+
         let level = match self.start_impl().await {
             Ok(_) => LoggerLevel::Info,
             Err(_) => LoggerLevel::Error,
@@ -251,6 +269,16 @@ impl Redirector {
             logger::write_error(format!("Failed to set module state in shared state: {e}"));
         }
 
+        // report redirector ready for provision
+        provision::redirector_ready(
+            self.cancellation_token.clone(),
+            self.key_keeper_shared_state.clone(),
+            self.telemetry_shared_state.clone(),
+            self.provision_shared_state.clone(),
+            self.agent_status_shared_state.clone(),
+        )
+        .await;
+
         Ok(())
     }
 
@@ -259,14 +287,6 @@ impl Redirector {
             .get_module_status(AgentStatusModule::Redirector)
             .await
             .message
-    }
-
-    pub async fn is_started(&self) -> bool {
-        self.agent_status_shared_state
-            .get_module_status(AgentStatusModule::Redirector)
-            .await
-            .status
-            == ModuleState::RUNNING
     }
 
     async fn set_error_status(&self, message: String) {

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -7,7 +7,7 @@ use crate::common::{config, constants, helpers, logger};
 use crate::key_keeper::KeyKeeper;
 use crate::proxy::proxy_connection::ConnectionLogger;
 use crate::proxy::proxy_server::ProxyServer;
-use crate::redirector;
+use crate::redirector::{self, Redirector};
 use crate::shared_state::SharedState;
 use proxy_agent_shared::logger::rolling_logger::RollingLogger;
 use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
@@ -52,6 +52,13 @@ pub async fn start_service(shared_state: SharedState) {
         );
         async move {
             key_keeper.poll_secure_channel_status().await;
+        }
+    });
+
+    tokio::spawn({
+        let redirector: Redirector = Redirector::new(constants::PROXY_AGENT_PORT, &shared_state);
+        async move {
+            redirector.start().await;
         }
     });
 


### PR DESCRIPTION
In provisioning the eBPF status show as 'Unknown', it does not have any error log either, hence I suspect the nested async task may not be launched for whatever reason.
Move the redirector async task from key_keeper to service to ensure the async task is launched and the eBPF status is correctly provisioned
Add event log for provisioning failed error message.