### PR TITLE
log libbpf error if load_bpf_object failed.

### DIFF
--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -12,7 +12,7 @@ use crate::common::{
 use libloading::{Library, Symbol};
 use proxy_agent_shared::{logger::LoggerLevel, misc_helpers, telemetry::event_logger};
 use std::env;
-use std::ffi::{c_char, c_int, c_longlong, c_uint, c_void, CString};
+use std::ffi::{c_char, c_int, c_long, c_uint, c_void, CString};
 use std::path::PathBuf;
 
 static EBPF_API: tokio::sync::OnceCell<Library> = tokio::sync::OnceCell::const_new();
@@ -152,13 +152,13 @@ type BpfMapLookupElem =
 
 type BpfMapDeleteElem = unsafe extern "C" fn(map_fd: c_int, key: *const c_void) -> c_int;
 
-type LibBpfGetError = unsafe extern "C" fn(no_use_ptr: *const c_void) -> c_longlong;
+type LibBpfGetError = unsafe extern "C" fn(no_use_ptr: *const c_void) -> c_long;
 
 fn get_cstring(s: &str) -> Result<CString> {
     CString::new(s).map_err(|e| Error::Bpf(BpfErrorType::CString(e)))
 }
 
-pub fn libbpf_get_error() -> Result<c_longlong> {
+pub fn libbpf_get_error() -> Result<c_long> {
     let ebpf_api = get_ebpf_api()?;
     let libbpf_get_error: Symbol<LibBpfGetError> =
         get_ebpf_api_fun(ebpf_api, "libbpf_get_error\0")?;

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -12,7 +12,7 @@ use crate::common::{
 use libloading::{Library, Symbol};
 use proxy_agent_shared::{logger::LoggerLevel, misc_helpers, telemetry::event_logger};
 use std::env;
-use std::ffi::{c_char, c_int, c_uint, c_void, CString};
+use std::ffi::{c_char, c_int, c_longlong, c_uint, c_void, CString};
 use std::path::PathBuf;
 
 static EBPF_API: tokio::sync::OnceCell<Library> = tokio::sync::OnceCell::const_new();
@@ -152,8 +152,17 @@ type BpfMapLookupElem =
 
 type BpfMapDeleteElem = unsafe extern "C" fn(map_fd: c_int, key: *const c_void) -> c_int;
 
+type LibBpfGetError = unsafe extern "C" fn(no_use_ptr: *const c_void) -> c_longlong;
+
 fn get_cstring(s: &str) -> Result<CString> {
     CString::new(s).map_err(|e| Error::Bpf(BpfErrorType::CString(e)))
+}
+
+pub fn libbpf_get_error() -> Result<c_longlong> {
+    let ebpf_api = get_ebpf_api()?;
+    let libbpf_get_error: Symbol<LibBpfGetError> =
+        get_ebpf_api_fun(ebpf_api, "libbpf_get_error\0")?;
+    Ok(unsafe { libbpf_get_error(std::ptr::null()) })
 }
 
 pub fn bpf_object__open(path: &str) -> Result<*mut bpf_object> {

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -81,6 +81,11 @@ impl BpfObject {
 
         if result == 0 {
             self.0 = obj;
+        } else {
+            return Err(Error::Bpf(BpfErrorType::LoadBpfObject(
+                bpf_file_path.display().to_string(),
+                format!("bpf_object__load return with error code '{}'", result),
+            )));
         }
 
         Ok(())

--- a/proxy_agent/src/redirector/windows/bpf_prog.rs
+++ b/proxy_agent/src/redirector/windows/bpf_prog.rs
@@ -57,11 +57,13 @@ impl BpfObject {
         };
 
         if obj.is_null() {
-            // logger::write_error("bpf_object__open return null".to_string());
-            // return EBPF_OBJECT_NULL;
+            let error_code = libbpf_get_error()?;
             return Err(Error::Bpf(BpfErrorType::OpenBpfObject(
                 bpf_file_path.display().to_string(),
-                "bpf_object__open return null".to_string(),
+                format!(
+                    "bpf_object__open return null pointer with error code '{}'",
+                    error_code
+                ),
             )));
         }
 


### PR DESCRIPTION
1. invoke libbpf_get_error if bpf_object__open failed.
2. return error if bpf_object__load failed.