### PR TITLE
Not write GPA file log if logFolder is empty in json config file

### DIFF
--- a/proxy_agent/config/GuestProxyAgent.linux.json
+++ b/proxy_agent/config/GuestProxyAgent.linux.json
@@ -1,5 +1,5 @@
 {
-    "logFolder": "/var/log/azure-proxy-agent",
+    "logFolder": "",
     "eventFolder": "/var/log/azure-proxy-agent/events",
     "latchKeyFolder": "/var/lib/azure-proxy-agent/keys",
     "monitorIntervalInSeconds": 60,

--- a/proxy_agent/config/GuestProxyAgent.linux.json
+++ b/proxy_agent/config/GuestProxyAgent.linux.json
@@ -1,5 +1,5 @@
 {
-    "logFolder": "",
+    "logFolder": "/var/log/azure-proxy-agent",
     "eventFolder": "/var/log/azure-proxy-agent/events",
     "latchKeyFolder": "/var/lib/azure-proxy-agent/keys",
     "monitorIntervalInSeconds": 60,

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -88,8 +88,8 @@ use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::telemetry_wrapper::TelemetrySharedState;
 use crate::telemetry::event_reader::EventReader;
 use proxy_agent_shared::logger::LoggerLevel;
-use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
+use proxy_agent_shared::{misc_helpers, proxy_agent_aggregate_status};
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -378,7 +378,7 @@ pub async fn start_event_threads(
     tokio::spawn({
         let agent_status_task = proxy_agent_status::ProxyAgentStatusTask::new(
             Duration::from_secs(60),
-            config::get_logs_dir(),
+            PathBuf::from(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FOLDER),
             cancellation_token.clone(),
             key_keeper_shared_state.clone(),
             agent_status_shared_state.clone(),

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -117,15 +117,12 @@ impl ProxyAgentStatusTask {
         let status_report_duration = Duration::from_secs(60 * 15);
         let mut status_report_time = Instant::now();
 
-        match misc_helpers::try_create_folder(&self.status_dir) {
-            Ok(_) => {}
-            Err(e) => {
-                logger::write_error(format!(
-                    "Error creating status directory: {} with error {}",
-                    self.status_dir.display(),
-                    e
-                ));
-            }
+        if let Err(e) = misc_helpers::try_create_folder(&self.status_dir) {
+            logger::write_error(format!(
+                "Error creating status directory: {} with error {}",
+                self.status_dir.display(),
+                e
+            ));
         }
 
         loop {

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -117,6 +117,17 @@ impl ProxyAgentStatusTask {
         let status_report_duration = Duration::from_secs(60 * 15);
         let mut status_report_time = Instant::now();
 
+        match misc_helpers::try_create_folder(&self.status_dir) {
+            Ok(_) => {}
+            Err(e) => {
+                logger::write_error(format!(
+                    "Error creating status directory: {} with error {}",
+                    self.status_dir.display(),
+                    e
+                ));
+            }
+        }
+
         loop {
             let aggregate_status = self.guest_proxy_agent_aggregate_status_new().await;
             // write proxyAgentStatus event

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -27,7 +27,14 @@ use std::time::Duration;
 /// service::start_service(shared_state).await;
 /// ```
 pub async fn start_service(shared_state: SharedState) {
-    setup_loggers(config::get_logs_dir(), config::get_file_log_level());
+    let log_folder = config::get_logs_dir();
+    if log_folder == PathBuf::from("") {
+        logger::write_console_log(
+            "The log folder is not set, skip write to GPA managed file log.".to_string(),
+        );
+    } else {
+        setup_loggers(log_folder, config::get_file_log_level());
+    }
 
     let start_message = format!(
         "============== GuestProxyAgent ({}) is starting on {}({}), elapsed: {}",

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -7,11 +7,6 @@ pub const PLUGIN_FAILED_AUTH_NAME: &str = "ProxyAgentFailedAuthenticationSummary
 pub const HANDLER_ENVIRONMENT_FILE: &str = "HandlerEnvironment.json";
 pub const HANDLER_LOG_FILE: &str = "ProxyAgentExtension.log";
 pub const SERVICE_LOG_FILE: &str = "ProxyAgentExtensionService.log";
-#[cfg(windows)]
-pub const PROXY_AGENT_AGGREGATE_STATUS_FILE: &str =
-    "C:\\WindowsAzure\\ProxyAgent\\Logs\\status.json";
-#[cfg(not(windows))]
-pub const PROXY_AGENT_AGGREGATE_STATUS_FILE: &str = "/var/log/azure-proxy-agent/status.json";
 pub const EXTENSION_SERVICE_NAME: &str = "GuestProxyAgentVMExtension";
 #[cfg(not(windows))]
 pub const EXTENSION_PROCESS_NAME: &str = "ProxyAgentExt";

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -5,8 +5,9 @@ use crate::constants;
 use crate::logger;
 use crate::structs::*;
 use proxy_agent_shared::logger::LoggerLevel;
-use proxy_agent_shared::proxy_agent_aggregate_status::GuestProxyAgentAggregateStatus;
-use proxy_agent_shared::proxy_agent_aggregate_status::ProxyConnectionSummary;
+use proxy_agent_shared::proxy_agent_aggregate_status::{
+    self, GuestProxyAgentAggregateStatus, ProxyConnectionSummary,
+};
 use proxy_agent_shared::telemetry::event_logger;
 use proxy_agent_shared::{misc_helpers, telemetry};
 use service_state::ServiceState;
@@ -317,7 +318,8 @@ fn report_proxy_agent_aggregate_status(
     service_state: &mut ServiceState,
 ) {
     let aggregate_status_file_path =
-        PathBuf::from(constants::PROXY_AGENT_AGGREGATE_STATUS_FILE.to_string());
+        PathBuf::from(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FOLDER)
+            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME);
 
     let proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus;
     match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -3,6 +3,12 @@
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[cfg(windows)]
+pub const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "C:\\WindowsAzure\\ProxyAgent\\Logs\\";
+#[cfg(not(windows))]
+pub const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "/var/log/azure-proxy-agent/";
+pub const PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME: &str = "status.json";
+
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum ModuleState {
     UNKNOWN,


### PR DESCRIPTION
1. Provide an option to not write file log to GPA managed log directory
2. Move GPA status consts to shared crate for both GPA and its VM Extension. 
3. GPA status task to try creating status folder if not exists before.