### PR TITLE
Upgrade GuestProxyAgentTest to .NET8

### DIFF
--- a/e2etest/GuestProxyAgentTest/GuestProxyAgentTest.csproj
+++ b/e2etest/GuestProxyAgentTest/GuestProxyAgentTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>CS8603,SYSLIB0028</NoWarn>


### PR DESCRIPTION
.NET 6 is deprecated in our daily Linux E2E test pipeline container.