### PR TITLE
windows: try load ebpf program file with eBPFAPI.dll product version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "windows-service",
- "windows-sys 0.42.0",
  "winres",
 ]
 

--- a/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
+++ b/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
@@ -34,3 +34,4 @@ SAMLIB.dll
 WLDAP32.dll
 crypt32.dll
 msasn1.dll
+version.dll

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -54,7 +54,7 @@ impl super::Redirector {
 
         if let Some(ebpf_api_version) = bpf_api::get_ebpf_api_version() {
             // eBPF program has to work with the same version of eBPF API if windows eBPF had break changes
-            // our latest eBPF program may not work with the older version of winodws eBPF API
+            // our latest eBPF program may not work with the older version of windows eBPF API
             // in some cases, the windows eBPF may not able, or be allowed to update,
             // so we need to load the eBPF program with the same version of eBPF API
             let file_ext = bpf_file_path.extension().unwrap_or_default();

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -57,10 +57,11 @@ impl super::Redirector {
             // our latest eBPF program may not work with the older version of windows eBPF API
             // in some cases, the windows eBPF may not able, or be allowed to update,
             // so we need to load the eBPF program with the same version of eBPF API
+            // the versioned eBPF program is named as <program_name>.<major>.<minor>.<extension>
             let file_ext = bpf_file_path.extension().unwrap_or_default();
             let file_name = bpf_file_path.file_stem().unwrap_or_default();
             let file_name = format!(
-                "{}.{}_{}.{}",
+                "{}.{}.{}.{}",
                 file_name.to_string_lossy(),
                 ebpf_api_version.major,
                 ebpf_api_version.minor,

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -50,8 +50,41 @@ impl super::Redirector {
     }
 
     pub fn load_bpf_object(&self) -> Result<BpfObject> {
+        let mut bpf_file_path = super::get_ebpf_file_path();
+
+        if let Some(ebpf_api_version) = bpf_api::get_ebpf_api_version() {
+            // eBPF program has to work with the same version of eBPF API if windows eBPF had break changes
+            // our latest eBPF program may not work with the older version of winodws eBPF API
+            // in some cases, the windows eBPF may not able, or be allowed to update,
+            // so we need to load the eBPF program with the same version of eBPF API
+            let file_ext = bpf_file_path.extension().unwrap_or_default();
+            let file_name = bpf_file_path.file_stem().unwrap_or_default();
+            let file_name = format!(
+                "{}.{}_{}.{}",
+                file_name.to_string_lossy(),
+                ebpf_api_version.major,
+                ebpf_api_version.minor,
+                file_ext.to_string_lossy()
+            );
+            let file_path = bpf_file_path.with_file_name(file_name);
+            let file_found: bool;
+            if file_path.exists() && file_path.is_file() {
+                bpf_file_path = file_path.to_path_buf();
+                file_found = true;
+            } else {
+                file_found = false;
+            }
+
+            logger::write(format!(
+                "eBPF API version: '{}' found, eBPF file with api version: '{}'{}found.",
+                ebpf_api_version,
+                file_path.display(),
+                if file_found { " " } else { " not " },
+            ));
+        }
+
         let mut bpf_object = BpfObject::new();
-        bpf_object.load_bpf_object(&super::get_ebpf_file_path())?;
+        bpf_object.load_bpf_object(&bpf_file_path)?;
         Ok(bpf_object)
     }
 

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -77,7 +77,7 @@ impl super::Redirector {
             }
 
             logger::write(format!(
-                "eBPF API version: '{}' found, eBPF file with api version: '{}'{}found.",
+                "eBPF API version: '{}' found, eBPF program file with api version: '{}'{}found.",
                 ebpf_api_version,
                 file_path.display(),
                 if file_found { " " } else { " not " },

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -76,7 +76,6 @@ fn init_ebpf_lib() -> Option<Library> {
                             "redirector",
                             logger::AGENT_LOGGER_KEY,
                         );
-                        return None;
                     }
                 }
             }

--- a/proxy_agent_extension/Cargo.toml
+++ b/proxy_agent_extension/Cargo.toml
@@ -22,12 +22,6 @@ windows-service = "0.7.0"     # windows NT
 winres = "0.1.12"             # Rust Windows resource helper to add file version
 static_vcruntime = "2.0.0"    # Statically link the VCRuntime when using the MSVC toolchain
 
-[target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.42.0"
-features = [
-  "Win32_Storage_FileSystem",
-]
-
 [target.'cfg(not(windows))'.dependencies.nix]
 version = "0.29.0"
 features = [

--- a/proxy_agent_extension/src/service_main/windows_main.rs
+++ b/proxy_agent_extension/src/service_main/windows_main.rs
@@ -5,20 +5,13 @@ use crate::constants;
 use crate::logger;
 use crate::result::Result;
 use crate::service_main;
-use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::os::windows::ffi::OsStrExt;
-use std::path::PathBuf;
-use std::ptr::null_mut;
 use std::time::Duration;
 use windows_service::service::{
     ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus, ServiceType,
 };
 use windows_service::service_control_handler::{
     self, ServiceControlHandlerResult, ServiceStatusHandle,
-};
-use windows_sys::Win32::Storage::FileSystem::{
-    GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
 };
 
 // The private global variable to store the windows service status handle.
@@ -79,61 +72,3 @@ pub async fn run_service(_args: Vec<OsString>) -> Result<()> {
     Ok(())
 }
 
-#[cfg(windows)]
-pub fn get_file_version(file: PathBuf) -> Result<String> {
-    logger::write(format!("get_file_version: {:?}", file.to_path_buf()));
-    let file = file
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect::<Vec<_>>();
-    let size = unsafe { GetFileVersionInfoSizeW(file.as_ptr(), null_mut()) };
-    if size == 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    let mut buffer = vec![0u8; size as usize];
-    let buffer_ptr = buffer.as_mut_ptr() as *mut _;
-    let result = unsafe { GetFileVersionInfoW(file.as_ptr(), 0, size, buffer_ptr) };
-    if result == 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-    let mut version = null_mut();
-    let mut version_len = 0;
-    let result = unsafe {
-        VerQueryValueW(
-            buffer_ptr,
-            OsStr::new("\\")
-                .encode_wide()
-                .chain(Some(0))
-                .collect::<Vec<_>>()
-                .as_ptr() as *const _,
-            &mut version,
-            &mut version_len,
-        )
-    };
-    if result == 0 {
-        return Err(std::io::Error::last_os_error().into());
-    }
-
-    let version_info = unsafe { &*(version as *const VS_FIXEDFILEINFO) };
-    let major = version_info.dwFileVersionMS >> 16;
-    let minor = version_info.dwFileVersionMS & 0xffff;
-    let build = version_info.dwFileVersionLS >> 16;
-    let revision = version_info.dwFileVersionLS & 0xffff;
-    let mut version_info_str = format!("{}.{}.{}", major, minor, build,);
-    if revision > 0 {
-        version_info_str = format!("{}.{}", version_info_str, revision);
-    }
-
-    Ok(version_info_str)
-}
-
-#[cfg(test)]
-mod tests {
-    #[tokio::test]
-    async fn test_get_file_version() {
-        let exe_path = std::env::current_exe().unwrap();
-        let version = super::get_file_version(exe_path).unwrap();
-        assert!(version.contains('.'), "version should contain .");
-    }
-}

--- a/proxy_agent_extension/src/service_main/windows_main.rs
+++ b/proxy_agent_extension/src/service_main/windows_main.rs
@@ -71,4 +71,3 @@ pub async fn run_service(_args: Vec<OsString>) -> Result<()> {
 
     Ok(())
 }
-

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -34,6 +34,7 @@ features = [
   "Win32_Security_Authentication_Identity", 
   "Win32_System_Diagnostics_Debug",
   "Win32_System_SystemInformation",
+  "Win32_Storage_FileSystem",
 ]
 
 [target.'cfg(not(windows))'.dependencies]

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -18,6 +18,10 @@ pub enum Error {
     #[error("Failed to create regex with error: {0}")]
     Regex(#[from] regex::Error),
 
+    #[cfg(windows)]
+    #[error("WindowsApi '{0}' failed with error: {1}")]
+    WindowsApi(String, std::io::Error),
+
     #[error("{0}")]
     ParseVersion(ParseVersionErrorType),
 

--- a/proxy_agent_shared/src/version.rs
+++ b/proxy_agent_shared/src/version.rs
@@ -1,9 +1,10 @@
-use std::fmt::{Display, Formatter};
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use crate::error::{Error, ParseVersionErrorType};
 use crate::result::Result;
+use std::fmt::{Display, Formatter};
 
+#[derive(Clone)]
 pub struct Version {
     pub major: u32,
     pub minor: u32,

--- a/proxy_agent_shared/src/windows.rs
+++ b/proxy_agent_shared/src/windows.rs
@@ -313,12 +313,8 @@ pub fn get_file_product_version(file_path: &Path) -> Result<Version> {
     let minor = fixed_file_info.dwFileVersionMS & 0xFFFF;
     let build = fixed_file_info.dwFileVersionLS >> 16;
     let revision = fixed_file_info.dwFileVersionLS & 0xFFFF;
-    let version = Version::from_major_minor_build_revision(
-        major as u32,
-        minor as u32,
-        Some(build),
-        Some(revision),
-    );
+    let version =
+        Version::from_major_minor_build_revision(major, minor, Some(build), Some(revision));
     Ok(version)
 }
 

--- a/proxy_agent_shared/src/windows.rs
+++ b/proxy_agent_shared/src/windows.rs
@@ -6,8 +6,13 @@ use crate::result::Result;
 use crate::version::Version;
 use std::ffi::OsStr;
 use std::mem::MaybeUninit;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
 use windows_service::service::{ServiceAccess, ServiceState};
 use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+use windows_sys::Win32::Storage::FileSystem::{
+    GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
+};
 use windows_sys::Win32::System::SystemInformation::SYSTEM_INFO;
 use winreg::enums::*;
 use winreg::RegKey;
@@ -232,6 +237,91 @@ pub fn ensure_service_running(service_name: &str) -> (bool, String) {
     (true, message)
 }
 
+pub fn get_file_product_version(file_path: &Path) -> Result<Version> {
+    if !file_path.exists() {
+        return Err(Error::ParseVersion(ParseVersionErrorType::InvalidString(
+            format!("File path does not exist: {}", file_path.display()),
+        )));
+    }
+    if !file_path.is_file() {
+        return Err(Error::ParseVersion(ParseVersionErrorType::InvalidString(
+            format!("File path is not a file: {}", file_path.display()),
+        )));
+    }
+    if !file_path.is_absolute() {
+        return Err(Error::ParseVersion(ParseVersionErrorType::InvalidString(
+            format!("File path is not absolute: {}", file_path.display()),
+        )));
+    }
+
+    let file_path = file_path
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<u16>>();
+    let size = unsafe { GetFileVersionInfoSizeW(file_path.as_ptr(), std::ptr::null_mut()) };
+    if size == 0 {
+        return Err(Error::WindowsApi(
+            "GetFileVersionInfoSizeW".to_string(),
+            std::io::Error::last_os_error(),
+        ));
+    }
+
+    let mut buffer = vec![0u8; size as usize];
+    if unsafe { GetFileVersionInfoW(file_path.as_ptr(), 0, size, buffer.as_mut_ptr() as *mut _) }
+        == 0
+    {
+        return Err(Error::WindowsApi(
+            "GetFileVersionInfoW".to_string(),
+            std::io::Error::last_os_error(),
+        ));
+    }
+
+    // get VS_FIXEDFILEINFO
+    // Ref: https://learn.microsoft.com/en-us/windows/win32/api/version/ns-version-vs_fixedfileinfo
+    let mut fixed_file_info = MaybeUninit::<VS_FIXEDFILEINFO>::uninit();
+    let mut fixed_file_info_size = 0;
+    let result = unsafe {
+        VerQueryValueW(
+            buffer.as_mut_ptr() as *mut _,
+            "\\".encode_utf16()
+                .chain(Some(0))
+                .collect::<Vec<u16>>()
+                .as_ptr(),
+            fixed_file_info.as_mut_ptr() as *mut _,
+            &mut fixed_file_info_size,
+        )
+    };
+    if result == 0 {
+        return Err(Error::WindowsApi(
+            "VerQueryValueW".to_string(),
+            std::io::Error::last_os_error(),
+        ));
+    }
+    if fixed_file_info_size != std::mem::size_of::<VS_FIXEDFILEINFO>() as u32 {
+        return Err(Error::ParseVersion(ParseVersionErrorType::InvalidString(
+            format!(
+                "Invalid VS_FIXEDFILEINFO size '{}' returned",
+                fixed_file_info_size
+            ),
+        )));
+    }
+
+    // get the product version from VS_FIXEDFILEINFO
+    let fixed_file_info = unsafe { fixed_file_info.assume_init() };
+    let major = fixed_file_info.dwFileVersionMS >> 16;
+    let minor = fixed_file_info.dwFileVersionMS & 0xFFFF;
+    let build = fixed_file_info.dwFileVersionLS >> 16;
+    let revision = fixed_file_info.dwFileVersionLS & 0xFFFF;
+    let version = Version::from_major_minor_build_revision(
+        major as u32,
+        minor as u32,
+        Some(build),
+        Some(revision),
+    );
+    Ok(version)
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -262,5 +352,23 @@ mod tests {
             "unknown", processor_arch,
             "processor arch cannot be 'unknown'"
         );
+    }
+
+    #[test]
+    fn get_file_product_version_test() {
+        let system_path = std::env::var("SystemRoot").unwrap_or("C:\\Windows".to_string());
+        let file_path = std::path::Path::new(&system_path)
+            .join("System32")
+            .join("kernel32.dll");
+        let version = match super::get_file_product_version(&file_path) {
+            Ok(v) => v,
+            Err(e) => {
+                println!("Failed to get file product version: {}", e);
+                assert!(false, "Failed to get file product version");
+                return;
+            }
+        };
+        println!("kernel32.dll File product version: {}", version);
+        assert_eq!(version.major, 10, "major version mismatch");
     }
 }

--- a/proxy_agent_shared/src/windows.rs
+++ b/proxy_agent_shared/src/windows.rs
@@ -278,7 +278,6 @@ pub fn get_file_product_version(file_path: &Path) -> Result<Version> {
     }
 
     // get VS_FIXEDFILEINFO
-    // Ref: https://learn.microsoft.com/en-us/windows/win32/api/version/ns-version-vs_fixedfileinfo
     let mut fixed_file_info = MaybeUninit::<VS_FIXEDFILEINFO>::uninit();
     let mut fixed_file_info_size = 0;
     let result = unsafe {


### PR DESCRIPTION
Windows eBPF program must match the windows eBPF API version, this PR to fetch the windows eBPF API version and try to load the eBPF program with the same version (major.minor).
