### PR TITLE
Bug Fix: Trim Status File When Exceeding 80KB

### DIFF
--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -71,6 +71,7 @@ pub const EBPF_SUBSTATUS_NAME: &str = "EbpfStatus";
 
 pub const MAX_CONNECTION_SUMMARY_LEN: usize = 100;
 pub const MAX_FAILED_AUTH_SUMMARY_LEN: usize = 50;
+// Max KB of substatus string for connection summary and failed authentication summary
 pub const MAX_SUBSTATUS_SIZE: usize = 80;
 
 #[cfg(not(windows))]

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -72,7 +72,7 @@ pub const EBPF_SUBSTATUS_NAME: &str = "EbpfStatus";
 pub const MAX_CONNECTION_SUMMARY_LEN: usize = 100;
 pub const MAX_FAILED_AUTH_SUMMARY_LEN: usize = 50;
 // Max KB of substatus string for connection summary and failed authentication summary
-pub const MAX_SUBSTATUS_SIZE: usize = 80;
+pub const MAX_PROXYAGENT_CONNECTION_DATA_SIZE_IN_KB: usize = 80;
 
 #[cfg(not(windows))]
 pub mod linux {

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -71,6 +71,7 @@ pub const EBPF_SUBSTATUS_NAME: &str = "EbpfStatus";
 
 pub const MAX_CONNECTION_SUMMARY_LEN: usize = 100;
 pub const MAX_FAILED_AUTH_SUMMARY_LEN: usize = 50;
+pub const MAX_SUBSTATUS_SIZE: usize = 80;
 
 #[cfg(not(windows))]
 pub mod linux {

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -341,7 +341,7 @@ fn report_proxy_agent_aggregate_status(
                 proxyagent_file_version_in_extension,
                 status,
                 status_state_obj,
-                service_state,            
+                service_state,         
             );
         }
         Err(e) => {
@@ -477,8 +477,7 @@ fn extension_substatus(
             );
             match serde_json::to_string(&proxy_agent_aggregate_connection_status_obj) {
                 Ok(proxy_agent_aggregate_connection_status) => {
-                    substatus_proxy_agent_connection_message =
-                        proxy_agent_aggregate_connection_status;
+                    substatus_proxy_agent_connection_message = proxy_agent_aggregate_connection_status;
                 }
                 Err(e) => {
                     let error_message = format!(
@@ -523,16 +522,14 @@ fn extension_substatus(
             substatus_failed_auth_message = "proxy failed auth summary is empty".to_string();
         }
 
-        match trim_proxy_agent_status_file(
+        if let Some((trimmed_connection_message, trimmed_failed_auth_message)) = trim_proxy_agent_status_file(
             substatus_proxy_agent_connection_message.len(),
             substatus_failed_auth_message.len(),
             constants::MAX_SUBSTATUS_SIZE,
-        ) {
-            Some((trimmed_connection_message, trimmed_failed_auth_message)) => {
-                substatus_proxy_agent_connection_message = trimmed_connection_message;
-                substatus_failed_auth_message = trimmed_failed_auth_message;
-            }
-            None => {}
+        )
+        {
+            substatus_proxy_agent_connection_message = trimmed_connection_message;
+            substatus_failed_auth_message = trimmed_failed_auth_message;
         }
 
         status.substatus = {
@@ -587,7 +584,7 @@ fn trim_proxy_agent_status_file(connection_summary_len: usize, failed_auth_len: 
     let substatus_failed_auth_message_size = failed_auth_len / 1024;
     if substatus_proxy_agent_connection_message_size + substatus_failed_auth_message_size > max_size {
         logger::write("Substatus of proxy agent connection message and failed auth message size exceeds max size, dropping connection summary".to_string());
-        let substatus_proxy_agent_connection_message = 
+        let substatus_proxy_agent_connection_message =
             "Proxy agent connection message size exceeds max size, dropping connection summary from status file. Connection logs are available in ProxyAgentConnection.log".to_string();
         let mut substatus_failed_auth_message = String::new();
         if substatus_failed_auth_message_size > max_size {
@@ -602,7 +599,7 @@ fn trim_proxy_agent_status_file(connection_summary_len: usize, failed_auth_len: 
             substatus_failed_auth_message,
         ));
     } 
-    return None;
+    None
 }
 
 fn get_top_proxy_connection_summary(

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -524,11 +524,11 @@ fn extension_substatus(
         }
 
         trim_proxy_agent_status_file(
-            &mut substatus_failed_auth_message, 
+            &mut substatus_failed_auth_message,
             &mut substatus_proxy_agent_connection_message,
             constants::MAX_PROXYAGENT_CONNECTION_DATA_SIZE_IN_KB,
         );
- 
+
         status.substatus = {
             vec![
                 SubStatus {
@@ -576,13 +576,14 @@ fn extension_substatus(
 
 fn trim_proxy_agent_status_file(
     substatus_failed_auth_message: &mut String,
-    substatus_connection_summary_message:  &mut String,
+    substatus_connection_summary_message: &mut String,
     max_size_in_kb: usize,
 ) {
-    let allowed_bytes = max_size_in_kb * 1024; 
-    if substatus_connection_summary_message.len() + substatus_failed_auth_message.len() > allowed_bytes
+    let allowed_bytes = max_size_in_kb * 1024;
+    if substatus_connection_summary_message.len() + substatus_failed_auth_message.len()
+        > allowed_bytes
     {
-        let connection_message = "Substatus of proxy agent connection message and failed auth message size exceeds max size, dropping connection summary".to_string(); 
+        let connection_message = "Substatus of proxy agent connection message and failed auth message size exceeds max size, dropping connection summary".to_string();
         logger::write(connection_message.clone());
         *substatus_connection_summary_message = connection_message;
         if substatus_failed_auth_message.len() > allowed_bytes {
@@ -1041,7 +1042,11 @@ mod tests {
         let max_size = 4; // 4 KB
         let orig_conn = connection_summary.clone();
         let orig_auth = failed_auth_summary.clone();
-        super::trim_proxy_agent_status_file(&mut failed_auth_summary, &mut connection_summary, max_size);
+        super::trim_proxy_agent_status_file(
+            &mut failed_auth_summary,
+            &mut connection_summary,
+            max_size,
+        );
         assert_eq!(connection_summary, orig_conn);
         assert_eq!(failed_auth_summary, orig_auth);
 
@@ -1049,7 +1054,11 @@ mod tests {
         let mut connection_summary = "b".repeat(1024 * 3); // 3 KB
         let mut failed_auth_summary = "a".repeat(1024 * 3); // 3 KB
         let max_size = 5; // 5 KB
-        super::trim_proxy_agent_status_file(&mut failed_auth_summary, &mut connection_summary, max_size);
+        super::trim_proxy_agent_status_file(
+            &mut failed_auth_summary,
+            &mut connection_summary,
+            max_size,
+        );
         assert!(connection_summary.contains("Substatus of proxy agent connection message and failed auth message size exceeds max size"));
         assert_eq!(failed_auth_summary, "a".repeat(1024 * 3));
 
@@ -1057,7 +1066,11 @@ mod tests {
         let mut connection_summary = "b".repeat(1024 * 1); // 1 KB
         let mut failed_auth_summary = "a".repeat(1024 * 10); // 10 KB
         let max_size = 2; // 2 KB
-        super::trim_proxy_agent_status_file(&mut failed_auth_summary, &mut connection_summary, max_size);
+        super::trim_proxy_agent_status_file(
+            &mut failed_auth_summary,
+            &mut connection_summary,
+            max_size,
+        );
         assert!(connection_summary.contains("Substatus of proxy agent connection message and failed auth message size exceeds max size"));
         assert_eq!(failed_auth_summary, "a".repeat(2048));
 
@@ -1067,7 +1080,11 @@ mod tests {
         let max_size = 4; // 4 KB
         let orig_conn = connection_summary.clone();
         let orig_auth = failed_auth_summary.clone();
-        super::trim_proxy_agent_status_file(&mut failed_auth_summary, &mut connection_summary, max_size);
+        super::trim_proxy_agent_status_file(
+            &mut failed_auth_summary,
+            &mut connection_summary,
+            max_size,
+        );
         assert_eq!(connection_summary, orig_conn);
         assert_eq!(failed_auth_summary, orig_auth);
     }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -341,7 +341,7 @@ fn report_proxy_agent_aggregate_status(
                 proxyagent_file_version_in_extension,
                 status,
                 status_state_obj,
-                service_state,         
+                service_state,
             );
         }
         Err(e) => {
@@ -477,7 +477,8 @@ fn extension_substatus(
             );
             match serde_json::to_string(&proxy_agent_aggregate_connection_status_obj) {
                 Ok(proxy_agent_aggregate_connection_status) => {
-                    substatus_proxy_agent_connection_message = proxy_agent_aggregate_connection_status;
+                    substatus_proxy_agent_connection_message =
+                        proxy_agent_aggregate_connection_status;
                 }
                 Err(e) => {
                     let error_message = format!(
@@ -522,11 +523,12 @@ fn extension_substatus(
             substatus_failed_auth_message = "proxy failed auth summary is empty".to_string();
         }
 
-        if let Some((trimmed_connection_message, trimmed_failed_auth_message)) = trim_proxy_agent_status_file(
-            substatus_proxy_agent_connection_message.len(),
-            substatus_failed_auth_message.len(),
-            constants::MAX_SUBSTATUS_SIZE,
-        )
+        if let Some((trimmed_connection_message, trimmed_failed_auth_message)) =
+            trim_proxy_agent_status_file(
+                substatus_proxy_agent_connection_message.len(),
+                substatus_failed_auth_message.len(),
+                constants::MAX_PROXYAGENT_CONNECTION_DATA_SIZE_IN_KB,
+            )
         {
             substatus_proxy_agent_connection_message = trimmed_connection_message;
             substatus_failed_auth_message = trimmed_failed_auth_message;
@@ -577,19 +579,27 @@ fn extension_substatus(
     }
 }
 
-fn trim_proxy_agent_status_file(connection_summary_len: usize, failed_auth_len: usize, max_size: usize) -> Option<(String, String)> {
-    // To ensure status file size does not exceed max file size, remove the substatus_proxy_agent_connection_message if the summary size is too large, 
+fn trim_proxy_agent_status_file(
+    connection_summary_len: usize,
+    failed_auth_len: usize,
+    max_size: usize,
+) -> Option<(String, String)> {
+    // To ensure status file size does not exceed max file size, remove the substatus_proxy_agent_connection_message if the summary size is too large,
     // if file size still exceeds max size trim substatus_failed_auth_message
     let substatus_proxy_agent_connection_message_size = connection_summary_len / 1024;
     let substatus_failed_auth_message_size = failed_auth_len / 1024;
-    if substatus_proxy_agent_connection_message_size + substatus_failed_auth_message_size > max_size {
+    if substatus_proxy_agent_connection_message_size + substatus_failed_auth_message_size > max_size
+    {
         logger::write("Substatus of proxy agent connection message and failed auth message size exceeds max size, dropping connection summary".to_string());
         let substatus_proxy_agent_connection_message =
             "Proxy agent connection message size exceeds max size, dropping connection summary from status file. Connection logs are available in ProxyAgentConnection.log".to_string();
         let mut substatus_failed_auth_message = String::new();
         if substatus_failed_auth_message_size > max_size {
-            logger::write("Substatus failed auth message size exceeds max limit, trimming it".to_string());
-            let trimmed_message = "".chars()
+            logger::write(
+                "Substatus failed auth message size exceeds max limit, trimming it".to_string(),
+            );
+            let trimmed_message = ""
+                .chars()
                 .take(max_size - substatus_proxy_agent_connection_message_size)
                 .collect::<String>();
             substatus_failed_auth_message = trimmed_message;
@@ -598,7 +608,7 @@ fn trim_proxy_agent_status_file(connection_summary_len: usize, failed_auth_len: 
             substatus_proxy_agent_connection_message,
             substatus_failed_auth_message,
         ));
-    } 
+    }
     None
 }
 
@@ -1050,14 +1060,16 @@ mod tests {
         let connection_summary_len = 1024 * 2; // 2 KB
         let failed_auth_len = 1024 * 1; // 1 KB
         let max_size = 4; // 4 KB
-        let result = super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
+        let result =
+            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
         assert!(result.is_none());
 
         // Case 2: total size exceeds max_size, should drop connection summary
         let connection_summary_len = 1024 * 3; // 3 KB
         let failed_auth_len = 1024 * 3; // 3 KB
         let max_size = 5; // 5 KB
-        let result = super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
+        let result =
+            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
         assert!(result.is_some());
         let (conn_msg, failed_auth_msg) = result.unwrap();
         assert!(conn_msg.contains("Proxy agent connection message size exceeds max size"));
@@ -1067,7 +1079,8 @@ mod tests {
         let connection_summary_len = 1024 * 1; // 1 KB
         let failed_auth_len = 1024 * 10; // 10 KB
         let max_size = 2; // 2 KB
-        let result = super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
+        let result =
+            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
         assert!(result.is_some());
         let (conn_msg, failed_auth_msg) = result.unwrap();
         assert!(conn_msg.contains("Proxy agent connection message size exceeds max size"));
@@ -1077,7 +1090,8 @@ mod tests {
         let connection_summary_len = 1024 * 2; // 2 KB
         let failed_auth_len = 1024 * 2; // 2 KB
         let max_size = 4; // 4 KB
-        let result = super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
+        let result =
+            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_len, max_size);
         assert!(result.is_none());
     }
 }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -1050,16 +1050,22 @@ mod tests {
         let connection_summary_len = 1024 * 2; // 2 KB
         let failed_auth_summary: String = "a".repeat(1024); // 1 KB
         let max_size = 4; // 4 KB
-        let result =
-            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_summary, max_size);
+        let result = super::trim_proxy_agent_status_file(
+            connection_summary_len,
+            failed_auth_summary,
+            max_size,
+        );
         assert!(result.is_none());
 
         // Case 2: total size exceeds max_size, should drop connection summary and keep failed_auth_summary the same
         let connection_summary_len = 1024 * 3; // 3 KB
         let failed_auth_summary: String = "a".repeat(1024 * 3); // 3 KB
         let max_size = 5; // 5 KB
-        let result =
-            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_summary.clone(), max_size);
+        let result = super::trim_proxy_agent_status_file(
+            connection_summary_len,
+            failed_auth_summary.clone(),
+            max_size,
+        );
         assert!(result.is_some());
         let (conn_msg, failed_auth_msg) = result.unwrap();
         assert!(conn_msg.contains("Proxy agent connection message size exceeds max size"));
@@ -1069,8 +1075,11 @@ mod tests {
         let connection_summary_len = 1024 * 1; // 1 KB
         let failed_auth_summary: String = "a".repeat(1024 * 10); // 10 KB
         let max_size = 2; // 2 KB
-        let result =
-            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_summary.clone(), max_size);
+        let result = super::trim_proxy_agent_status_file(
+            connection_summary_len,
+            failed_auth_summary.clone(),
+            max_size,
+        );
         assert!(result.is_some());
         let (conn_msg, failed_auth_msg) = result.unwrap();
         assert!(conn_msg.contains("Proxy agent connection message size exceeds max size"));
@@ -1080,8 +1089,11 @@ mod tests {
         let connection_summary_len = 1024 * 2; // 2 KB
         let failed_auth_summary: String = "a".repeat(1024 * 2); // 2 KB
         let max_size = 4; // 4 KB
-        let result =
-            super::trim_proxy_agent_status_file(connection_summary_len, failed_auth_summary, max_size);
+        let result = super::trim_proxy_agent_status_file(
+            connection_summary_len,
+            failed_auth_summary,
+            max_size,
+        );
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
VM Agent cannot read status file > 100KB. Trim the proxy agent connection summary first, if status is still larger than 80KB, trim the failed authentication summary.