### PR TITLE
Fix GuestProxyAgentLoadedModulesValidationCase

### DIFF
--- a/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
+++ b/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
@@ -35,3 +35,6 @@ WLDAP32.dll
 crypt32.dll
 msasn1.dll
 version.dll
+combase.dll
+oleaut32.dll
+msvcp_win.dll

--- a/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
+++ b/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
@@ -38,3 +38,5 @@ version.dll
 combase.dll
 oleaut32.dll
 msvcp_win.dll
+symsrv.dll
+shlwapi.dll


### PR DESCRIPTION
Win11 and WS2025 E2E tests failed at GuestProxyAgentLoadedModulesValidationCase, it seems that the new OS Version started to load more system dlls.