### PR TITLE
Pass the right folder to log the access control rule details

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -88,8 +88,8 @@ xcopy /Y %out_dir%\redirect.bpf.o %out_package_proxyagent_dir%\
 echo ======= convert redirect.bpf.o to redirect.bpf.sys
 call %eBPF_for_Windows_bin_path%\export_program_info.exe --clear
 call %eBPF_for_Windows_bin_path%\export_program_info.exe
-echo call powershell.exe %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir "%out_dir%" -FileName redirect.bpf.o -IncludeDir "%eBPF_for_Windows_inc_path%" -Platform %eBPF_Platform% -Packages "%root_path%packages"
-call powershell.exe %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir "%out_dir%" -FileName redirect.bpf.o -IncludeDir "%eBPF_for_Windows_inc_path%" -Platform %eBPF_Platform% -Packages "%root_path%packages"
+echo call powershell.exe -ExecutionPolicy Bypass %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir "%out_dir%" -FileName redirect.bpf.o -IncludeDir "%eBPF_for_Windows_inc_path%" -Platform %eBPF_Platform% -Packages "%root_path%packages"
+call powershell.exe -ExecutionPolicy Bypass %eBPF_for_Windows_bin_path%\Convert-BpfToNative.ps1 -OutDir "%out_dir%" -FileName redirect.bpf.o -IncludeDir "%eBPF_for_Windows_inc_path%" -Platform %eBPF_Platform% -Packages "%root_path%packages"
 if  %ERRORLEVEL% NEQ 0 (
     echo call Convert-BpfToNative.ps1 failed with exit-code: %errorlevel%
     if "%ContinueAtConvertBpfToNative%"=="" (

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -65,8 +65,8 @@ pub struct KeyKeeper {
     base_url: Uri,
     /// key_dir: the folder to save the key details
     key_dir: PathBuf,
-    /// log_dir: the folder to log the access control rule details
-    log_dir: PathBuf,
+    /// status_dir: the folder to log the access control rule details
+    status_dir: PathBuf,
     /// interval: the interval to poll the secure channel status
     interval: Duration,
     /// cancellation_token: the cancellation token to cancel the key keeper task
@@ -87,14 +87,14 @@ impl KeyKeeper {
     pub fn new(
         base_url: Uri,
         key_dir: PathBuf,
-        log_dir: PathBuf,
+        status_dir: PathBuf,
         interval: Duration,
         shared_state: &SharedState,
     ) -> Self {
         KeyKeeper {
             base_url,
             key_dir,
-            log_dir,
+            status_dir,
             interval,
             cancellation_token: shared_state.get_cancellation_token(),
             key_keeper_shared_state: shared_state.get_key_keeper_shared_state(),
@@ -392,7 +392,7 @@ impl KeyKeeper {
                             hostga: hostga_rules,
                         },
                     );
-                    rules.write_all(&self.log_dir, constants::MAX_LOG_FILE_COUNT);
+                    rules.write_all(&self.status_dir, constants::MAX_LOG_FILE_COUNT);
                 }
             }
 
@@ -812,8 +812,8 @@ mod tests {
     async fn poll_secure_channel_status_tests() {
         let mut temp_test_path = env::temp_dir();
         temp_test_path.push("poll_secure_channel_status_tests");
-        let mut log_dir = temp_test_path.to_path_buf();
-        log_dir.push("Logs");
+        let mut status_dir = temp_test_path.to_path_buf();
+        status_dir.push("Logs");
         let mut keys_dir = temp_test_path.to_path_buf();
         keys_dir.push("Keys");
 
@@ -844,7 +844,7 @@ mod tests {
         let key_keeper = KeyKeeper {
             base_url: (format!("http://{}:{}/", ip, port)).parse().unwrap(),
             key_dir: cloned_keys_dir.clone(),
-            log_dir: cloned_keys_dir.clone(),
+            status_dir: cloned_keys_dir.clone(),
             interval: Duration::from_millis(10),
             cancellation_token: cancellation_token.clone(),
             key_keeper_shared_state: key_keeper::KeyKeeperSharedState::start_new(),

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -11,6 +11,7 @@ use crate::redirector::{self, Redirector};
 use crate::shared_state::SharedState;
 use proxy_agent_shared::logger::rolling_logger::RollingLogger;
 use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
+use proxy_agent_shared::proxy_agent_aggregate_status;
 use proxy_agent_shared::telemetry::event_logger;
 
 use std::path::PathBuf;
@@ -59,7 +60,7 @@ pub async fn start_service(shared_state: SharedState) {
                 .parse()
                 .unwrap(),
             config::get_keys_dir(),
-            config::get_logs_dir(),
+            proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder(),
             config::get_poll_key_status_duration(),
             &shared_state,
         );


### PR DESCRIPTION
After removed the log_dir from Linux GPA json file, it does not have the folder to log the access control rule details. Same as ProxyAgent status, we need to pass the same folder to key_keeper mod.