### PR TITLE
move update_current_secure_channel_state before reporting attest the key

### DIFF
--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -397,6 +397,11 @@ impl KeyKeeper {
             }
 
             let state = status.get_secure_channel_state();
+            let secure_channel_state_updated = self
+                .key_keeper_shared_state
+                .update_current_secure_channel_state(state.to_string())
+                .await;
+
             // check if need fetch the key
             if state != DISABLE_STATE
                 && (status.keyGuid.is_none()  // key has not latched yet
@@ -523,12 +528,8 @@ impl KeyKeeper {
                 }
             }
 
-            // update the current secure channel state if different
-            match self
-                .key_keeper_shared_state
-                .update_current_secure_channel_state(state.to_string())
-                .await
-            {
+            // update redirect policy if current secure channel state updated
+            match secure_channel_state_updated {
                 Ok(updated) => {
                     if updated {
                         // update the redirector policy map


### PR DESCRIPTION
It is a race condition bug, when key_latched and all provisioned, GPA starts the status reporting async task (_some other telemetry async tasks too_), and then update the secure channel state into shared state. There is a risk, status reporting task could get the current_secure_channel_state from shared state earlier than GPA updated it. 
Hence there will be 1 minutes delay our status reporting task to get the updated current_secure_channel_state.