### PR TITLE
Enable ProxyAgentExtension Arm64 tests

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -210,6 +210,7 @@ pprev
 prandom
 predef
 prefmaxlen
+preprovisioned
 printk
 PROCESSINFOCLASS
 proxyagent
@@ -342,6 +343,7 @@ wireserver
 wireserverand
 wireserverandimds
 WMI
+workarounds
 WORKDIR
 WScript
 wsf

--- a/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
+++ b/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
@@ -21,7 +21,7 @@ namespace GuestProxyAgentTest
         public async Task StartAsync(List<TestScenarioSetting> testScenarioList)
         {
             var groupTestResultBuilderMap = new Dictionary<string, JunitTestResultBuilder>();
-            foreach(var testGroupName in testScenarioList.Select(x => x.testGroupName).ToHashSet())
+            foreach (var testGroupName in testScenarioList.Select(x => x.testGroupName).ToHashSet())
             {
                 groupTestResultBuilderMap[testGroupName] = new JunitTestResultBuilder(TestSetting.Instance.testResultFolder, testGroupName);
             }
@@ -57,7 +57,6 @@ namespace GuestProxyAgentTest
                         testScenarioStatusDetails.Status = ScenarioTestStatus.Completed;
                         testScenarioStatusDetails.ErrorMessage = "Failed to create the scenario class instance: " + testScenario.testScenarioClassName;
                     }
-
                 }
                 catch (Exception ex)
                 {
@@ -72,6 +71,10 @@ namespace GuestProxyAgentTest
                     {
                         taskList.Add(testScenarioTask);
                     }
+                    var message = string.Format("Test Group: {0}, Test Scenario: {1}: {2} ({3})"
+                        , testScenario.testGroupName, testScenario.testScenarioName
+                        , testScenarioStatusDetails.Result, testScenarioStatusDetails.ErrorMessage);
+                    Console.WriteLine(message);
                 }
             }
             var stopMonitor = new ManualResetEvent(false);
@@ -91,7 +94,7 @@ namespace GuestProxyAgentTest
             {
                 Console.WriteLine($"Test execution exception: {ex.Message}");
             }
-            
+
             stopMonitor.Set();
 
             foreach (var groupName in groupTestResultBuilderMap.Keys)

--- a/e2etest/GuestProxyAgentTest/Models/TestScenarioStatusDetails.cs
+++ b/e2etest/GuestProxyAgentTest/Models/TestScenarioStatusDetails.cs
@@ -37,7 +37,7 @@ namespace GuestProxyAgentTest.Models
         {
             get
             {
-                return FailedCases.Count() == 0? "": $"Test Scenario:{ScenarioName} failed by test cases: {string.Join(',', FailedCases)}, Check the test case log for error details.";
+                return FailedCases.Count() == 0 ? "" : $"Test Scenario:{ScenarioName} failed by test cases: {string.Join(',', FailedCases)}, Check the test case log for error details.";
             }
         }
     }

--- a/e2etest/GuestProxyAgentTest/Program.cs
+++ b/e2etest/GuestProxyAgentTest/Program.cs
@@ -23,13 +23,15 @@ namespace GuestProxyAgentTest
             var testConfigFilePath = args[0];
             var testResultFolder = args[1];
             var guestProxyAgentZipFilePath = args[2];
+            var proxyAgentVersion = args[3];
             var test_arm64 = false;
-            if (args.Length > 3 && args[3].Equals("arm64", StringComparison.InvariantCultureIgnoreCase))
+            if (args.Length > 4 && args[4].Equals("arm64", StringComparison.InvariantCultureIgnoreCase))
             {
                 test_arm64 = true;
             }
+          
 
-            TestCommonUtilities.TestSetup(guestProxyAgentZipFilePath, testConfigFilePath, testResultFolder);
+            TestCommonUtilities.TestSetup(guestProxyAgentZipFilePath, testConfigFilePath, testResultFolder, proxyAgentVersion);
 
             VMHelper.Instance.CleanupOldTestResourcesAndForget();
 

--- a/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
@@ -54,5 +54,15 @@ namespace GuestProxyAgentTest.Settings
         public string Offer { get; set; } = null!;
         public string Sku { get; set; } = null!;
         public string Version { get; set; } = null!;
+
+        public bool IsArm64
+        {
+            get
+            {
+                return Offer == null ? false : Offer.Contains("arm64", StringComparison.OrdinalIgnoreCase) ||
+                  Sku == null ? false : Sku.Contains("arm64", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
     }
 }

--- a/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestScenarioSetting.cs
@@ -59,10 +59,9 @@ namespace GuestProxyAgentTest.Settings
         {
             get
             {
-                return Offer == null ? false : Offer.Contains("arm64", StringComparison.OrdinalIgnoreCase) ||
-                  Sku == null ? false : Sku.Contains("arm64", StringComparison.OrdinalIgnoreCase);
+                return (Offer == null ? false : Offer.Contains("arm64", StringComparison.OrdinalIgnoreCase)) ||
+                  (Sku == null ? false : Sku.Contains("arm64", StringComparison.OrdinalIgnoreCase));
             }
         }
-
     }
 }

--- a/e2etest/GuestProxyAgentTest/Settings/TestSetting.cs
+++ b/e2etest/GuestProxyAgentTest/Settings/TestSetting.cs
@@ -35,6 +35,7 @@ namespace GuestProxyAgentTest.Settings
         internal string zipFilePath = null!;
         internal string sharedStorageAccountUrl = null!;
         internal string testResultFolder = null!;
+        internal string proxyAgentVersion = null!;
         internal int testMapTimeoutMilliseconds = 1000 * 60 * 180;
         internal string windowsInVmWireServerAccessControlProfileReferenceId = null!;
         internal string windowsInVmIMDSAccessControlProfileReferenceId = null!;
@@ -53,7 +54,7 @@ namespace GuestProxyAgentTest.Settings
 
         private TestSetting() { }
 
-        public static void Init(TestConfig testConfig, string zipFilePath, string testResultFolder)
+        public static void Init(TestConfig testConfig, string zipFilePath, string testResultFolder, string proxyAgentVersion)
         {
             var scriptsFolder = Constants.IS_WINDOWS() ? "Scripts" : "LinuxScripts";
 
@@ -78,6 +79,7 @@ namespace GuestProxyAgentTest.Settings
                 linuxInVmIMDSAccessControlProfileReferenceId = testConfig.LinuxInVmIMDSAccessControlProfileReferenceId,
                 zipFilePath = zipFilePath,
                 testResultFolder = testResultFolder,
+                proxyAgentVersion = proxyAgentVersion,
             };
         }
     }

--- a/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/AddLinuxVMExtensionCase.cs
@@ -24,7 +24,7 @@ namespace GuestProxyAgentTest.TestCases
             {
                 Location = GuestProxyAgentTest.Settings.TestSetting.Instance.location,
                 Publisher = "Microsoft.CPlat.ProxyAgent",
-                ExtensionType = "ProxyAgentLinuxTest",
+                ExtensionType = context.ScenarioSetting.VMImageDetails.IsArm64 ? "ProxyAgentLinuxARM64Test" : "ProxyAgentLinuxTest",
                 TypeHandlerVersion = "1.0",
                 AutoUpgradeMinorVersion = false,
                 EnableAutomaticUpgrade = false,

--- a/e2etest/GuestProxyAgentTest/TestMap/AzureLinux3-Arm64-TestGroup.yml
+++ b/e2etest/GuestProxyAgentTest/TestMap/AzureLinux3-Arm64-TestGroup.yml
@@ -8,3 +8,5 @@ scenarios:
     name: BVTScenario
   - name: LinuxPackageScenario
     className: GuestProxyAgentTest.TestScenarios.LinuxPackageScenario
+  - name: ProxyAgentExtension
+    className: GuestProxyAgentTest.TestScenarios.ProxyAgentExtension

--- a/e2etest/GuestProxyAgentTest/TestMap/Ubuntu24-Arm64-TestGroup.yml
+++ b/e2etest/GuestProxyAgentTest/TestMap/Ubuntu24-Arm64-TestGroup.yml
@@ -8,3 +8,5 @@ scenarios:
     name: BVTScenario
   - name: LinuxPackageScenario
     className: GuestProxyAgentTest.TestScenarios.LinuxPackageScenario
+  - name: ProxyAgentExtension
+    className: GuestProxyAgentTest.TestScenarios.ProxyAgentExtension

--- a/e2etest/GuestProxyAgentTest/TestMap/WinClient11-Arm64-TestGroup.yml
+++ b/e2etest/GuestProxyAgentTest/TestMap/WinClient11-Arm64-TestGroup.yml
@@ -8,4 +8,6 @@ scenarios:
     className: GuestProxyAgentTest.TestScenarios.BVTScenario
   - name: BugFixesScenario
     className: GuestProxyAgentTest.TestScenarios.BugFixesScenario
+  - name: ProxyAgentExtension 
+    className: GuestProxyAgentTest.TestScenarios.ProxyAgentExtension
 

--- a/e2etest/GuestProxyAgentTest/TestScenarios/ProxyAgentExtension.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/ProxyAgentExtension.cs
@@ -14,47 +14,23 @@ namespace GuestProxyAgentTest.TestScenarios
             string zipFile = Settings.TestSetting.Instance.zipFilePath;
             string withoutExt = Path.GetFileNameWithoutExtension(zipFile);
             string extractPath = Path.Combine(Path.GetDirectoryName(zipFile), withoutExt);
-            string proxyAgentVersion = "";
-            string exePath = "";
-            try
-            {
-                ZipFile.ExtractToDirectory(zipFile, extractPath);
-                Console.WriteLine("Extraction successful!");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"An error occurred: {ex.Message}");
-            }
+            // Passing in 0 version number for the first validation case
+            string proxyAgentVersionBeforeUpdate = "0";
+            string proxyAgentVersion = Settings.TestSetting.Instance.proxyAgentVersion;
+            ConsoleLog(string.Format("Received ProxyAgent Version:{0}", proxyAgentVersion));
+
             if (!Constants.IS_WINDOWS())
             {
                 AddTestCase(new SetupCGroup2TestCase("SetupCGroup2"));
                 AddTestCase(new RebootVMCase("RebootVMCaseAfterSetupCGroup2"));
                 AddTestCase(new AddLinuxVMExtensionCase("AddLinuxVMExtensionCase"));
                 AddTestCase(new EnableProxyAgentCase());
-                exePath = extractPath + "/ProxyAgent/ProxyAgent/azure-proxy-agent";
             }
             else
             {
                 EnableProxyAgentForNewVM = true;
-                exePath = extractPath + "\\ProxyAgent\\ProxyAgent\\GuestProxyAgent.exe";
             }
-            var process = new Process()
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = exePath,
-                    Arguments = "--version",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                }
-            };
-            process.Start();
-            proxyAgentVersion = process.StandardOutput.ReadToEnd();
-            process.WaitForExit();
-            // Passing in 0 version number for the first validation case
-            string proxyAgentVersionBeforeUpdate = "0";
+
             AddTestCase(new GuestProxyAgentExtensionValidationCase("GuestProxyAgentExtensionValidationCaseBeforeUpdate", proxyAgentVersionBeforeUpdate));
             AddTestCase(new InstallOrUpdateGuestProxyAgentExtensionCase());
             AddTestCase(new GuestProxyAgentExtensionValidationCase("GuestProxyAgentExtensionValidationCaseAfterUpdate", proxyAgentVersion));

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -154,6 +154,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 var vmCreateTestName = "CreateVM";
                 try
                 {
+                    ConsoleLog(string.Format("Creating {0} VM...", _testScenarioSetting.VMImageDetails.IsArm64 ? "ARM64" : "AMD64"));
                     vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, cancellationToken);
                     ConsoleLog("VM Create succeed");
                     sw.Stop();

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -58,7 +58,8 @@ namespace GuestProxyAgentTest.TestScenarios
         {
             get
             {
-                return "Test Group: " + _testScenarioSetting.testGroupName + ", Test Scenario: " + _testScenarioSetting.testScenarioName + ": ";
+                // _testScenarioSetting may still null in constructor functions
+                return "Test Group: " + _testScenarioSetting?.testGroupName + ", Test Scenario: " + _testScenarioSetting?.testScenarioName + ": ";
             }
         }
 

--- a/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-using Azure.Core;
-using Azure.ResourceManager.Network.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GuestProxyAgentTest.Utilities
 {

--- a/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
@@ -16,7 +16,8 @@ namespace GuestProxyAgentTest.Utilities
         public static readonly string RUNCOMMAND_ERROR_OUTPUT_FILE_NAME = "runCommandErr.txt";
         public static readonly string RUNCOMMAND_CUSTOM_OUTPUT_SAS_PARAMETER_NAME = "customOutputJsonSAS";
         public static readonly string COULD_CLEANUP_TAG_NAME = "CouldCleanup";
-        public static readonly string ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS = "EnforceArchitectureTypeForExtensions";
+        public static readonly string TAGS_ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS = "EnforceArchitectureTypeForExtensions";
+        public static readonly string TAGS_MUST_NOT_REUSE_PREPROVISIONED_VM = "MustNotReusePreprovisionedVM";
         public const string INSTALL_LINUX_GUEST_PROXY_AGENT_PACKAGE_SCRIPT_NAME = "InstallGuestProxyAgentPackage.sh";
         public static readonly string GUEST_PROXY_AGENT_E2E_ACCESS_TOKEN_ENV = "GuestProxyAgentE2EAccessToken";
         public static readonly string GUEST_PROXY_AGENT_E2E_ACCESS_TOKEN_STORAGE_ACCOUNT_ENV = "GuestProxyAgentE2EAccessTokenForStorageAccount";
@@ -53,7 +54,7 @@ namespace GuestProxyAgentTest.Utilities
 
         public static bool IS_WINDOWS()
         {
-           return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/Constants.cs
@@ -23,6 +23,7 @@ namespace GuestProxyAgentTest.Utilities
         public static readonly string RUNCOMMAND_ERROR_OUTPUT_FILE_NAME = "runCommandErr.txt";
         public static readonly string RUNCOMMAND_CUSTOM_OUTPUT_SAS_PARAMETER_NAME = "customOutputJsonSAS";
         public static readonly string COULD_CLEANUP_TAG_NAME = "CouldCleanup";
+        public static readonly string ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS = "EnforceArchitectureTypeForExtensions";
         public const string INSTALL_LINUX_GUEST_PROXY_AGENT_PACKAGE_SCRIPT_NAME = "InstallGuestProxyAgentPackage.sh";
         public static readonly string GUEST_PROXY_AGENT_E2E_ACCESS_TOKEN_ENV = "GuestProxyAgentE2EAccessToken";
         public static readonly string GUEST_PROXY_AGENT_E2E_ACCESS_TOKEN_STORAGE_ACCOUNT_ENV = "GuestProxyAgentE2EAccessTokenForStorageAccount";

--- a/e2etest/GuestProxyAgentTest/Utilities/TestCommonUtilities.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/TestCommonUtilities.cs
@@ -16,9 +16,9 @@ namespace GuestProxyAgentTest.Utilities
         /// <param name="guestProxyAgentZipFilePath"></param>
         /// <param name="testConfigFilePath"></param>
         /// <param name="testResultFolder"></param>
-        public static void TestSetup(string guestProxyAgentZipFilePath, string testConfigFilePath, string testResultFolder)
+        public static void TestSetup(string guestProxyAgentZipFilePath, string testConfigFilePath, string testResultFolder, string proxyAgentVersion)
         {
-            TestSetting.Init(YamlUtils.DeserializeYaml<TestConfig>(testConfigFilePath), guestProxyAgentZipFilePath, testResultFolder);
+            TestSetting.Init(YamlUtils.DeserializeYaml<TestConfig>(testConfigFilePath), guestProxyAgentZipFilePath, testResultFolder, proxyAgentVersion);
             StorageHelper.Init(TestSetting.Instance.tenantId, TestSetting.Instance.appClientId);
             VMHelper.Init(TestSetting.Instance.tenantId, TestSetting.Instance.appClientId, TestSetting.Instance.subscriptionId);
 

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -172,7 +172,12 @@ namespace GuestProxyAgentTest.Utilities
                     Product = this.testScenarioSetting.VMImageDetails.Offer,
                 };
             }
-            
+
+            if (this.testScenarioSetting.VMImageDetails.IsArm64)
+            {
+                vmData.Tags.Add(Constants.ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS, "true");
+            }
+
             return vmData;
         }
 

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -175,7 +175,9 @@ namespace GuestProxyAgentTest.Utilities
 
             if (this.testScenarioSetting.VMImageDetails.IsArm64)
             {
-                vmData.Tags.Add(Constants.ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS, "true");
+                // workarounds to use ARM64 VM Extension
+                vmData.Tags.Add(Constants.TAGS_ENFORCE_ARCHITECTURE_TYPE_FOR_EXTENSIONS, "true");
+                vmData.Tags.Add(Constants.TAGS_MUST_NOT_REUSE_PREPROVISIONED_VM, "true");
             }
 
             return vmData;

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -397,6 +397,11 @@ impl KeyKeeper {
             }
 
             let state = status.get_secure_channel_state();
+            let secure_channel_state_updated = self
+                .key_keeper_shared_state
+                .update_current_secure_channel_state(state.to_string())
+                .await;
+
             // check if need fetch the key
             if state != DISABLE_STATE
                 && (status.keyGuid.is_none()  // key has not latched yet
@@ -523,12 +528,8 @@ impl KeyKeeper {
                 }
             }
 
-            // update the current secure channel state if different
-            match self
-                .key_keeper_shared_state
-                .update_current_secure_channel_state(state.to_string())
-                .await
-            {
+            // update redirect policy if current secure channel state updated
+            match secure_channel_state_updated {
                 Ok(updated) => {
                     if updated {
                         // update the redirector policy map


### PR DESCRIPTION
- Add tag { "EnforceArchitectureTypeForExtensions": "true" } for Arm64 VMs
- Accept ProxyAgentVersion from E2E test program as it could not run windows arm64 command `GuestProxyAgent.exe --version` at windows amd64 build container image
- Add ARM64 ProxyAgentExtension test coverage in Win11, Ubuntu 24 and Azure Linux3