### PR TITLE
Windows GPA to close the process handler using `close_process_handler`

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,6 +34,7 @@ ccbf
 cicd
 cimv
 cla
+closehandle
 cmds
 codeofconduct
 codeql
@@ -120,6 +121,7 @@ gpalinuxdev
 gpawindev
 guestproxyagentmsis
 guiddef
+handleapi
 hklm
 hlist
 hostga
@@ -195,6 +197,7 @@ ntdll
 NTSTATUS
 onscreen
 onebranch
+openprocess
 oneshot
 opencode
 opensource
@@ -213,6 +216,7 @@ prefmaxlen
 preprovisioned
 printk
 PROCESSINFOCLASS
+processthreadsapi
 proxyagent
 proxyagentextensionvalidation
 proxyagentvalidation

--- a/build.cmd
+++ b/build.cmd
@@ -243,7 +243,8 @@ xcopy /Y %out_dir%\proxy_agent_setup.pdb %out_package_dir%\
 
 echo ======= copy to ProxyAgent folder
 xcopy /Y %out_dir%\azure-proxy-agent.exe %out_package_proxyagent_dir%\GuestProxyAgent.exe*
-xcopy /Y %out_dir%\azure_proxy_agent.pdb %out_package_proxyagent_dir%\GuestProxyAgent.pdb*
+REM do NOT rename pdb file, as it is used by the debugger to load the symbols automatically
+xcopy /Y %out_dir%\azure_proxy_agent.pdb %out_package_proxyagent_dir%\
 xcopy /Y %out_dir%\GuestProxyAgent.json %out_package_proxyagent_dir%\
 
 SET out_package_proxyagent_extension_dir=%out_package_dir%\ProxyAgent_Extension
@@ -254,7 +255,7 @@ for %%F in (%extension_src_path%\*.cmd) do (
     echo Found file: %%F
     xcopy /Y %%F %out_package_proxyagent_extension_dir%\
 )
-xcopy /Y %out_dir%\ProxyAgentExt.exe %out_package_proxyagent_extension_dir%\
+xcopy /Y %out_dir%\ProxyAgentExt.* %out_package_proxyagent_extension_dir%\
 
 echo ======= copy e2e test project to Package folder
 SET out_package_e2etest_dir=%out_package_dir%\e2etest

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -181,6 +181,10 @@ impl Process {
                     println!("Failed to query basic process info: {e}");
                 }
             }
+            // close the handle
+            if let Err(e) = windows::close_process_handler(handler) {
+                println!("Failed to close process handler: {e}");
+            }
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
Windows GPA: `Process""from_pid` leaks process handles, as the caller of `get_process_handler` must close the process handle when it is no longer needed to avoid resource leaks.
 https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess