### PR TITLE
Quick fix from Linux RPM Spec work.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt clippy
       - run: cargo fmt --all -- --check -l
       - name: Clippy
         run: cargo clippy -- -D warnings
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt clippy
+      - run: cargo fmt --all -- --check -l
       - name: Clippy
         run: cargo clippy -- -D warnings
       - name: cargo-audit

--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -3,6 +3,9 @@ name = "azure-proxy-agent"
 version = "9.9.9"      # always 3-number version
 edition = "2021"
 build = "build.rs"
+readme = "README.md"
+description = "Microsoft Azure Guest Proxy Agent"
+license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -184,7 +184,7 @@ pub fn get_files(dir: &Path) -> Result<Vec<PathBuf>> {
 /// ```rust
 /// use std::path::PathBuf;
 /// use proxy_agent_shared::misc_helpers;
-/// let dir = PathBuf::from("C:\\");
+/// let dir = PathBuf::from(".");
 /// let search_regex_pattern = r"^(.*\.log)$";  // search for files with .log extension
 /// let files = misc_helpers::search_files(&dir, search_regex_pattern).unwrap();
 ///


### PR DESCRIPTION
- Add more settings in Cargo.toml for RPM SPEC requirements
- Fixed doc test for linux environment
- explicit install the clippy in rust v1.90