### PR TITLE
Set tokio runtime worker threads between 2 and 10 instead default to number of cpus.

### DIFF
--- a/proxy_agent/src/common/helpers.rs
+++ b/proxy_agent/src/common/helpers.rs
@@ -62,6 +62,17 @@ pub fn get_long_os_version() -> String {
     CURRENT_OS_INFO.1.to_string()
 }
 
+/// Determine the number of worker threads for the tokio runtime
+/// Limit the number of worker threads to a maximum of 10 and minimum of 2  
+static TOKIO_RUNTIME_WORKER_THREADS: Lazy<usize> = Lazy::new(|| {
+    let cpu_count = get_cpu_count();
+    cpu_count.clamp(2, 10)
+});
+
+pub fn get_worker_threads() -> usize {
+    *TOKIO_RUNTIME_WORKER_THREADS
+}
+
 // replace xml escape characters
 pub fn xml_escape(s: String) -> String {
     s.replace('&', "&amp;")

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -44,10 +44,11 @@ pub async fn start_service(shared_state: SharedState) {
     }
 
     let start_message = format!(
-        "============== GuestProxyAgent ({}) is starting on {}({}), elapsed: {}",
+        "============== GuestProxyAgent ({}) is starting on {}({}) with {} worker threads, elapsed: {}",
         proxy_agent_shared::misc_helpers::get_current_version(),
         helpers::get_long_os_version(),
         helpers::get_cpu_arch(),
+        helpers::get_worker_threads(),
         helpers::get_elapsed_time_in_millisec()
     );
     logger::write_information(start_message.clone());


### PR DESCRIPTION
tokio runtime defaults the number of worker threads to the number of cpus; if the Azure VM is extra-large (372 vCPUs), it may spin up unnecessary worker threads and eat the system cpu cycles.