### PR TITLE
set gpa service resource limits

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -145,6 +145,7 @@ INVM
 Ioctl
 iusr
 jetbrains
+JOBOBJECT
 jobsjob
 joutvhu
 JScript
@@ -320,10 +321,12 @@ vflji
 vhd
 vmagentlog
 VMGA
+vmhwm
 VMId
 vmlinux
 vmr
 vmrcs
+vmrss
 vms
 vns
 VTeam
@@ -351,6 +354,7 @@ wireserverand
 wireserverandimds
 WMI
 workarounds
+WORKINGSET
 WORKDIR
 WScript
 wsf

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -188,7 +188,7 @@ impl Process {
                 }
             }
             // close the handle
-            if let Err(e) = proxy_agent_shared::windows::close_process_handler(handler) {
+            if let Err(e) = proxy_agent_shared::windows::close_handler(handler) {
                 println!("Failed to close process handler: {e}");
             }
         }

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -165,10 +165,16 @@ impl Process {
         let (process_full_path, cmd);
         #[cfg(windows)]
         {
-            let handler = windows::get_process_handler(pid).unwrap_or_else(|e| {
-                println!("Failed to get process handler: {e}");
-                0
-            });
+            use windows_sys::Win32::System::Threading::{
+                PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+            };
+            
+            let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
+            let handler = proxy_agent_shared::windows::get_process_handler(pid, options)
+                .unwrap_or_else(|e| {
+                    println!("Failed to get process handler: {e}");
+                    0
+                });
             let base_info = windows::query_basic_process_info(handler);
             match base_info {
                 Ok(_) => {
@@ -182,7 +188,7 @@ impl Process {
                 }
             }
             // close the handle
-            if let Err(e) = windows::close_process_handler(handler) {
+            if let Err(e) = proxy_agent_shared::windows::close_process_handler(handler) {
                 println!("Failed to close process handler: {e}");
             }
         }

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -168,7 +168,7 @@ impl Process {
             use windows_sys::Win32::System::Threading::{
                 PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
             };
-            
+
             let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
             let handler = proxy_agent_shared::windows::get_process_handler(pid, options)
                 .unwrap_or_else(|e| {

--- a/proxy_agent_extension/src/windows/HandlerManifest.json
+++ b/proxy_agent_extension/src/windows/HandlerManifest.json
@@ -18,8 +18,7 @@
             "memoryQuotaMB":  75
         }, 
         {
-            "name": "GuestProxyAgent", 
-            "memoryQuotaMB":  17
+            "name": "GuestProxyAgent"
         }]
     }
 }]

--- a/proxy_agent_extension/src/windows/HandlerManifest.json
+++ b/proxy_agent_extension/src/windows/HandlerManifest.json
@@ -19,7 +19,6 @@
         }, 
         {
             "name": "GuestProxyAgent", 
-            "cpuQuotaPercentage": 15, 
             "memoryQuotaMB":  17
         }]
     }

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -54,6 +54,7 @@ features = [
   "Win32_System_Diagnostics_Debug",
   "Win32_System_SystemInformation",
   "Win32_Storage_FileSystem",
+  "Win32_System_JobObjects",
 ]
 
 [target.'cfg(not(windows))'.dependencies]

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -143,7 +143,7 @@ pub fn set_cpu_quota(service_name: &str, cpu_quota: u16) -> Result<()> {
         vec![
             "set-property",
             service_name,
-            &format!("CPUQuota={}%", cpu_quota),
+            &format!("CPUQuota={cpu_quota}%"),
         ],
         -1,
     ) {

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -134,6 +134,35 @@ pub fn compute_signature(hex_encoded_key: &str, input_to_sign: &[u8]) -> Result<
     }
 }
 
+
+/// Set the CPU quota for a service.
+/// The CPU quota is set in percentage of the one CPU time available.
+/// For example, if the total CPU time available is 100%, setting the CPU quota to 50% will limit the service to use up to 50% of the total CPU time available.
+pub fn set_cpu_quota(service_name: &str, cpu_quota: u16) -> Result<()> {
+    match misc_helpers::execute_command(
+        "systemctl",
+        vec![
+            "set-property",
+            service_name,
+            &format!("CPUQuota={}%", cpu_quota),
+        ],
+        -1,
+    ) {
+        Ok(result) => {
+            logger_manager::write_warn(format!(
+                "Successfully set {service_name} CPUQuota to {cpu_quota}% with result: {}",
+                result.message()
+            ));
+        }
+        Err(e) => {
+            let message = format!("Failed to set {service_name} CPUQuota with error: {e}");
+            logger_manager::write_err(message);
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::misc_helpers;

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -134,7 +134,6 @@ pub fn compute_signature(hex_encoded_key: &str, input_to_sign: &[u8]) -> Result<
     }
 }
 
-
 /// Set the CPU quota for a service.
 /// The CPU quota is set in percentage of the one CPU time available.
 /// For example, if the total CPU time available is 100%, setting the CPU quota to 50% will limit the service to use up to 50% of the total CPU time available.

--- a/proxy_agent_shared/src/linux.rs
+++ b/proxy_agent_shared/src/linux.rs
@@ -138,7 +138,7 @@ pub fn compute_signature(hex_encoded_key: &str, input_to_sign: &[u8]) -> Result<
 /// The CPU quota is set in percentage of the one CPU time available.
 /// For example, if the total CPU time available is 100%, setting the CPU quota to 50% will limit the service to use up to 50% of the total CPU time available.
 pub fn set_cpu_quota(service_name: &str, cpu_quota: u16) -> Result<()> {
-    match misc_helpers::execute_command(
+    misc_helpers::execute_command(
         "systemctl",
         vec![
             "set-property",
@@ -146,20 +146,32 @@ pub fn set_cpu_quota(service_name: &str, cpu_quota: u16) -> Result<()> {
             &format!("CPUQuota={cpu_quota}%"),
         ],
         -1,
-    ) {
-        Ok(result) => {
-            logger_manager::write_warn(format!(
-                "Successfully set {service_name} CPUQuota to {cpu_quota}% with result: {}",
-                result.message()
-            ));
-        }
-        Err(e) => {
-            let message = format!("Failed to set {service_name} CPUQuota with error: {e}");
-            logger_manager::write_err(message);
-            return Err(e);
+    )?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct MemStatus {
+    pub vmrss_kb: Option<u64>,
+    pub vmhwm_kb: Option<u64>,
+}
+
+pub fn read_proc_memory_status(pid: u32) -> Result<MemStatus> {
+    let s = fs::read_to_string(format!("/proc/{pid}/status"))?;
+    let mut vmrss_kb = None;
+    let mut vmhwm_kb = None;
+    for line in s.lines() {
+        if line.starts_with("VmRSS:") {
+            // Format: "VmRSS:\t  12345 kB"
+            let val = line.split_whitespace().nth(1).and_then(|x| x.parse().ok());
+            vmrss_kb = val;
+        } else if line.starts_with("VmHWM:") {
+            let val = line.split_whitespace().nth(1).and_then(|x| x.parse().ok());
+            vmhwm_kb = val;
         }
     }
-    Ok(())
+    Ok(MemStatus { vmrss_kb, vmhwm_kb })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
1. Set the resource limits before launching the lower priority tasks.
2. Set the cpu limits for Linux GPA service and monitor memory usage.
3. Set the CPU and memory limits for Windows GPA service.
4. Removed the GPA service resource limits from its windows VM Extension