### PR TITLE
proxy server async improvements

### DIFF
--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -10,7 +10,6 @@ use crate::proxy::Claims;
 use crate::redirector::{self, AuditEntry};
 use crate::shared_state::proxy_server_wrapper::ProxyServerSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
-use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::client::conn::http1;
 use hyper::Request;
@@ -23,7 +22,8 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::Mutex;
 
-pub type RequestBody = Full<Bytes>;
+pub type RequestBody =
+    http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 struct Client {
     sender: http1::SendRequest<RequestBody>,
 }

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -744,8 +744,8 @@ impl ProxyServer {
             "Converting response to the client format.".to_string(),
         );
         let (head, body) = proxy_response.into_parts();
-        let response_body = Self::read_body_bytes(body).await?;
-        let mut response = Response::from_parts(head, hyper_client::full_body(response_body));
+        // Stream the response body directly without buffering
+        let mut response = Response::from_parts(head, body.boxed());
 
         http_connection_context.log(LoggerLevel::Trace, "Adding proxy agent header.".to_string());
         // insert default x-ms-azure-host-authorization header to let the client know it is through proxy agent

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -25,6 +25,7 @@ use super::proxy_connection::{ConnectionLogger, HttpConnectionContext, TcpConnec
 use crate::common::{constants, error::Error, helpers, logger, result::Result};
 use crate::provision;
 use crate::proxy::{proxy_authorizer, proxy_summary::ProxySummary, Claims};
+use crate::shared_state::access_control_wrapper::AccessControlSharedState;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::shared_state::provision_wrapper::ProvisionSharedState;
@@ -69,6 +70,7 @@ pub struct ProxyServer {
     agent_status_shared_state: AgentStatusSharedState,
     redirector_shared_state: RedirectorSharedState,
     proxy_server_shared_state: ProxyServerSharedState,
+    access_control_shared_state: AccessControlSharedState,
 }
 
 impl ProxyServer {
@@ -82,6 +84,7 @@ impl ProxyServer {
             agent_status_shared_state: shared_state.get_agent_status_shared_state(),
             redirector_shared_state: shared_state.get_redirector_shared_state(),
             proxy_server_shared_state: shared_state.get_proxy_server_shared_state(),
+            access_control_shared_state: shared_state.get_access_control_shared_state(),
         }
     }
 
@@ -468,7 +471,7 @@ impl ProxyServer {
         let access_control_rules = match proxy_authorizer::get_access_control_rules(
             ip.to_string(),
             port,
-            self.key_keeper_shared_state.clone(),
+            self.access_control_shared_state.clone(),
         )
         .await
         {

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -55,9 +55,11 @@ use crate::provision;
 use crate::proxy::authorization_rules::AuthorizationMode;
 use crate::shared_state::access_control_wrapper::AccessControlSharedState;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
+use crate::shared_state::connection_summary_wrapper::ConnectionSummarySharedState;
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
+use crate::shared_state::EventThreadsSharedState;
 use crate::shared_state::SharedState;
 use proxy_agent_shared::common_state::CommonState;
 use proxy_agent_shared::logger::LoggerLevel;
@@ -114,6 +116,7 @@ pub struct Redirector {
     common_state: CommonState,
     provision_shared_state: ProvisionSharedState,
     access_control_shared_state: AccessControlSharedState,
+    connection_summary_shared_state: ConnectionSummarySharedState,
 }
 
 impl Redirector {
@@ -127,6 +130,7 @@ impl Redirector {
             agent_status_shared_state: shared_state.get_agent_status_shared_state(),
             redirector_shared_state: shared_state.get_redirector_shared_state(),
             access_control_shared_state: shared_state.get_access_control_shared_state(),
+            connection_summary_shared_state: shared_state.get_connection_summary_shared_state(),
         }
     }
 
@@ -278,13 +282,14 @@ impl Redirector {
         }
 
         // report redirector ready for provision
-        provision::redirector_ready(
-            self.cancellation_token.clone(),
-            self.common_state.clone(),
-            self.key_keeper_shared_state.clone(),
-            self.provision_shared_state.clone(),
-            self.agent_status_shared_state.clone(),
-        )
+        provision::redirector_ready(EventThreadsSharedState {
+            cancellation_token: self.cancellation_token.clone(),
+            common_state: self.common_state.clone(),
+            key_keeper_shared_state: self.key_keeper_shared_state.clone(),
+            provision_shared_state: self.provision_shared_state.clone(),
+            agent_status_shared_state: self.agent_status_shared_state.clone(),
+            connection_summary_shared_state: self.connection_summary_shared_state.clone(),
+        })
         .await;
 
         Ok(())

--- a/proxy_agent/src/shared_state.rs
+++ b/proxy_agent/src/shared_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+pub mod access_control_wrapper;
 pub mod agent_status_wrapper;
 pub mod key_keeper_wrapper;
 pub mod provision_wrapper;
@@ -46,6 +47,8 @@ pub struct SharedState {
     redirector_shared_state: redirector_wrapper::RedirectorSharedState,
     /// The sender for the proxy server module
     proxy_server_shared_state: proxy_server_wrapper::ProxyServerSharedState,
+    /// The sender for the access control module
+    access_control_shared_state: access_control_wrapper::AccessControlSharedState,
 }
 
 impl SharedState {
@@ -58,6 +61,8 @@ impl SharedState {
             agent_status_shared_state: agent_status_wrapper::AgentStatusSharedState::start_new(),
             redirector_shared_state: redirector_wrapper::RedirectorSharedState::start_new(),
             proxy_server_shared_state: proxy_server_wrapper::ProxyServerSharedState::start_new(),
+            access_control_shared_state:
+                access_control_wrapper::AccessControlSharedState::start_new(),
         }
     }
 
@@ -83,6 +88,12 @@ impl SharedState {
 
     pub fn get_proxy_server_shared_state(&self) -> proxy_server_wrapper::ProxyServerSharedState {
         self.proxy_server_shared_state.clone()
+    }
+
+    pub fn get_access_control_shared_state(
+        &self,
+    ) -> access_control_wrapper::AccessControlSharedState {
+        self.access_control_shared_state.clone()
     }
 
     pub fn get_cancellation_token(&self) -> CancellationToken {

--- a/proxy_agent/src/shared_state.rs
+++ b/proxy_agent/src/shared_state.rs
@@ -3,6 +3,7 @@
 
 pub mod access_control_wrapper;
 pub mod agent_status_wrapper;
+pub mod connection_summary_wrapper;
 pub mod key_keeper_wrapper;
 pub mod provision_wrapper;
 pub mod proxy_server_wrapper;
@@ -49,6 +50,8 @@ pub struct SharedState {
     proxy_server_shared_state: proxy_server_wrapper::ProxyServerSharedState,
     /// The sender for the access control module
     access_control_shared_state: access_control_wrapper::AccessControlSharedState,
+    /// The sender for the connection summary module
+    connection_summary_shared_state: connection_summary_wrapper::ConnectionSummarySharedState,
 }
 
 impl SharedState {
@@ -63,6 +66,8 @@ impl SharedState {
             proxy_server_shared_state: proxy_server_wrapper::ProxyServerSharedState::start_new(),
             access_control_shared_state:
                 access_control_wrapper::AccessControlSharedState::start_new(),
+            connection_summary_shared_state:
+                connection_summary_wrapper::ConnectionSummarySharedState::start_new(),
         }
     }
 
@@ -96,11 +101,44 @@ impl SharedState {
         self.access_control_shared_state.clone()
     }
 
+    pub fn get_connection_summary_shared_state(
+        &self,
+    ) -> connection_summary_wrapper::ConnectionSummarySharedState {
+        self.connection_summary_shared_state.clone()
+    }
+
     pub fn get_cancellation_token(&self) -> CancellationToken {
         self.cancellation_token.clone()
     }
 
     pub fn cancel_cancellation_token(&self) {
         self.cancellation_token.cancel();
+    }
+}
+
+/// The shared state for the lower priority event threads, including event logger & reader tasks and status reporting task
+/// It contains the cancellation token, which is used to cancel the event threads when the agent is stopped.
+/// It also contains the senders for the key keeper, provision, agent status, and connection summary modules.
+/// This struct contains multiple shared states to avoid too_many_arguments error from `cargo clippy`.
+#[derive(Clone)]
+pub struct EventThreadsSharedState {
+    pub cancellation_token: CancellationToken,
+    pub common_state: CommonState,
+    pub key_keeper_shared_state: key_keeper_wrapper::KeyKeeperSharedState,
+    pub provision_shared_state: provision_wrapper::ProvisionSharedState,
+    pub agent_status_shared_state: agent_status_wrapper::AgentStatusSharedState,
+    pub connection_summary_shared_state: connection_summary_wrapper::ConnectionSummarySharedState,
+}
+
+impl EventThreadsSharedState {
+    pub fn new(shared_state: &SharedState) -> Self {
+        EventThreadsSharedState {
+            cancellation_token: shared_state.get_cancellation_token(),
+            common_state: shared_state.get_common_state(),
+            key_keeper_shared_state: shared_state.get_key_keeper_shared_state(),
+            provision_shared_state: shared_state.get_provision_shared_state(),
+            agent_status_shared_state: shared_state.get_agent_status_shared_state(),
+            connection_summary_shared_state: shared_state.get_connection_summary_shared_state(),
+        }
     }
 }

--- a/proxy_agent/src/shared_state/access_control_wrapper.rs
+++ b/proxy_agent/src/shared_state/access_control_wrapper.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+use crate::common::error::Error;
+use crate::common::logger;
+use crate::common::result::Result;
+use crate::key_keeper::key::AuthorizationItem;
+use crate::proxy::authorization_rules::ComputedAuthorizationItem;
+use tokio::sync::{mpsc, oneshot};
+
+/// The AccessControlAction enum represents the actions that can be performed on the Access Control
+enum AccessControlAction {
+    SetWireServer {
+        rules: Option<ComputedAuthorizationItem>,
+        response: oneshot::Sender<()>,
+    },
+    GetWireServer {
+        response: oneshot::Sender<Option<ComputedAuthorizationItem>>,
+    },
+    SetImds {
+        rules: Option<ComputedAuthorizationItem>,
+        response: oneshot::Sender<()>,
+    },
+    GetImds {
+        response: oneshot::Sender<Option<ComputedAuthorizationItem>>,
+    },
+    SetHostGA {
+        rules: Option<ComputedAuthorizationItem>,
+        response: oneshot::Sender<()>,
+    },
+    GetHostGA {
+        response: oneshot::Sender<Option<ComputedAuthorizationItem>>,
+    },
+}
+
+/// The AccessControlState struct is used to send actions to the Access Control Rules related shared state fields
+#[derive(Clone, Debug)]
+pub struct AccessControlSharedState(mpsc::Sender<AccessControlAction>);
+
+impl AccessControlSharedState {
+    pub fn start_new() -> Self {
+        let (sender, mut receiver) = mpsc::channel(100);
+
+        tokio::spawn(async move {
+            // The authorization rules for the WireServer endpoints
+            let mut wireserver_rules: Option<ComputedAuthorizationItem> = None;
+            // The authorization rules for the IMDS endpoints
+            let mut imds_rules: Option<ComputedAuthorizationItem> = None;
+            // The authorization rules for the HostGAPlugin endpoints
+            let mut hostga_rules: Option<ComputedAuthorizationItem> = None;
+            loop {
+                match receiver.recv().await {
+                    Some(AccessControlAction::SetWireServer { rules, response }) => {
+                        wireserver_rules = rules;
+                        if response.send(()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::SetWireServer"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(AccessControlAction::GetWireServer { response }) => {
+                        if response.send(wireserver_rules.clone()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::GetWireServer"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(AccessControlAction::SetImds { rules, response }) => {
+                        imds_rules = rules;
+                        if response.send(()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::SetImds"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(AccessControlAction::GetImds { response }) => {
+                        if response.send(imds_rules.clone()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::GetImds"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(AccessControlAction::SetHostGA { rules, response }) => {
+                        hostga_rules = rules;
+                        if response.send(()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::SetHostGA"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Some(AccessControlAction::GetHostGA { response }) => {
+                        if response.send(hostga_rules.clone()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to AccessControlAction::GetHostGA"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    None => break,
+                }
+            }
+        });
+
+        Self(sender)
+    }
+
+    pub async fn set_wireserver_rules(&self, rules: Option<AuthorizationItem>) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::SetWireServer {
+                rules: rules.map(ComputedAuthorizationItem::from_authorization_item),
+                response,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "AccessControlAction::SetWireServer".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::GetWireServer".to_string(), e))
+    }
+
+    pub async fn get_wireserver_rules(&self) -> Result<Option<ComputedAuthorizationItem>> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::GetWireServer { response })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "AccessControlAction::GetWireServer".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::GetWireServer".to_string(), e))
+    }
+
+    pub async fn set_imds_rules(&self, rules: Option<AuthorizationItem>) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::SetImds {
+                rules: rules.map(ComputedAuthorizationItem::from_authorization_item),
+                response,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError("AccessControlAction::SetImds".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::SetImds".to_string(), e))
+    }
+
+    pub async fn get_imds_rules(&self) -> Result<Option<ComputedAuthorizationItem>> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::GetImds { response })
+            .await
+            .map_err(|e| {
+                Error::SendError("AccessControlAction::GetImds".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::GetImds".to_string(), e))
+    }
+
+    pub async fn set_hostga_rules(&self, rules: Option<AuthorizationItem>) -> Result<()> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::SetHostGA {
+                rules: rules.map(ComputedAuthorizationItem::from_authorization_item),
+                response,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError("AccessControlAction::SetHostGA".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::GetHostGA".to_string(), e))
+    }
+
+    pub async fn get_hostga_rules(&self) -> Result<Option<ComputedAuthorizationItem>> {
+        let (response, receiver) = oneshot::channel();
+        self.0
+            .send(AccessControlAction::GetHostGA { response })
+            .await
+            .map_err(|e| {
+                Error::SendError("AccessControlAction::GetHostGA".to_string(), e.to_string())
+            })?;
+        receiver
+            .await
+            .map_err(|e| Error::RecvError("AccessControlAction::GetHostGA".to_string(), e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::proxy::authorization_rules;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_access_control_shared_state() {
+        let access_control = AccessControlSharedState::start_new();
+
+        // test WireServer Rule
+        let rule_id = "test_rule_id";
+        let rules = AuthorizationItem {
+            defaultAccess: "allow".to_string(),
+            mode: "audit".to_string(),
+            id: rule_id.to_string(),
+            rules: None,
+        };
+        access_control
+            .set_wireserver_rules(Some(rules.clone()))
+            .await
+            .unwrap();
+        let retrieved_rules = access_control.get_wireserver_rules().await.unwrap();
+        assert!(retrieved_rules.is_some());
+        let retrieved_rules = retrieved_rules.unwrap();
+        assert_eq!(rules.id, retrieved_rules.id);
+        assert_eq!(true, retrieved_rules.defaultAllowed);
+        assert_eq!(
+            authorization_rules::AuthorizationMode::Audit,
+            retrieved_rules.mode
+        );
+        assert_eq!(0, retrieved_rules.privilegeAssignments.len());
+        assert_eq!(0, retrieved_rules.privileges.len());
+        assert_eq!(0, retrieved_rules.identities.len());
+
+        // test IMDS Rule
+        let rules = AuthorizationItem {
+            defaultAccess: "deny".to_string(),
+            mode: "enforce".to_string(),
+            id: rule_id.to_string(),
+            rules: None,
+        };
+        access_control
+            .set_imds_rules(Some(rules.clone()))
+            .await
+            .unwrap();
+        let retrieved_rules = access_control.get_imds_rules().await.unwrap();
+        assert!(retrieved_rules.is_some());
+        let retrieved_rules = retrieved_rules.unwrap();
+        assert_eq!(rules.id, retrieved_rules.id);
+        assert_eq!(false, retrieved_rules.defaultAllowed);
+        assert_eq!(
+            authorization_rules::AuthorizationMode::Enforce,
+            retrieved_rules.mode
+        );
+    }
+}

--- a/proxy_agent/src/shared_state/agent_status_wrapper.rs
+++ b/proxy_agent/src/shared_state/agent_status_wrapper.rs
@@ -3,19 +3,14 @@
 
 //! This module contains the logic to interact with the proxy agent status.
 //! The proxy agent status contains the 'state' and 'status message' of the key keeper, telemetry reader, telemetry logger, redirector, and proxy server modules.
-//! The proxy agent status contains the 'connection summary' of the proxy server.
-//! The proxy agent status contains the 'failed connection summary' of the proxy server.
 //! The proxy agent status contains the 'connection count' of the proxy server.
 
+use crate::common::error::Error;
 use crate::common::logger;
 use crate::common::result::Result;
-use crate::{common::error::Error, proxy::proxy_summary::ProxySummary};
 use proxy_agent_shared::logger::LoggerLevel;
-use proxy_agent_shared::proxy_agent_aggregate_status::{
-    ModuleState, ProxyAgentDetailStatus, ProxyConnectionSummary,
-};
+use proxy_agent_shared::proxy_agent_aggregate_status::{ModuleState, ProxyAgentDetailStatus};
 use proxy_agent_shared::telemetry::event_logger;
-use std::collections::{hash_map, HashMap};
 use tokio::sync::{mpsc, oneshot};
 
 const MAX_STATUS_MESSAGE_LENGTH: usize = 1024;
@@ -38,23 +33,6 @@ enum AgentStatusAction {
     GetState {
         module: AgentStatusModule,
         response: oneshot::Sender<ModuleState>,
-    },
-    AddOneConnectionSummary {
-        summary: ProxySummary,
-        response: oneshot::Sender<()>,
-    },
-    AddOneFailedConnectionSummary {
-        summary: ProxySummary,
-        response: oneshot::Sender<()>,
-    },
-    GetAllConnectionSummary {
-        response: oneshot::Sender<Vec<ProxyConnectionSummary>>,
-    },
-    GetAllFailedConnectionSummary {
-        response: oneshot::Sender<Vec<ProxyConnectionSummary>>,
-    },
-    ClearAllSummary {
-        response: oneshot::Sender<()>,
     },
     GetConnectionCount {
         response: oneshot::Sender<u128>,
@@ -97,11 +75,6 @@ impl AgentStatusSharedState {
             let mut proxy_agent_status_state = ModuleState::UNKNOWN;
             let mut proxy_agent_status_message = super::UNKNOWN_STATUS_MESSAGE.to_string();
 
-            // The proxy connection summary from the proxy
-            let mut proxy_summary: HashMap<String, ProxyConnectionSummary> = HashMap::new();
-            // The failed authenticate summary from the proxy
-            let mut failed_authenticate_summary: HashMap<String, ProxyConnectionSummary> =
-                HashMap::new();
             // The proxied connection count for the listener
             let mut tcp_connection_count: u128 = 0;
             let mut http_connection_count: u128 = 0;
@@ -227,68 +200,6 @@ impl AgentStatusSharedState {
                             ));
                         }
                     }
-                    AgentStatusAction::AddOneConnectionSummary { summary, response } => {
-                        let key = summary.to_key_string();
-                        if let hash_map::Entry::Vacant(e) = proxy_summary.entry(key.clone()) {
-                            e.insert(summary.into());
-                        } else if let Some(connection_summary) = proxy_summary.get_mut(&key) {
-                            //increase_count(connection_summary);
-                            connection_summary.count += 1;
-                        }
-                        if response.send(()).is_err() {
-                            logger::write_warning("Failed to send response to AgentStatusAction::AddOneConnectionSummary".to_string());
-                        }
-                    }
-                    AgentStatusAction::AddOneFailedConnectionSummary { summary, response } => {
-                        let key = summary.to_key_string();
-                        if let hash_map::Entry::Vacant(e) =
-                            failed_authenticate_summary.entry(key.clone())
-                        {
-                            e.insert(summary.into());
-                        } else if let Some(connection_summary) =
-                            failed_authenticate_summary.get_mut(&key)
-                        {
-                            //increase_count(connection_summary);
-                            connection_summary.count += 1;
-                        }
-                        if response.send(()).is_err() {
-                            logger::write_warning("Failed to send response to AgentStatusAction::AddOneFailedConnectionSummary".to_string());
-                        }
-                    }
-                    AgentStatusAction::GetAllConnectionSummary { response } => {
-                        let mut copy_summary: Vec<ProxyConnectionSummary> = Vec::new();
-                        for (_, connection_summary) in proxy_summary.iter() {
-                            copy_summary.push(connection_summary.clone());
-                        }
-                        if let Err(summary) = response.send(copy_summary) {
-                            logger::write_warning(format!(
-                                "Failed to send response to AgentStatusAction::GetAllConnectionSummary with summary count '{:?}'",
-                                summary.len()
-                            ));
-                        }
-                    }
-                    AgentStatusAction::GetAllFailedConnectionSummary { response } => {
-                        let mut copy_summary: Vec<ProxyConnectionSummary> = Vec::new();
-                        for (_, connection_summary) in failed_authenticate_summary.iter() {
-                            copy_summary.push(connection_summary.clone());
-                        }
-                        if let Err(summary) = response.send(copy_summary) {
-                            logger::write_warning(format!(
-                                "Failed to send response to AgentStatusAction::GetAllFailedConnectionSummary with summary count '{:?}'",
-                                summary.len()
-                            ));
-                        }
-                    }
-                    AgentStatusAction::ClearAllSummary { response } => {
-                        proxy_summary.clear();
-                        failed_authenticate_summary.clear();
-                        if response.send(()).is_err() {
-                            logger::write_warning(
-                                "Failed to send response to AgentStatusAction::ClearAllSummary"
-                                    .to_string(),
-                            );
-                        }
-                    }
                     AgentStatusAction::GetConnectionCount { response } => {
                         if let Err(count) = response.send(http_connection_count) {
                             logger::write_warning(format!(
@@ -319,105 +230,6 @@ impl AgentStatusSharedState {
         });
 
         AgentStatusSharedState(tx)
-    }
-
-    pub async fn add_one_connection_summary(&self, summary: ProxySummary) -> Result<()> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.0
-            .send(AgentStatusAction::AddOneConnectionSummary {
-                summary,
-                response: response_tx,
-            })
-            .await
-            .map_err(|e| {
-                Error::SendError(
-                    "AgentStatusAction::AddOneConnectionSummary".to_string(),
-                    e.to_string(),
-                )
-            })?;
-        response_rx.await.map_err(|e| {
-            Error::RecvError("AgentStatusAction::AddOneConnectionSummary".to_string(), e)
-        })
-    }
-
-    pub async fn add_one_failed_connection_summary(&self, summary: ProxySummary) -> Result<()> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.0
-            .send(AgentStatusAction::AddOneFailedConnectionSummary {
-                summary,
-                response: response_tx,
-            })
-            .await
-            .map_err(|e| {
-                Error::SendError(
-                    "AgentStatusAction::AddOneFailedConnectionSummary".to_string(),
-                    e.to_string(),
-                )
-            })?;
-        response_rx.await.map_err(|e| {
-            Error::RecvError(
-                "AgentStatusAction::AddOneFailedConnectionSummary".to_string(),
-                e,
-            )
-        })
-    }
-
-    pub async fn clear_all_summary(&self) -> Result<()> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.0
-            .send(AgentStatusAction::ClearAllSummary {
-                response: response_tx,
-            })
-            .await
-            .map_err(|e| {
-                Error::SendError(
-                    "AgentStatusAction::ClearAllSummary".to_string(),
-                    e.to_string(),
-                )
-            })?;
-        response_rx
-            .await
-            .map_err(|e| Error::RecvError("AgentStatusAction::ClearAllSummary".to_string(), e))?;
-        Ok(())
-    }
-
-    pub async fn get_all_connection_summary(&self) -> Result<Vec<ProxyConnectionSummary>> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.0
-            .send(AgentStatusAction::GetAllConnectionSummary {
-                response: response_tx,
-            })
-            .await
-            .map_err(|e| {
-                Error::SendError(
-                    "AgentStatusAction::GetAllConnectionSummary".to_string(),
-                    e.to_string(),
-                )
-            })?;
-        response_rx.await.map_err(|e| {
-            Error::RecvError("AgentStatusAction::GetAllConnectionSummary".to_string(), e)
-        })
-    }
-
-    pub async fn get_all_failed_connection_summary(&self) -> Result<Vec<ProxyConnectionSummary>> {
-        let (response_tx, response_rx) = oneshot::channel();
-        self.0
-            .send(AgentStatusAction::GetAllFailedConnectionSummary {
-                response: response_tx,
-            })
-            .await
-            .map_err(|e| {
-                Error::SendError(
-                    "AgentStatusAction::GetAllFailedConnectionSummary".to_string(),
-                    e.to_string(),
-                )
-            })?;
-        response_rx.await.map_err(|e| {
-            Error::RecvError(
-                "AgentStatusAction::GetAllFailedConnectionSummary".to_string(),
-                e,
-            )
-        })
     }
 
     async fn get_module_state(&self, module: AgentStatusModule) -> Result<ModuleState> {
@@ -629,9 +441,8 @@ impl AgentStatusSharedState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{proxy::proxy_summary::ProxySummary, shared_state};
+    use crate::shared_state;
     use proxy_agent_shared::proxy_agent_aggregate_status::ModuleState;
-    use std::path::PathBuf;
 
     #[tokio::test]
     async fn test_agent_status_shared_state() {
@@ -697,82 +508,10 @@ mod tests {
             .unwrap();
         assert_eq!(1, connection_count);
 
-        let connection_summary = ProxySummary {
-            id: connection_id,
-            method: "GET".to_string(),
-            url: "/status".to_string(),
-            clientIp: "127.0.0.1".to_string(),
-            clientPort: 6080,
-            ip: "127.0.0.1".to_string(),
-            port: 8080,
-            userId: 999,
-            userName: "user1".to_string(),
-            userGroups: vec!["group1".to_string()],
-            processFullPath: PathBuf::from("C:\\path\\to\\process.exe"),
-            processCmdLine: "process --arg1 --arg2".to_string(),
-            runAsElevated: true,
-            responseStatus: "200 OK".to_string(),
-            elapsedTime: 123,
-            errorDetails: "".to_string(),
-        };
-        agent_status_shared_state
-            .add_one_connection_summary(connection_summary.clone())
-            .await
-            .unwrap();
-        let get_all_connection_summary = agent_status_shared_state
-            .get_all_connection_summary()
-            .await
-            .unwrap();
-        assert_eq!(1, get_all_connection_summary.len());
-        assert_eq!(1, get_all_connection_summary[0].count);
-
         let connection_id = agent_status_shared_state
             .increase_connection_count()
             .await
             .unwrap();
         assert_eq!(2, connection_id);
-
-        let failed_connection_summary = ProxySummary {
-            id: connection_id,
-            method: "GET".to_string(),
-            url: "/status".to_string(),
-            clientIp: "127.0.0.1".to_string(),
-            clientPort: 6080,
-            ip: "127.0.0.1".to_string(),
-            port: 8080,
-            userId: 999,
-            userName: "user1".to_string(),
-            userGroups: vec!["group1".to_string()],
-            processFullPath: PathBuf::from("C:\\path\\to\\process.exe"),
-            processCmdLine: "process --arg1 --arg2".to_string(),
-            runAsElevated: true,
-            responseStatus: "500 Internal Server Error".to_string(),
-            elapsedTime: 123,
-            errorDetails: "Some error occurred".to_string(),
-        };
-        agent_status_shared_state
-            .add_one_failed_connection_summary(failed_connection_summary.clone())
-            .await
-            .unwrap();
-        let get_all_failed_connection_summary = agent_status_shared_state
-            .get_all_failed_connection_summary()
-            .await
-            .unwrap();
-        assert_eq!(1, get_all_failed_connection_summary.len());
-
-        // clear all summaries
-        agent_status_shared_state.clear_all_summary().await.unwrap();
-        let get_all_connection_summary = agent_status_shared_state
-            .get_all_connection_summary()
-            .await
-            .unwrap();
-        assert_eq!(0, get_all_connection_summary.len());
-
-        // connection count should not be reset
-        let connection_id = agent_status_shared_state
-            .increase_connection_count()
-            .await
-            .unwrap();
-        assert_eq!(3, connection_id);
     }
 }

--- a/proxy_agent/src/shared_state/connection_summary_wrapper.rs
+++ b/proxy_agent/src/shared_state/connection_summary_wrapper.rs
@@ -1,0 +1,297 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+//! This module contains the logic to interact with the connection summary status.
+//! The proxy agent status contains the 'connection summary' of the proxy server.
+//! The proxy agent status contains the 'failed connection summary' of the proxy server.
+
+use crate::common::logger;
+use crate::common::result::Result;
+use crate::{common::error::Error, proxy::proxy_summary::ProxySummary};
+use proxy_agent_shared::proxy_agent_aggregate_status::ProxyConnectionSummary;
+use std::collections::{hash_map, HashMap};
+use tokio::sync::{mpsc, oneshot};
+
+enum ConnectionSummaryAction {
+    AddOneConnection {
+        summary: ProxySummary,
+        response: oneshot::Sender<()>,
+    },
+    AddOneFailedConnection {
+        summary: ProxySummary,
+        response: oneshot::Sender<()>,
+    },
+    GetAllConnection {
+        response: oneshot::Sender<Vec<ProxyConnectionSummary>>,
+    },
+    GetAllFailedConnection {
+        response: oneshot::Sender<Vec<ProxyConnectionSummary>>,
+    },
+    ClearAll {
+        response: oneshot::Sender<()>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ConnectionSummarySharedState(mpsc::Sender<ConnectionSummaryAction>);
+
+impl ConnectionSummarySharedState {
+    pub fn start_new() -> Self {
+        let (tx, mut rx) = mpsc::channel(100);
+        tokio::spawn(async move {
+            // The proxy connection summary from the proxy
+            let mut proxy_summary: HashMap<String, ProxyConnectionSummary> = HashMap::new();
+            // The failed authenticate summary from the proxy
+            let mut failed_authenticate_summary: HashMap<String, ProxyConnectionSummary> =
+                HashMap::new();
+
+            while let Some(action) = rx.recv().await {
+                match action {
+                    ConnectionSummaryAction::AddOneConnection { summary, response } => {
+                        let key = summary.to_key_string();
+                        if let hash_map::Entry::Vacant(e) = proxy_summary.entry(key.clone()) {
+                            e.insert(summary.into());
+                        } else if let Some(connection_summary) = proxy_summary.get_mut(&key) {
+                            //increase_count(connection_summary);
+                            connection_summary.count += 1;
+                        }
+                        if response.send(()).is_err() {
+                            logger::write_warning("Failed to send response to ConnectionSummaryAction::AddOneConnection".to_string());
+                        }
+                    }
+                    ConnectionSummaryAction::AddOneFailedConnection { summary, response } => {
+                        let key = summary.to_key_string();
+                        if let hash_map::Entry::Vacant(e) =
+                            failed_authenticate_summary.entry(key.clone())
+                        {
+                            e.insert(summary.into());
+                        } else if let Some(connection_summary) =
+                            failed_authenticate_summary.get_mut(&key)
+                        {
+                            //increase_count(connection_summary);
+                            connection_summary.count += 1;
+                        }
+                        if response.send(()).is_err() {
+                            logger::write_warning("Failed to send response to ConnectionSummaryAction::AddOneFailedConnection".to_string());
+                        }
+                    }
+                    ConnectionSummaryAction::GetAllConnection { response } => {
+                        let mut copy_summary: Vec<ProxyConnectionSummary> = Vec::new();
+                        for (_, connection_summary) in proxy_summary.iter() {
+                            copy_summary.push(connection_summary.clone());
+                        }
+                        if let Err(summary) = response.send(copy_summary) {
+                            logger::write_warning(format!(
+                                "Failed to send response to ConnectionSummaryAction::GetAllConnection with summary count '{:?}'",
+                                summary.len()
+                            ));
+                        }
+                    }
+                    ConnectionSummaryAction::GetAllFailedConnection { response } => {
+                        let mut copy_summary: Vec<ProxyConnectionSummary> = Vec::new();
+                        for (_, connection_summary) in failed_authenticate_summary.iter() {
+                            copy_summary.push(connection_summary.clone());
+                        }
+                        if let Err(summary) = response.send(copy_summary) {
+                            logger::write_warning(format!(
+                                "Failed to send response to ConnectionSummaryAction::GetAllFailedConnection with summary count '{:?}'",
+                                summary.len()
+                            ));
+                        }
+                    }
+                    ConnectionSummaryAction::ClearAll { response } => {
+                        proxy_summary.clear();
+                        failed_authenticate_summary.clear();
+                        if response.send(()).is_err() {
+                            logger::write_warning(
+                                "Failed to send response to ConnectionSummaryAction::ClearAll"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                }
+            }
+        });
+
+        ConnectionSummarySharedState(tx)
+    }
+
+    pub async fn add_one_connection_summary(&self, summary: ProxySummary) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .send(ConnectionSummaryAction::AddOneConnection {
+                summary,
+                response: response_tx,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "ConnectionSummaryAction::AddOneConnection".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        response_rx.await.map_err(|e| {
+            Error::RecvError("ConnectionSummaryAction::AddOneConnection".to_string(), e)
+        })
+    }
+
+    pub async fn add_one_failed_connection_summary(&self, summary: ProxySummary) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .send(ConnectionSummaryAction::AddOneFailedConnection {
+                summary,
+                response: response_tx,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "ConnectionSummaryAction::AddOneFailedConnection".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        response_rx.await.map_err(|e| {
+            Error::RecvError(
+                "ConnectionSummaryAction::AddOneFailedConnection".to_string(),
+                e,
+            )
+        })
+    }
+
+    pub async fn clear_all_summary(&self) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .send(ConnectionSummaryAction::ClearAll {
+                response: response_tx,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "ConnectionSummaryAction::ClearAll".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        response_rx
+            .await
+            .map_err(|e| Error::RecvError("ConnectionSummaryAction::ClearAll".to_string(), e))?;
+        Ok(())
+    }
+
+    pub async fn get_all_connection_summary(&self) -> Result<Vec<ProxyConnectionSummary>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .send(ConnectionSummaryAction::GetAllConnection {
+                response: response_tx,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "ConnectionSummaryAction::GetAllConnection".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        response_rx.await.map_err(|e| {
+            Error::RecvError("ConnectionSummaryAction::GetAllConnection".to_string(), e)
+        })
+    }
+
+    pub async fn get_all_failed_connection_summary(&self) -> Result<Vec<ProxyConnectionSummary>> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .send(ConnectionSummaryAction::GetAllFailedConnection {
+                response: response_tx,
+            })
+            .await
+            .map_err(|e| {
+                Error::SendError(
+                    "ConnectionSummaryAction::GetAllFailedConnection".to_string(),
+                    e.to_string(),
+                )
+            })?;
+        response_rx.await.map_err(|e| {
+            Error::RecvError(
+                "ConnectionSummaryAction::GetAllFailedConnection".to_string(),
+                e,
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proxy::proxy_summary::ProxySummary;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_agent_status_shared_state() {
+        let connection_summary_shared_state = ConnectionSummarySharedState::start_new();
+
+        let connection_summary = ProxySummary {
+            id: 1,
+            method: "GET".to_string(),
+            url: "/status".to_string(),
+            clientIp: "127.0.0.1".to_string(),
+            clientPort: 6080,
+            ip: "127.0.0.1".to_string(),
+            port: 8080,
+            userId: 999,
+            userName: "user1".to_string(),
+            userGroups: vec!["group1".to_string()],
+            processFullPath: PathBuf::from("C:\\path\\to\\process.exe"),
+            processCmdLine: "process --arg1 --arg2".to_string(),
+            runAsElevated: true,
+            responseStatus: "200 OK".to_string(),
+            elapsedTime: 123,
+            errorDetails: "".to_string(),
+        };
+        connection_summary_shared_state
+            .add_one_connection_summary(connection_summary.clone())
+            .await
+            .unwrap();
+        let get_all_connection_summary = connection_summary_shared_state
+            .get_all_connection_summary()
+            .await
+            .unwrap();
+        assert_eq!(1, get_all_connection_summary.len());
+        assert_eq!(1, get_all_connection_summary[0].count);
+
+        let failed_connection_summary = ProxySummary {
+            id: 2,
+            method: "GET".to_string(),
+            url: "/status".to_string(),
+            clientIp: "127.0.0.1".to_string(),
+            clientPort: 6080,
+            ip: "127.0.0.1".to_string(),
+            port: 8080,
+            userId: 999,
+            userName: "user1".to_string(),
+            userGroups: vec!["group1".to_string()],
+            processFullPath: PathBuf::from("C:\\path\\to\\process.exe"),
+            processCmdLine: "process --arg1 --arg2".to_string(),
+            runAsElevated: true,
+            responseStatus: "500 Internal Server Error".to_string(),
+            elapsedTime: 123,
+            errorDetails: "Some error occurred".to_string(),
+        };
+        connection_summary_shared_state
+            .add_one_failed_connection_summary(failed_connection_summary.clone())
+            .await
+            .unwrap();
+        let get_all_failed_connection_summary = connection_summary_shared_state
+            .get_all_failed_connection_summary()
+            .await
+            .unwrap();
+        assert_eq!(1, get_all_failed_connection_summary.len());
+
+        // clear all summaries
+        connection_summary_shared_state
+            .clear_all_summary()
+            .await
+            .unwrap();
+        let get_all_connection_summary = connection_summary_shared_state
+            .get_all_connection_summary()
+            .await
+            .unwrap();
+        assert_eq!(0, get_all_connection_summary.len());
+    }
+}

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -86,8 +86,8 @@ pub enum HyperErrorType {
     #[error("Failed to build request with error: {0}")]
     RequestBuilder(String),
 
-    #[error("Failed to receive the request body with error: {0}")]
-    RequestBody(String),
+    #[error("Failed to receive the body with error: {0}")]
+    ReceiveBody(String),
 
     #[error("Failed to get response from {0}, status code: {1}")]
     ServerError(String, StatusCode),


### PR DESCRIPTION
- Move access control rules from KeyKeeperSharedState to AccessControlSharedState
- Move connection summary from AgentStatusShared to ConnectionSummarySharedState
- Stream the response body directly without buffering
- Stream the request body directly without buffering if the request does not require signature
- Async read body bytes to avoid blocking the thread if the body is large