### PR TITLE
retry update the redirect policy if not updated successfully before

### DIFF
--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -600,6 +600,25 @@ impl KeyKeeper {
         }
     }
 
+    async fn update_key_to_shared_state(&self, key: Key) -> Result<()> {
+        self.key_keeper_shared_state.update_key(key.clone()).await?;
+
+        // update the current key guid and value to common states
+        self.common_state
+            .set_state(
+                proxy_agent_shared::common_state::SECURE_KEY_GUID.to_string(),
+                key.guid.to_string(),
+            )
+            .await?;
+        self.common_state
+            .set_state(
+                proxy_agent_shared::common_state::SECURE_KEY_VALUE.to_string(),
+                key.key.to_string(),
+            )
+            .await?;
+        Ok(())
+    }
+
     async fn update_redirector_policy(&self, status: KeyStatus) -> bool {
         // update the redirector policy map
         if !redirector::update_wire_server_redirect_policy(

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -279,7 +279,7 @@ impl BpfObject {
         dest_port: u16,
         local_port: u16,
         redirect: bool,
-    ) {
+    ) -> bool {
         let policy_map_name = "policy_map";
         match self.0.map_mut(policy_map_name) {
             Some(map) => match HashMap::<&mut MapData, [u32; 6], [u32; 6]>::try_from(map) {
@@ -319,22 +319,26 @@ impl BpfObject {
                         let local_ip: u32 = super::string_to_ip(&local_ip);
                         let value = destination_entry::from_ipv4(local_ip, local_port);
                         match policy_map.insert(key.to_array(), value.to_array(), 0) {
-                            Ok(_) => event_logger::write_event(
-                                LoggerLevel::Info,
-                                format!(
-                                    "policy_map updated for destination: {}:{}",
-                                    ip_to_string(dest_ipv4),
-                                    dest_port
-                                ),
-                                "update_redirect_policy_internal",
-                                "redirector/linux",
-                                logger::AGENT_LOGGER_KEY,
-                            ),
+                            Ok(_) => {
+                                event_logger::write_event(
+                                    LoggerLevel::Info,
+                                    format!(
+                                        "policy_map updated for destination: {}:{}",
+                                        ip_to_string(dest_ipv4),
+                                        dest_port
+                                    ),
+                                    "update_redirect_policy_internal",
+                                    "redirector/linux",
+                                    logger::AGENT_LOGGER_KEY,
+                                );
+                                return true;
+                            }
                             Err(err) => {
                                 logger::write(format!("Failed to insert destination: {}:{} to policy_map with error: {}", ip_to_string(dest_ipv4), dest_port, err));
                             }
                         }
                     }
+                    return true;
                 }
                 Err(err) => {
                     logger::write(format!(
@@ -346,6 +350,8 @@ impl BpfObject {
                 logger::write("Failed to get map 'policy_map'.".to_string());
             }
         }
+
+        false
     }
 
     pub fn remove_audit_map_entry(&mut self, source_port: u16) -> Result<()> {
@@ -425,52 +431,56 @@ impl super::Redirector {
 pub async fn update_wire_server_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let (Ok(Some(bpf_object)), Ok(local_port)) = (
         redirector_shared_state.get_bpf_object().await,
         redirector_shared_state.get_local_port().await,
     ) {
-        bpf_object.lock().unwrap().update_redirect_policy(
+        return bpf_object.lock().unwrap().update_redirect_policy(
             constants::WIRE_SERVER_IP_NETWORK_BYTE_ORDER,
             constants::WIRE_SERVER_PORT,
             local_port,
             redirect,
         );
     }
+
+    false
 }
 
 pub async fn update_imds_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let (Ok(Some(bpf_object)), Ok(local_port)) = (
         redirector_shared_state.get_bpf_object().await,
         redirector_shared_state.get_local_port().await,
     ) {
-        bpf_object.lock().unwrap().update_redirect_policy(
+        return bpf_object.lock().unwrap().update_redirect_policy(
             constants::IMDS_IP_NETWORK_BYTE_ORDER,
             constants::IMDS_PORT,
             local_port,
             redirect,
         );
     }
+    false
 }
 
 pub async fn update_hostga_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let (Ok(Some(bpf_object)), Ok(local_port)) = (
         redirector_shared_state.get_bpf_object().await,
         redirector_shared_state.get_local_port().await,
     ) {
-        bpf_object.lock().unwrap().update_redirect_policy(
+        return bpf_object.lock().unwrap().update_redirect_policy(
             constants::GA_PLUGIN_IP_NETWORK_BYTE_ORDER,
             constants::GA_PLUGIN_PORT,
             local_port,
             redirect,
         );
     }
+    false
 }
 
 #[cfg(test)]

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -144,7 +144,7 @@ pub fn get_audit_from_redirect_context(raw_socket_id: usize) -> Result<AuditEntr
 pub async fn update_wire_server_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let Ok(Some(bpf_object)) = redirector_shared_state.get_bpf_object().await {
         if redirect {
             if let Ok(local_port) = redirector_shared_state.get_local_port().await {
@@ -173,13 +173,16 @@ pub async fn update_wire_server_redirect_policy(
         } else {
             logger::write("Success deleted bpf map for wireserver redirect policy.".to_string());
         }
+        true
+    } else {
+        false
     }
 }
 
 pub async fn update_imds_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let Ok(Some(bpf_object)) = redirector_shared_state.get_bpf_object().await {
         if redirect {
             if let Ok(local_port) = redirector_shared_state.get_local_port().await {
@@ -207,13 +210,16 @@ pub async fn update_imds_redirect_policy(
         } else {
             logger::write("Success deleted bpf map for IMDS redirect policy.".to_string());
         }
+        true
+    } else {
+        false
     }
 }
 
 pub async fn update_hostga_redirect_policy(
     redirect: bool,
     redirector_shared_state: RedirectorSharedState,
-) {
+) -> bool {
     if let Ok(Some(bpf_object)) = redirector_shared_state.get_bpf_object().await {
         if redirect {
             if let Ok(local_port) = redirector_shared_state.get_local_port().await {
@@ -242,5 +248,9 @@ pub async fn update_hostga_redirect_policy(
         } else {
             logger::write("Success deleted bpf map for HostGAPlugin redirect policy.".to_string());
         }
+
+        true
+    } else {
+        false
     }
 }


### PR DESCRIPTION
When GPA service starts, it has two separate async tasks: one to setup redirect/eBPF intercepting host endpoints by default; one gets the MSP status from host, aka key-latch task. If the host module is in disabled mode, it should remove the corresponding host endpoint from eBPF policy map. Usually setup redirect/eBPF task finishes quicker; while in some cases if the key-latch task finishes earlier, it will not remove the corresponding endpoint from eBPF policy map. 
To fix this timing issue at GPA service provisioning time, key-latch task should retry updating the redirect policy if not updated successfully before.