### PR TITLE
Fix get_proxy_agent_service_path for Linux

### DIFF
--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -8,14 +8,12 @@ use crate::structs;
 use crate::structs::FormattedMessage;
 use crate::structs::HandlerEnvironment;
 use crate::structs::TopLevelStatus;
+use proxy_agent_shared::service;
 use proxy_agent_shared::{misc_helpers, telemetry};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process;
-
-#[cfg(windows)]
-use proxy_agent_shared::service;
 
 pub fn get_handler_environment(exe_path: &Path) -> HandlerEnvironment {
     let mut handler_env_path: PathBuf = exe_path.to_path_buf();
@@ -169,15 +167,7 @@ pub fn get_current_seq_no(exe_path: &Path) -> String {
 }
 
 pub fn get_proxy_agent_service_path() -> PathBuf {
-    #[cfg(windows)]
-    {
-        service::query_service_executable_path(constants::PROXY_AGENT_SERVICE_NAME)
-    }
-    #[cfg(not(windows))]
-    {
-        // linux service hard-coded to this location
-        PathBuf::from(proxy_agent_shared::linux::EXE_FOLDER_PATH).join("azure-proxy-agent")
-    }
+    service::query_service_executable_path(constants::PROXY_AGENT_SERVICE_NAME)
 }
 
 pub fn get_proxy_agent_exe_path() -> PathBuf {

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -13,7 +13,10 @@ pub const EXTENSION_PROCESS_NAME: &str = "ProxyAgentExt";
 #[cfg(windows)]
 pub const EXTENSION_PROCESS_NAME: &str = "ProxyAgentExt.exe";
 pub const EXTENSION_SERVICE_DISPLAY_NAME: &str = "Microsoft Azure GuestProxyAgent VMExtension";
+#[cfg(windows)]
 pub const PROXY_AGENT_SERVICE_NAME: &str = "GuestProxyAgent";
+#[cfg(not(windows))]
+pub const PROXY_AGENT_SERVICE_NAME: &str = "azure-proxy-agent";
 pub const UPDATE_TAG_FILE: &str = "update.tag";
 pub const ENABLE_OPERATION: &str = "Enable";
 pub const LANG_EN_US: &str = "en-US";

--- a/proxy_agent_shared/src/service/linux_service.rs
+++ b/proxy_agent_shared/src/service/linux_service.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+use crate::error::CommandErrorType;
+use crate::error::Error;
 use crate::linux;
 use crate::logger::logger_manager;
 use crate::misc_helpers;
@@ -17,14 +19,23 @@ pub fn stop_service(service_name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Starts the specified service with `systemctl start` command.
+/// If the command fails, an Error is returned.
 pub fn start_service(service_name: &str) -> Result<()> {
     let output = misc_helpers::execute_command("systemctl", vec!["start", service_name], -1)?;
-    logger_manager::write_info(format!(
-        "start_service: {}  result: {}",
-        service_name,
-        output.message()
-    ));
-    Ok(())
+    if output.is_success() {
+        logger_manager::write_info(format!("Service {service_name} started successfully"));
+        Ok(())
+    } else {
+        let error_message = format!(
+            "start_service: {service_name} failed with error: {}",
+            output.message()
+        );
+        Err(Error::Command(
+            CommandErrorType::CommandName("systemctl start".to_string()),
+            error_message,
+        ))
+    }
 }
 
 pub fn install_or_update_service(service_name: &str) -> Result<()> {
@@ -95,4 +106,69 @@ fn delete_service_config_file(service_name: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Queries the executable path of the specified service.
+/// It uses systemctl show command to get the ExecStart property.
+/// If the command fails or the output cannot be parsed, an Error is returned.
+pub fn query_service_executable_path(service_name: &str) -> Result<PathBuf> {
+    let output = misc_helpers::execute_command(
+        "systemctl",
+        vec!["show", "--property=ExecStart", service_name],
+        -1,
+    )?;
+
+    if !output.is_success() {
+        let error_message = format!(
+            "query_service_executable_path: {service_name} failed with error: {}",
+            output.message()
+        );
+        return Err(Error::Command(
+            CommandErrorType::CommandName("systemctl show --property=ExecStart".to_string()),
+            error_message,
+        ));
+    }
+
+    let stdout = output.stdout();
+    logger_manager::write_info(format!(
+        "query_service_executable_path: {service_name} result: {stdout}",
+    ));
+
+    // Parse ExecStart output
+    // Format: ExecStart={ path=/path/to/executable ; argv[]=/path/to/executable [args] ; ... }
+    if let Some(path_start) = stdout.find("path=") {
+        let path_str = &stdout[path_start + 5..];
+        if let Some(semicolon_pos) = path_str.find(" ;") {
+            let executable_path = path_str[..semicolon_pos].trim();
+            return Ok(PathBuf::from(executable_path));
+        }
+    }
+
+    let error_message = format!(
+        "query_service_executable_path: {service_name} failed to parse ExecStart output: {stdout}"
+    );
+    Err(Error::Command(
+        CommandErrorType::CommandName("systemctl show --property=ExecStart".to_string()),
+        error_message,
+    ))
+}
+
+/// Check if the service is installed by verifying the existence of its unit file.
+pub fn check_service_installed(service_name: &str) -> (bool, String) {
+    let config_file_path =
+        PathBuf::from(linux::SERVICE_CONFIG_FOLDER_PATH).join(format!("{service_name}.service"));
+
+    if config_file_path.exists() && config_file_path.is_file() {
+        let message =
+            format!("check_service_installed: service: {service_name} successfully queried.");
+        logger_manager::write_info(message.clone());
+        (true, message)
+    } else {
+        let message = format!(
+            "check_service_installed: service: {service_name} unit file not found at '{}'",
+            misc_helpers::path_to_string(&config_file_path)
+        );
+        logger_manager::write_info(message.clone());
+        (false, message)
+    }
 }

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -58,8 +58,7 @@ pub async fn start_service_with_retry(
     }
 
     // reach here means all retries exhausted
-    Err(Error::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
+    Err(Error::Io(std::io::Error::other(
         "start_service_with_retry exceeded maximum retry attempts".to_string(),
     )))
 }

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -56,7 +56,12 @@ pub async fn start_service_with_retry(
         }
         tokio::time::sleep(duration).await;
     }
-    Ok(())
+
+    // reach here means all retries exhausted
+    Err(Error::Io(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "start_service_with_retry exceeded maximum retry attempts".to_string(),
+    )))
 }
 
 async fn start_service_once(service_name: &str) -> Result<ServiceStatus> {


### PR DESCRIPTION
Instead of hard-coded the Linux GPA service path, it should read from its Service config unit file.