### PR TITLE
Update redirect policy when provision finished

### DIFF
--- a/proxy_agent/src/common/config.rs
+++ b/proxy_agent/src/common/config.rs
@@ -49,10 +49,6 @@ pub fn get_monitor_duration() -> Duration {
 pub fn get_poll_key_status_duration() -> Duration {
     Duration::from_secs(SYSTEM_CONFIG.get_poll_key_status_interval())
 }
-//TODO: remove this config/function once the contract is defined for HostGAPlugin
-pub fn get_host_gaplugin_support() -> u8 {
-    SYSTEM_CONFIG.hostGAPluginSupport
-}
 
 pub fn get_max_event_file_count() -> usize {
     SYSTEM_CONFIG.get_max_event_file_count()
@@ -90,7 +86,6 @@ pub struct Config {
     latchKeyFolder: String,
     monitorIntervalInSeconds: u64,
     pollKeyStatusIntervalInSeconds: u64,
-    hostGAPluginSupport: u8, // 0 not support; 1 proxy only; 2 proxy + authentication check
     #[serde(skip_serializing_if = "Option::is_none")]
     maxEventFileCount: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -168,10 +163,6 @@ impl Config {
 
     pub fn get_poll_key_status_interval(&self) -> u64 {
         self.pollKeyStatusIntervalInSeconds
-    }
-
-    pub fn get_host_gaplugin_support(&self) -> u8 {
-        self.hostGAPluginSupport
     }
 
     pub fn get_max_event_file_count(&self) -> usize {
@@ -267,12 +258,6 @@ mod tests {
             15u64,
             config.get_poll_key_status_interval(),
             "get_poll_key_status_interval mismatch"
-        );
-
-        assert_eq!(
-            1u8,
-            config.get_host_gaplugin_support(),
-            "get_host_gaplugin_support mismatch"
         );
 
         assert_eq!(

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -209,7 +209,7 @@ impl KeyKeeper {
             ));
         }
 
-        let mut start = Instant::now();
+        let mut provision_start_time = Instant::now();
         let mut redirect_policy_updated = false;
         loop {
             if !first_iteration {
@@ -233,7 +233,7 @@ impl KeyKeeper {
                     .await;
 
                 if reset_timer {
-                    start = Instant::now();
+                    provision_start_time = Instant::now();
                     provision_timeout = false;
                 }
 
@@ -243,7 +243,7 @@ impl KeyKeeper {
             }
             first_iteration = false;
 
-            self.handle_provision_timeout(&mut start, &mut provision_timeout)
+            self.handle_provision_timeout(&mut provision_start_time, &mut provision_timeout)
                 .await;
             started_event_threads = self.handle_event_threads_start(started_event_threads).await;
 
@@ -428,8 +428,8 @@ impl KeyKeeper {
     }
 
     /// Handle provision timeout logic
-    async fn handle_provision_timeout(&self, start: &mut Instant, provision_timeout: &mut bool) {
-        if !*provision_timeout && start.elapsed().as_millis() > PROVISION_TIMEOUT_IN_MILLISECONDS {
+    async fn handle_provision_timeout(&self, provision_start_time: &mut Instant, provision_timeout: &mut bool) {
+        if !*provision_timeout && provision_start_time.elapsed().as_millis() > PROVISION_TIMEOUT_IN_MILLISECONDS {
             provision::provision_timeout(
                 None,
                 self.provision_shared_state.clone(),

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -619,6 +619,8 @@ impl KeyKeeper {
         Ok(())
     }
 
+    /// update the redirector/eBPF policy based on the secure channel status
+    /// it should be called when the secure channel state is changed
     async fn update_redirector_policy(&self, status: KeyStatus) -> bool {
         // update the redirector policy map
         if !redirector::update_wire_server_redirect_policy(

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -204,8 +204,6 @@ impl KeyKeeper {
         let mut redirect_policy_updated = false;
         loop {
             if !first_iteration {
-                // skip the sleep for the first loop
-
                 let current_state = match self
                     .key_keeper_shared_state
                     .get_current_secure_channel_state()
@@ -220,199 +218,40 @@ impl KeyKeeper {
                     }
                 };
 
-                let sleep = if current_state == UNKNOWN_STATE
-                    && helpers::get_elapsed_time_in_millisec()
-                        < FREQUENT_PULL_TIMEOUT_IN_MILLISECONDS
-                {
-                    // frequent poll the secure channel status every second for the first 5 minutes
-                    // until the secure channel state is known
-                    FREQUENT_PULL_INTERVAL
-                } else {
-                    self.interval
-                };
+                let sleep = self.calculate_sleep_duration(&current_state);
+                let (continue_loop, reset_timer) = self
+                    .handle_notification(&notify, sleep, &current_state)
+                    .await;
 
-                let time = Instant::now();
-                tokio::select! {
-                    // notify to query the secure channel status immediately when the secure channel state is unknown or disabled
-                    // this is to handle quicker response to the secure channel state change during VM provisioning.
-                    _ = notify.notified() => {
-                        if  current_state == DISABLE_STATE || current_state == UNKNOWN_STATE {
-                            logger::write_warning(format!("poll_secure_channel_status task notified and secure channel state is '{current_state}', reset states and start poll status now."));
-                            provision::key_latch_ready_state_reset(self.provision_shared_state.clone()).await;
-                            if let Err(e) =  self.key_keeper_shared_state.update_current_secure_channel_state(UNKNOWN_STATE.to_string()).await{
-                                logger::write_warning(format!("Failed to update secure channel state to 'Unknown': {e}"));
-                            }
+                if reset_timer {
+                    start = Instant::now();
+                    provision_timeup = false;
+                }
 
-                            if start.elapsed().as_millis() > PROVISION_TIMEUP_IN_MILLISECONDS {
-                                // already timeup, reset the start timer
-                                start = Instant::now();
-                                provision_timeup = false;
-                            }
-                        } else {
-                            // report key latched ready to try update the provision finished time_tick
-                            provision::key_latched( EventThreadsSharedState{
-                                                        cancellation_token: self.cancellation_token.clone(),
-                                                        common_state: self.common_state.clone(),
-                                                        access_control_shared_state: self.access_control_shared_state.clone(),
-                                                        redirector_shared_state: self.redirector_shared_state.clone(),
-                                                        key_keeper_shared_state: self.key_keeper_shared_state.clone(),
-                                                        provision_shared_state: self.provision_shared_state.clone(),
-                                                        agent_status_shared_state: self.agent_status_shared_state.clone(),
-                                                        connection_summary_shared_state: self.connection_summary_shared_state.clone(),
-                            },).await;
-                            let slept_time_in_millisec = time.elapsed().as_millis();
-                            let continue_sleep = sleep.as_millis() - slept_time_in_millisec;
-                            if continue_sleep > 0 {
-                                let continue_sleep = Duration::from_millis(continue_sleep as u64);
-                                let message = format!("poll_secure_channel_status task notified but secure channel state is '{current_state}', continue with sleep wait for {continue_sleep:?}.");
-                                logger::write_warning(message);
-                                tokio::time::sleep(continue_sleep).await;
-                            }
-                        }
-                    },
-                    _ = tokio::time::sleep(sleep) => {}
+                if !continue_loop {
+                    continue;
                 }
             }
             first_iteration = false;
 
-            if !provision_timeup && start.elapsed().as_millis() > PROVISION_TIMEUP_IN_MILLISECONDS {
-                provision::provision_timeup(
-                    None,
-                    self.provision_shared_state.clone(),
-                    self.agent_status_shared_state.clone(),
-                )
+            provision_timeup = self
+                .handle_provision_timeup(&mut start, provision_timeup)
                 .await;
-                provision_timeup = true;
-            }
-
-            if !started_event_threads
-                && helpers::get_elapsed_time_in_millisec()
-                    > DELAY_START_EVENT_THREADS_IN_MILLISECONDS
-            {
-                provision::start_event_threads(EventThreadsSharedState {
-                    cancellation_token: self.cancellation_token.clone(),
-                    common_state: self.common_state.clone(),
-                    access_control_shared_state: self.access_control_shared_state.clone(),
-                    redirector_shared_state: self.redirector_shared_state.clone(),
-                    key_keeper_shared_state: self.key_keeper_shared_state.clone(),
-                    provision_shared_state: self.provision_shared_state.clone(),
-                    agent_status_shared_state: self.agent_status_shared_state.clone(),
-                    connection_summary_shared_state: self.connection_summary_shared_state.clone(),
-                })
-                .await;
-                started_event_threads = true;
-            }
+            started_event_threads = self.handle_event_threads_start(started_event_threads).await;
 
             let status = match key::get_status(&self.base_url).await {
                 Ok(s) => s,
                 Err(e) => {
                     self.update_status_message(format!("Failed to get key status - {e}"), true)
                         .await;
+                    // failed to get status, skip to next iteration
                     continue;
                 }
             };
             self.update_status_message(format!("Got key status successfully: {status}."), true)
                 .await;
 
-            let mut access_control_rules_changed = false;
-            let wireserver_rule_id = status.get_wireserver_rule_id();
-            let imds_rule_id: String = status.get_imds_rule_id();
-            let hostga_rule_id: String = status.get_hostga_rule_id();
-
-            match self
-                .key_keeper_shared_state
-                .update_wireserver_rule_id(wireserver_rule_id.to_string())
-                .await
-            {
-                Ok((updated, old_wire_server_rule_id)) => {
-                    if updated {
-                        logger::write_warning(format!(
-                            "Wireserver rule id changed from '{old_wire_server_rule_id}' to '{wireserver_rule_id}'."
-                        ));
-                        if let Err(e) = self
-                            .access_control_shared_state
-                            .set_wireserver_rules(status.get_wireserver_rules())
-                            .await
-                        {
-                            logger::write_error(format!("Failed to set wireserver rules: {e}"));
-                        }
-                        access_control_rules_changed = true;
-                    }
-                }
-                Err(e) => {
-                    logger::write_warning(format!("Failed to update wireserver rule id: {e}"));
-                }
-            }
-
-            match self
-                .key_keeper_shared_state
-                .update_imds_rule_id(imds_rule_id.to_string())
-                .await
-            {
-                Ok((updated, old_imds_rule_id)) => {
-                    if updated {
-                        logger::write_warning(format!(
-                            "IMDS rule id changed from '{old_imds_rule_id}' to '{imds_rule_id}'."
-                        ));
-                        if let Err(e) = self
-                            .access_control_shared_state
-                            .set_imds_rules(status.get_imds_rules())
-                            .await
-                        {
-                            logger::write_error(format!("Failed to set imds rules: {e}"));
-                        }
-                        access_control_rules_changed = true;
-                    }
-                }
-                Err(e) => {
-                    logger::write_warning(format!("Failed to update imds rule id: {e}"));
-                }
-            }
-
-            match self
-                .key_keeper_shared_state
-                .update_hostga_rule_id(hostga_rule_id.to_string())
-                .await
-            {
-                Ok((updated, old_hostga_rule_id)) => {
-                    if updated {
-                        logger::write_warning(format!(
-                            "HostGA rule id changed from '{old_hostga_rule_id}' to '{hostga_rule_id}'."
-                        ));
-                        if let Err(e) = self
-                            .access_control_shared_state
-                            .set_hostga_rules(status.get_hostga_rules())
-                            .await
-                        {
-                            logger::write_error(format!("Failed to set HostGA rules: {e}"));
-                        }
-                        access_control_rules_changed = true;
-                    }
-                }
-                Err(e) => {
-                    logger::write_warning(format!("Failed to update HostGA rule id: {e}"));
-                }
-            }
-
-            if access_control_rules_changed {
-                if let (Ok(wireserver_rules), Ok(imds_rules), Ok(hostga_rules)) = (
-                    self.access_control_shared_state
-                        .get_wireserver_rules()
-                        .await,
-                    self.access_control_shared_state.get_imds_rules().await,
-                    self.access_control_shared_state.get_hostga_rules().await,
-                ) {
-                    let rules = AuthorizationRulesForLogging::new(
-                        status.authorizationRules.clone(),
-                        ComputedAuthorizationRules {
-                            wireserver: wireserver_rules,
-                            imds: imds_rules,
-                            hostga: hostga_rules,
-                        },
-                    );
-                    rules.write_all(&self.status_dir, constants::MAX_LOG_FILE_COUNT);
-                }
-            }
+            self.update_access_control_rules(&status).await;
 
             let state = status.get_secure_channel_state();
             let secure_channel_state_updated = self
@@ -420,189 +259,22 @@ impl KeyKeeper {
                 .update_current_secure_channel_state(state.to_string())
                 .await;
 
-            // check if need fetch the key
-            if state != DISABLE_STATE
-                && (status.keyGuid.is_none()  // key has not latched yet
-                || status.keyGuid != self.key_keeper_shared_state.get_current_key_guid().await.unwrap_or(None))
-            // key changed
-            {
-                let mut key_found = false;
-                if let Some(guid) = &status.keyGuid {
-                    // key latched before and search the key locally first
-                    match Self::fetch_key(&self.key_dir, guid) {
-                        Ok(key) => {
-                            if let Err(e) = self.update_key_to_shared_state(key.clone()).await {
-                                logger::write_warning(format!("Failed to update key: {e}"));
-                            }
-
-                            let message = helpers::write_startup_event(
-                                "Found key details from local and ready to use.",
-                                "poll_secure_channel_status",
-                                "key_keeper",
-                                logger::AGENT_LOGGER_KEY,
-                            );
-                            self.update_status_message(message, false).await;
-                            key_found = true;
-
-                            provision::key_latched(EventThreadsSharedState {
-                                cancellation_token: self.cancellation_token.clone(),
-                                common_state: self.common_state.clone(),
-                                access_control_shared_state: self
-                                    .access_control_shared_state
-                                    .clone(),
-                                redirector_shared_state: self.redirector_shared_state.clone(),
-                                key_keeper_shared_state: self.key_keeper_shared_state.clone(),
-                                provision_shared_state: self.provision_shared_state.clone(),
-                                agent_status_shared_state: self.agent_status_shared_state.clone(),
-                                connection_summary_shared_state: self
-                                    .connection_summary_shared_state
-                                    .clone(),
-                            })
-                            .await;
-                        }
-                        Err(e) => {
-                            event_logger::write_event(
-                                LoggerLevel::Info,
-                                format!("Failed to fetch local key details with error: {e:?}. Will try acquire the key details from Server."),
-                                "poll_secure_channel_status",
-                                "key_keeper",
-                                logger::AGENT_LOGGER_KEY,
-                            );
-                        }
-                    };
-                }
-
-                // if key has not latched before,
-                // or not found
-                // or could not read locally,
-                // try fetch from server
-                if !key_found {
-                    let key = match key::acquire_key(&self.base_url).await {
-                        Ok(k) => k,
-                        Err(e) => {
-                            self.update_status_message(
-                                format!("Failed to acquire key details: {e:?}"),
-                                true,
-                            )
-                            .await;
-                            continue;
-                        }
-                    };
-
-                    // persist the new key to local disk
-                    let guid = key.guid.to_string();
-                    match Self::store_key(&self.key_dir, &key) {
-                        Ok(()) => {
-                            logger::write_information(format!(
-                        "Successfully acquired the key '{guid}' details from server and saved locally."));
-                        }
-                        Err(e) => {
-                            self.update_status_message(
-                                format!("Failed to save key details to file: {e:?}"),
-                                true,
-                            )
-                            .await;
-                            continue;
-                        }
-                    }
-
-                    // double check the key details saved correctly to local disk
-                    if let Err(e) = Self::check_key(&self.key_dir, &key) {
-                        self.update_status_message(
-                            format!(
-                                "Failed to check the key '{guid}' details saved locally: {e:?}."
-                            ),
-                            true,
-                        )
-                        .await;
-                        continue;
-                    } else {
-                        match key::attest_key(&self.base_url, &key).await {
-                            Ok(()) => {
-                                // update in memory
-                                if let Err(e) = self.update_key_to_shared_state(key.clone()).await {
-                                    logger::write_warning(format!("Failed to update key: {e}"));
-                                }
-
-                                let message = helpers::write_startup_event(
-                                    "Successfully attest the key and ready to use.",
-                                    "poll_secure_channel_status",
-                                    "key_keeper",
-                                    logger::AGENT_LOGGER_KEY,
-                                );
-                                self.update_status_message(message, false).await;
-                                provision::key_latched(EventThreadsSharedState {
-                                    cancellation_token: self.cancellation_token.clone(),
-                                    common_state: self.common_state.clone(),
-                                    access_control_shared_state: self
-                                        .access_control_shared_state
-                                        .clone(),
-                                    redirector_shared_state: self.redirector_shared_state.clone(),
-                                    key_keeper_shared_state: self.key_keeper_shared_state.clone(),
-                                    provision_shared_state: self.provision_shared_state.clone(),
-                                    agent_status_shared_state: self
-                                        .agent_status_shared_state
-                                        .clone(),
-                                    connection_summary_shared_state: self
-                                        .connection_summary_shared_state
-                                        .clone(),
-                                })
-                                .await;
-                            }
-                            Err(e) => {
-                                logger::write_warning(format!("Failed to attest the key: {e:?}"));
-                                continue;
-                            }
-                        }
-                    }
-                }
+            if !self.handle_key_acquisition(&status, &state).await {
+                // Handle key acquisition failed, skip to next iteration
+                continue;
             }
 
-            // update redirect policy if current secure channel state updated
-            match secure_channel_state_updated {
-                Ok(updated) => {
-                    if updated {
-                        // secure channel state changed, update the redirect policy
-                        redirect_policy_updated = self.update_redirector_policy(status).await;
-
-                        // customer has not enforce the secure channel state
-                        if state == DISABLE_STATE {
-                            let message = helpers::write_startup_event(
-                                "Customer has not enforce the secure channel state.",
-                                "poll_secure_channel_status",
-                                "key_keeper",
-                                logger::AGENT_LOGGER_KEY,
-                            );
-                            // Update the status message and let the provision to continue
-                            self.update_status_message(message, false).await;
-
-                            // clear key in memory for disabled state
-                            if let Err(e) = self.key_keeper_shared_state.clear_key().await {
-                                logger::write_warning(format!("Failed to clear key: {e}"));
-                            }
-                            provision::key_latched(EventThreadsSharedState {
-                                cancellation_token: self.cancellation_token.clone(),
-                                common_state: self.common_state.clone(),
-                                access_control_shared_state: self
-                                    .access_control_shared_state
-                                    .clone(),
-                                redirector_shared_state: self.redirector_shared_state.clone(),
-                                key_keeper_shared_state: self.key_keeper_shared_state.clone(),
-                                provision_shared_state: self.provision_shared_state.clone(),
-                                agent_status_shared_state: self.agent_status_shared_state.clone(),
-                                connection_summary_shared_state: self
-                                    .connection_summary_shared_state
-                                    .clone(),
-                            })
-                            .await;
-                        }
-
-                        continue;
-                    }
-                }
-                Err(e) => {
-                    logger::write_warning(format!("Failed to update secure channel state: {e}"));
-                }
+            if self
+                .handle_secure_channel_state_change(
+                    secure_channel_state_updated,
+                    &state,
+                    &status,
+                    &mut redirect_policy_updated,
+                )
+                .await
+            {
+                // successfully handled secure channel state change, skip to next iteration
+                continue;
             }
 
             // check and update the redirect policy if not updated successfully before, try again here
@@ -611,8 +283,367 @@ impl KeyKeeper {
                 logger::write_warning(
                     "redirect policy was not update successfully before, retrying now".to_string(),
                 );
-                redirect_policy_updated = self.update_redirector_policy(status).await;
+                redirect_policy_updated = self.update_redirector_policy(&status).await;
             }
+        }
+    }
+
+    /// Calculate sleep duration based on current secure channel state
+    fn calculate_sleep_duration(&self, current_state: &str) -> Duration {
+        if current_state == UNKNOWN_STATE
+            && helpers::get_elapsed_time_in_millisec() < FREQUENT_PULL_TIMEOUT_IN_MILLISECONDS
+        {
+            // frequent poll the secure channel status every second for the first 5 minutes
+            // until the secure channel state is known
+            FREQUENT_PULL_INTERVAL
+        } else {
+            self.interval
+        }
+    }
+
+    /// Handle notification and sleep logic
+    /// Returns (continue_loop, reset_timer)
+    async fn handle_notification(
+        &self,
+        notify: &tokio::sync::Notify,
+        sleep: Duration,
+        current_state: &str,
+    ) -> (bool, bool) {
+        let time = Instant::now();
+        tokio::select! {
+            // notify to query the secure channel status immediately when the secure channel state is unknown or disabled
+            // this is to handle quicker response to the secure channel state change during VM provisioning.
+            _ = notify.notified() => {
+                if current_state == DISABLE_STATE || current_state == UNKNOWN_STATE {
+                    logger::write_warning(format!("poll_secure_channel_status task notified and secure channel state is '{current_state}', reset states and start poll status now."));
+                    provision::key_latch_ready_state_reset(self.provision_shared_state.clone()).await;
+                    if let Err(e) = self.key_keeper_shared_state.update_current_secure_channel_state(UNKNOWN_STATE.to_string()).await {
+                        logger::write_warning(format!("Failed to update secure channel state to 'Unknown': {e}"));
+                    }
+                    (true, true)
+                } else {
+                    // report key latched ready to try update the provision finished time_tick
+                    provision::key_latched(self.create_event_threads_shared_state()).await;
+                    let slept_time_in_millisec = time.elapsed().as_millis();
+                    let continue_sleep = sleep.as_millis() - slept_time_in_millisec;
+                    if continue_sleep > 0 {
+                        let continue_sleep = Duration::from_millis(continue_sleep as u64);
+                        let message = format!("poll_secure_channel_status task notified but secure channel state is '{current_state}', continue with sleep wait for {continue_sleep:?}.");
+                        logger::write_warning(message);
+                        tokio::time::sleep(continue_sleep).await;
+                    }
+                    (true, false)
+                }
+            },
+            _ = tokio::time::sleep(sleep) => {
+                (true, false)
+            }
+        }
+    }
+
+    /// Handle provision timeout logic
+    async fn handle_provision_timeup(&self, start: &mut Instant, provision_timeup: bool) -> bool {
+        if !provision_timeup && start.elapsed().as_millis() > PROVISION_TIMEUP_IN_MILLISECONDS {
+            provision::provision_timeup(
+                None,
+                self.provision_shared_state.clone(),
+                self.agent_status_shared_state.clone(),
+            )
+            .await;
+            return true;
+        }
+        provision_timeup
+    }
+
+    /// Handle starting event threads
+    async fn handle_event_threads_start(&self, started_event_threads: bool) -> bool {
+        if !started_event_threads
+            && helpers::get_elapsed_time_in_millisec() > DELAY_START_EVENT_THREADS_IN_MILLISECONDS
+        {
+            provision::start_event_threads(self.create_event_threads_shared_state()).await;
+            return true;
+        }
+        started_event_threads
+    }
+
+    /// Update access control rules from the key status
+    /// Returns true if any rules changed
+    async fn update_access_control_rules(&self, status: &KeyStatus) -> bool {
+        let mut access_control_rules_changed = false;
+        let wireserver_rule_id = status.get_wireserver_rule_id();
+        let imds_rule_id = status.get_imds_rule_id();
+        let hostga_rule_id = status.get_hostga_rule_id();
+
+        // Update wireserver rules
+        match self
+            .key_keeper_shared_state
+            .update_wireserver_rule_id(wireserver_rule_id.to_string())
+            .await
+        {
+            Ok((updated, old_wire_server_rule_id)) => {
+                if updated {
+                    logger::write_warning(format!(
+                        "Wireserver rule id changed from '{old_wire_server_rule_id}' to '{wireserver_rule_id}'."
+                    ));
+                    if let Err(e) = self
+                        .access_control_shared_state
+                        .set_wireserver_rules(status.get_wireserver_rules())
+                        .await
+                    {
+                        logger::write_error(format!("Failed to set wireserver rules: {e}"));
+                    }
+                    access_control_rules_changed = true;
+                }
+            }
+            Err(e) => {
+                logger::write_warning(format!("Failed to update wireserver rule id: {e}"));
+            }
+        }
+
+        // Update IMDS rules
+        match self
+            .key_keeper_shared_state
+            .update_imds_rule_id(imds_rule_id.to_string())
+            .await
+        {
+            Ok((updated, old_imds_rule_id)) => {
+                if updated {
+                    logger::write_warning(format!(
+                        "IMDS rule id changed from '{old_imds_rule_id}' to '{imds_rule_id}'."
+                    ));
+                    if let Err(e) = self
+                        .access_control_shared_state
+                        .set_imds_rules(status.get_imds_rules())
+                        .await
+                    {
+                        logger::write_error(format!("Failed to set imds rules: {e}"));
+                    }
+                    access_control_rules_changed = true;
+                }
+            }
+            Err(e) => {
+                logger::write_warning(format!("Failed to update imds rule id: {e}"));
+            }
+        }
+
+        // Update HostGA rules
+        match self
+            .key_keeper_shared_state
+            .update_hostga_rule_id(hostga_rule_id.to_string())
+            .await
+        {
+            Ok((updated, old_hostga_rule_id)) => {
+                if updated {
+                    logger::write_warning(format!(
+                        "HostGA rule id changed from '{old_hostga_rule_id}' to '{hostga_rule_id}'."
+                    ));
+                    if let Err(e) = self
+                        .access_control_shared_state
+                        .set_hostga_rules(status.get_hostga_rules())
+                        .await
+                    {
+                        logger::write_error(format!("Failed to set HostGA rules: {e}"));
+                    }
+                    access_control_rules_changed = true;
+                }
+            }
+            Err(e) => {
+                logger::write_warning(format!("Failed to update HostGA rule id: {e}"));
+            }
+        }
+
+        // Write authorization rules to file if changed
+        if access_control_rules_changed {
+            if let (Ok(wireserver_rules), Ok(imds_rules), Ok(hostga_rules)) = (
+                self.access_control_shared_state
+                    .get_wireserver_rules()
+                    .await,
+                self.access_control_shared_state.get_imds_rules().await,
+                self.access_control_shared_state.get_hostga_rules().await,
+            ) {
+                let rules = AuthorizationRulesForLogging::new(
+                    status.authorizationRules.clone(),
+                    ComputedAuthorizationRules {
+                        wireserver: wireserver_rules,
+                        imds: imds_rules,
+                        hostga: hostga_rules,
+                    },
+                );
+                rules.write_all(&self.status_dir, constants::MAX_LOG_FILE_COUNT);
+            }
+        }
+
+        access_control_rules_changed
+    }
+
+    /// Handle key acquisition from local or server
+    /// Returns true if successful, false if should continue to next iteration
+    async fn handle_key_acquisition(&self, status: &KeyStatus, state: &str) -> bool {
+        // check if need fetch the key
+        if state != DISABLE_STATE
+            && (status.keyGuid.is_none()  // key has not latched yet
+            || status.keyGuid != self.key_keeper_shared_state.get_current_key_guid().await.unwrap_or(None))
+        // key changed
+        {
+            if self.try_fetch_local_key(&status.keyGuid).await {
+                return true;
+            }
+
+            // if key has not latched before, or not found, or could not read locally,
+            // try fetch from server
+            return self.acquire_key_from_server().await;
+        }
+        true
+    }
+
+    /// Try to fetch key from local storage
+    /// Returns true if key was found and loaded successfully
+    async fn try_fetch_local_key(&self, key_guid: &Option<String>) -> bool {
+        if let Some(guid) = key_guid {
+            // key latched before and search the key locally first
+            match Self::fetch_key(&self.key_dir, guid) {
+                Ok(key) => {
+                    if let Err(e) = self.update_key_to_shared_state(key.clone()).await {
+                        logger::write_warning(format!("Failed to update key: {e}"));
+                    }
+
+                    let message = helpers::write_startup_event(
+                        "Found key details from local and ready to use.",
+                        "poll_secure_channel_status",
+                        "key_keeper",
+                        logger::AGENT_LOGGER_KEY,
+                    );
+                    self.update_status_message(message, false).await;
+
+                    provision::key_latched(self.create_event_threads_shared_state()).await;
+                    return true;
+                }
+                Err(e) => {
+                    event_logger::write_event(
+                        LoggerLevel::Info,
+                        format!("Failed to fetch local key details with error: {e:?}. Will try acquire the key details from Server."),
+                        "poll_secure_channel_status",
+                        "key_keeper",
+                        logger::AGENT_LOGGER_KEY,
+                    );
+                }
+            };
+        }
+        false
+    }
+
+    /// Acquire key from server, persist it, and attest it
+    /// Returns true if successful, false if should continue to next iteration
+    async fn acquire_key_from_server(&self) -> bool {
+        let key = match key::acquire_key(&self.base_url).await {
+            Ok(k) => k,
+            Err(e) => {
+                self.update_status_message(format!("Failed to acquire key details: {e:?}"), true)
+                    .await;
+                return false;
+            }
+        };
+
+        // persist the new key to local disk
+        let guid = key.guid.to_string();
+        if let Err(e) = Self::store_key(&self.key_dir, &key) {
+            self.update_status_message(format!("Failed to save key details to file: {e:?}"), true)
+                .await;
+            return false;
+        }
+        logger::write_information(format!(
+            "Successfully acquired the key '{guid}' details from server and saved locally."
+        ));
+
+        // double check the key details saved correctly to local disk
+        if let Err(e) = Self::check_key(&self.key_dir, &key) {
+            self.update_status_message(
+                format!("Failed to check the key '{guid}' details saved locally: {e:?}."),
+                true,
+            )
+            .await;
+            return false;
+        }
+
+        // attest the key
+        match key::attest_key(&self.base_url, &key).await {
+            Ok(()) => {
+                // update in memory
+                if let Err(e) = self.update_key_to_shared_state(key.clone()).await {
+                    logger::write_warning(format!("Failed to update key: {e}"));
+                }
+
+                let message = helpers::write_startup_event(
+                    "Successfully attest the key and ready to use.",
+                    "poll_secure_channel_status",
+                    "key_keeper",
+                    logger::AGENT_LOGGER_KEY,
+                );
+                self.update_status_message(message, false).await;
+                provision::key_latched(self.create_event_threads_shared_state()).await;
+                true
+            }
+            Err(e) => {
+                logger::write_warning(format!("Failed to attest the key: {e:?}"));
+                false
+            }
+        }
+    }
+
+    /// Handle secure channel state change
+    /// Returns true if should continue to next iteration
+    async fn handle_secure_channel_state_change(
+        &self,
+        secure_channel_state_updated: std::result::Result<bool, crate::common::error::Error>,
+        state: &str,
+        status: &KeyStatus,
+        redirect_policy_updated: &mut bool,
+    ) -> bool {
+        match secure_channel_state_updated {
+            Ok(updated) => {
+                if updated {
+                    // secure channel state changed, update the redirect policy
+                    *redirect_policy_updated = self.update_redirector_policy(status).await;
+
+                    // customer has not enforce the secure channel state
+                    if state == DISABLE_STATE {
+                        let message = helpers::write_startup_event(
+                            "Customer has not enforce the secure channel state.",
+                            "poll_secure_channel_status",
+                            "key_keeper",
+                            logger::AGENT_LOGGER_KEY,
+                        );
+                        // Update the status message and let the provision to continue
+                        self.update_status_message(message, false).await;
+
+                        // clear key in memory for disabled state
+                        if let Err(e) = self.key_keeper_shared_state.clear_key().await {
+                            logger::write_warning(format!("Failed to clear key: {e}"));
+                        }
+                        provision::key_latched(self.create_event_threads_shared_state()).await;
+                    }
+
+                    return true;
+                }
+            }
+            Err(e) => {
+                logger::write_warning(format!("Failed to update secure channel state: {e}"));
+            }
+        }
+        false
+    }
+
+    /// Create EventThreadsSharedState from current state
+    fn create_event_threads_shared_state(&self) -> EventThreadsSharedState {
+        EventThreadsSharedState {
+            cancellation_token: self.cancellation_token.clone(),
+            common_state: self.common_state.clone(),
+            access_control_shared_state: self.access_control_shared_state.clone(),
+            redirector_shared_state: self.redirector_shared_state.clone(),
+            key_keeper_shared_state: self.key_keeper_shared_state.clone(),
+            provision_shared_state: self.provision_shared_state.clone(),
+            agent_status_shared_state: self.agent_status_shared_state.clone(),
+            connection_summary_shared_state: self.connection_summary_shared_state.clone(),
         }
     }
 
@@ -637,7 +668,7 @@ impl KeyKeeper {
 
     /// update the redirector/eBPF policy based on the secure channel status
     /// it should be called when the secure channel state is changed
-    async fn update_redirector_policy(&self, status: KeyStatus) -> bool {
+    async fn update_redirector_policy(&self, status: &KeyStatus) -> bool {
         // update the redirector policy map
         if !redirector::update_wire_server_redirect_policy(
             status.get_wire_server_mode() != DISABLE_STATE,

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -253,6 +253,8 @@ impl KeyKeeper {
                             provision::key_latched( EventThreadsSharedState{
                                                         cancellation_token: self.cancellation_token.clone(),
                                                         common_state: self.common_state.clone(),
+                                                        access_control_shared_state: self.access_control_shared_state.clone(),
+                                                        redirector_shared_state: self.redirector_shared_state.clone(),
                                                         key_keeper_shared_state: self.key_keeper_shared_state.clone(),
                                                         provision_shared_state: self.provision_shared_state.clone(),
                                                         agent_status_shared_state: self.agent_status_shared_state.clone(),
@@ -290,6 +292,8 @@ impl KeyKeeper {
                 provision::start_event_threads(EventThreadsSharedState {
                     cancellation_token: self.cancellation_token.clone(),
                     common_state: self.common_state.clone(),
+                    access_control_shared_state: self.access_control_shared_state.clone(),
+                    redirector_shared_state: self.redirector_shared_state.clone(),
                     key_keeper_shared_state: self.key_keeper_shared_state.clone(),
                     provision_shared_state: self.provision_shared_state.clone(),
                     agent_status_shared_state: self.agent_status_shared_state.clone(),
@@ -443,6 +447,10 @@ impl KeyKeeper {
                             provision::key_latched(EventThreadsSharedState {
                                 cancellation_token: self.cancellation_token.clone(),
                                 common_state: self.common_state.clone(),
+                                access_control_shared_state: self
+                                    .access_control_shared_state
+                                    .clone(),
+                                redirector_shared_state: self.redirector_shared_state.clone(),
                                 key_keeper_shared_state: self.key_keeper_shared_state.clone(),
                                 provision_shared_state: self.provision_shared_state.clone(),
                                 agent_status_shared_state: self.agent_status_shared_state.clone(),
@@ -526,6 +534,10 @@ impl KeyKeeper {
                                 provision::key_latched(EventThreadsSharedState {
                                     cancellation_token: self.cancellation_token.clone(),
                                     common_state: self.common_state.clone(),
+                                    access_control_shared_state: self
+                                        .access_control_shared_state
+                                        .clone(),
+                                    redirector_shared_state: self.redirector_shared_state.clone(),
                                     key_keeper_shared_state: self.key_keeper_shared_state.clone(),
                                     provision_shared_state: self.provision_shared_state.clone(),
                                     agent_status_shared_state: self
@@ -571,6 +583,10 @@ impl KeyKeeper {
                             provision::key_latched(EventThreadsSharedState {
                                 cancellation_token: self.cancellation_token.clone(),
                                 common_state: self.common_state.clone(),
+                                access_control_shared_state: self
+                                    .access_control_shared_state
+                                    .clone(),
+                                redirector_shared_state: self.redirector_shared_state.clone(),
                                 key_keeper_shared_state: self.key_keeper_shared_state.clone(),
                                 provision_shared_state: self.provision_shared_state.clone(),
                                 agent_status_shared_state: self.agent_status_shared_state.clone(),

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -580,12 +580,14 @@ impl KeyStatus {
     }
 
     pub fn get_hostga_rules(&self) -> Option<AuthorizationItem> {
-        // short-term: HostGA has no rules
+        // match &self.authorizationRules {
+        //     Some(rules) => rules.hostga.clone(),
+        //     None => None,
+        // }
+
+        // short-term: HostGA uses wireserver rules
         // long-term: TBD
-        match &self.authorizationRules {
-            Some(rules) => rules.hostga.clone(),
-            None => None,
-        }
+        self.get_wireserver_rules()
     }
 
     pub fn get_wire_server_mode(&self) -> String {

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -1263,95 +1263,105 @@ mod tests {
             "roleAssignment identities mismatch"
         );
 
-        // Validate HostGA rules
+        // Validate HostGA rules to match WireServer rules
         let hostga_rules = status.get_hostga_rules().unwrap();
         assert_eq!(
-            "allow", hostga_rules.defaultAccess,
-            "defaultAccess mismatch"
+            wireserver_rules.defaultAccess, hostga_rules.defaultAccess,
+            "hostga_rules defaultAccess mismatch"
         );
         assert_eq!(
-            "sigid",
+            status.get_wireserver_rule_id(),
             status.get_hostga_rule_id(),
             "HostGA rule id mismatch"
         );
-        assert_eq!("enforce", status.get_hostga_mode(), "HostGA mode mismatch");
-
-        // Validate HostGA rule details
-        // Retrieve and validate second privilege for HostGA
-        let privilege = &hostga_rules
-            .rules
-            .as_ref()
-            .unwrap()
-            .privileges
-            .as_ref()
-            .unwrap()[1];
-
-        assert_eq!("test2", privilege.name, "privilege name mismatch");
-        assert_eq!("/test2", privilege.path, "privilege path mismatch");
-
         assert_eq!(
-            "value3",
-            privilege.queryParameters.as_ref().unwrap()["key1"],
-            "privilege queryParameters mismatch"
-        );
-        assert_eq!(
-            "value4",
-            privilege.queryParameters.as_ref().unwrap()["key2"],
-            "privilege queryParameters mismatch"
+            status.get_wire_server_mode(),
+            status.get_hostga_mode(),
+            "HostGA mode mismatch"
         );
 
-        // Retrieve and validate second role for HostGA
-        let role = &hostga_rules.rules.as_ref().unwrap().roles.as_ref().unwrap()[1];
-        assert_eq!("test6", role.name, "role name mismatch");
-        assert_eq!("test4", role.privileges[0], "role privilege mismatch");
-        assert_eq!("test5", role.privileges[1], "role privilege mismatch");
+        /***
+        *
+        * Validate HostGA rule details in future when HostGA has independent rules
 
-        // Retrieve and validate first identity for HostGA
-        let identity = &hostga_rules
-            .rules
-            .as_ref()
-            .unwrap()
-            .identities
-            .as_ref()
-            .unwrap()[0];
-        assert_eq!("test", identity.name, "identity name mismatch");
-        assert_eq!(
-            "test",
-            identity.userName.as_ref().unwrap(),
-            "identity userName mismatch"
-        );
-        assert_eq!(
-            "test",
-            identity.groupName.as_ref().unwrap(),
-            "identity groupName mismatch"
-        );
-        assert_eq!(
-            "test",
-            identity.exePath.as_ref().unwrap(),
-            "identity exePath mismatch"
-        );
-        assert_eq!(
-            "test",
-            identity.processName.as_ref().unwrap(),
-            "identity processName mismatch"
-        );
+           // Validate HostGA rule details
+           // Retrieve and validate second privilege for HostGA
+           let privilege = &hostga_rules
+               .rules
+               .as_ref()
+               .unwrap()
+               .privileges
+               .as_ref()
+               .unwrap()[1];
 
-        // Retrieve and validate first role assignment for HostGA
-        let role_assignment = &hostga_rules
-            .rules
-            .as_ref()
-            .unwrap()
-            .roleAssignments
-            .as_ref()
-            .unwrap()[0];
-        assert_eq!(
-            "test4", role_assignment.role,
-            "roleAssignment role mismatch"
-        );
-        assert_eq!(
-            "test", role_assignment.identities[0],
-            "roleAssignment identities mismatch"
-        );
+           assert_eq!("test2", privilege.name, "privilege name mismatch");
+           assert_eq!("/test2", privilege.path, "privilege path mismatch");
+
+           assert_eq!(
+               "value3",
+               privilege.queryParameters.as_ref().unwrap()["key1"],
+               "privilege queryParameters mismatch"
+           );
+           assert_eq!(
+               "value4",
+               privilege.queryParameters.as_ref().unwrap()["key2"],
+               "privilege queryParameters mismatch"
+           );
+
+           // Retrieve and validate second role for HostGA
+           let role = &hostga_rules.rules.as_ref().unwrap().roles.as_ref().unwrap()[1];
+           assert_eq!("test6", role.name, "role name mismatch");
+           assert_eq!("test4", role.privileges[0], "role privilege mismatch");
+           assert_eq!("test5", role.privileges[1], "role privilege mismatch");
+
+           // Retrieve and validate first identity for HostGA
+           let identity = &hostga_rules
+               .rules
+               .as_ref()
+               .unwrap()
+               .identities
+               .as_ref()
+               .unwrap()[0];
+           assert_eq!("test", identity.name, "identity name mismatch");
+           assert_eq!(
+               "test",
+               identity.userName.as_ref().unwrap(),
+               "identity userName mismatch"
+           );
+           assert_eq!(
+               "test",
+               identity.groupName.as_ref().unwrap(),
+               "identity groupName mismatch"
+           );
+           assert_eq!(
+               "test",
+               identity.exePath.as_ref().unwrap(),
+               "identity exePath mismatch"
+           );
+           assert_eq!(
+               "test",
+               identity.processName.as_ref().unwrap(),
+               "identity processName mismatch"
+           );
+
+           // Retrieve and validate first role assignment for HostGA
+           let role_assignment = &hostga_rules
+               .rules
+               .as_ref()
+               .unwrap()
+               .roleAssignments
+               .as_ref()
+               .unwrap()[0];
+           assert_eq!(
+               "test4", role_assignment.role,
+               "roleAssignment role mismatch"
+           );
+           assert_eq!(
+               "test", role_assignment.identities[0],
+               "roleAssignment identities mismatch"
+           );
+        *
+        */
     }
 
     #[test]

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -237,9 +237,9 @@ async fn reset_provision_state(
 /// use std::sync::{Arc, Mutex};
 ///
 /// let shared_state = Arc::new(Mutex::new(SharedState::new()));
-/// provision::provision_timeup(None, shared_state.clone());
+/// provision::provision_timeout(None, shared_state.clone());
 /// ```
-pub async fn provision_timeup(
+pub async fn provision_timeout(
     provision_dir: Option<PathBuf>,
     provision_shared_state: ProvisionSharedState,
     agent_status_shared_state: AgentStatusSharedState,
@@ -944,7 +944,7 @@ mod tests {
                 super::AgentStatusModule::KeyKeeper,
             )
             .await;
-        super::provision_timeup(
+        super::provision_timeout(
             Some(temp_test_path.clone()),
             provision_shared_state.clone(),
             agent_status_shared_state.clone(),

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -160,7 +160,7 @@ async fn update_provision_state(
 }
 
 /// update the redirector/eBPF policy based on access control status
-/// it should be called when provlision finished
+/// it should be called when provision finished
 async fn update_redirector_policy(
     redirector_shared_state: RedirectorSharedState,
     access_control_shared_state: AccessControlSharedState,

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -8,11 +8,14 @@
 
 use crate::common::{config, logger};
 use crate::key_keeper::{DISABLE_STATE, UNKNOWN_STATE};
-use crate::proxy_agent_status;
+use crate::proxy::authorization_rules::AuthorizationMode;
+use crate::shared_state::access_control_wrapper::AccessControlSharedState;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
 use crate::shared_state::provision_wrapper::ProvisionSharedState;
+use crate::shared_state::redirector_wrapper::RedirectorSharedState;
 use crate::shared_state::EventThreadsSharedState;
+use crate::{proxy_agent_status, redirector};
 use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::telemetry::event_logger;
 use proxy_agent_shared::telemetry::event_reader::EventReader;
@@ -122,6 +125,15 @@ async fn update_provision_state(
         .await
     {
         if provision_state.contains(ProvisionFlags::ALL_READY) {
+            // update redirector/eBPF policy based on access control status
+            update_redirector_policy(
+                event_threads_shared_state.redirector_shared_state.clone(),
+                event_threads_shared_state
+                    .access_control_shared_state
+                    .clone(),
+            )
+            .await;
+
             if let Err(e) = event_threads_shared_state
                 .provision_shared_state
                 .set_provision_finished(true)
@@ -145,6 +157,51 @@ async fn update_provision_state(
             start_event_threads(event_threads_shared_state).await;
         }
     }
+}
+
+/// update the redirector/eBPF policy based on access control status
+/// it should be called when provlision finished
+async fn update_redirector_policy(
+    redirector_shared_state: RedirectorSharedState,
+    access_control_shared_state: AccessControlSharedState,
+) {
+    let wireserver_mode =
+        if let Ok(Some(rules)) = access_control_shared_state.get_wireserver_rules().await {
+            rules.mode
+        } else {
+            // default to disabled if the rules are not ready
+            AuthorizationMode::Disabled
+        };
+    redirector::update_wire_server_redirect_policy(
+        wireserver_mode != AuthorizationMode::Disabled,
+        redirector_shared_state.clone(),
+    )
+    .await;
+
+    let imds_mode = if let Ok(Some(rules)) = access_control_shared_state.get_imds_rules().await {
+        rules.mode
+    } else {
+        // default to disabled if the rules are not ready
+        AuthorizationMode::Disabled
+    };
+    redirector::update_imds_redirect_policy(
+        imds_mode != AuthorizationMode::Disabled,
+        redirector_shared_state.clone(),
+    )
+    .await;
+
+    let ga_plugin_mode =
+        if let Ok(Some(rules)) = access_control_shared_state.get_hostga_rules().await {
+            rules.mode
+        } else {
+            // default to disabled if the rules are not ready
+            AuthorizationMode::Disabled
+        };
+    redirector::update_hostga_redirect_policy(
+        ga_plugin_mode != AuthorizationMode::Disabled,
+        redirector_shared_state.clone(),
+    )
+    .await;
 }
 
 pub async fn key_latch_ready_state_reset(provision_shared_state: ProvisionSharedState) {

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -192,6 +192,8 @@ impl ProxyServer {
         provision::listener_started(EventThreadsSharedState {
             cancellation_token: self.cancellation_token.clone(),
             common_state: self.common_state.clone(),
+            access_control_shared_state: self.access_control_shared_state.clone(),
+            redirector_shared_state: self.redirector_shared_state.clone(),
             key_keeper_shared_state: self.key_keeper_shared_state.clone(),
             provision_shared_state: self.provision_shared_state.clone(),
             agent_status_shared_state: self.agent_status_shared_state.clone(),

--- a/proxy_agent/src/redirector/linux.rs
+++ b/proxy_agent/src/redirector/linux.rs
@@ -301,7 +301,7 @@ impl BpfObject {
                                 );
                             }
                             Err(err) => {
-                                logger::write(format!("Failed to remove destination: {}:{} from policy_map with error: {}", ip_to_string(dest_ipv4), dest_port, err));
+                                logger::write(format!("Failed to remove destination: {}:{} from policy_map with error: {}. The policy_map may not contain this entry, skip and continue.", ip_to_string(dest_ipv4), dest_port, err));
                             }
                         };
                     } else {
@@ -334,7 +334,7 @@ impl BpfObject {
                                 return true;
                             }
                             Err(err) => {
-                                logger::write(format!("Failed to insert destination: {}:{} to policy_map with error: {}", ip_to_string(dest_ipv4), dest_port, err));
+                                logger::write_error(format!("Failed to insert destination: {}:{} to policy_map with error: {}", ip_to_string(dest_ipv4), dest_port, err));
                             }
                         }
                     }

--- a/proxy_agent/src/shared_state.rs
+++ b/proxy_agent/src/shared_state.rs
@@ -124,6 +124,8 @@ impl SharedState {
 pub struct EventThreadsSharedState {
     pub cancellation_token: CancellationToken,
     pub common_state: CommonState,
+    pub access_control_shared_state: access_control_wrapper::AccessControlSharedState,
+    pub redirector_shared_state: redirector_wrapper::RedirectorSharedState,
     pub key_keeper_shared_state: key_keeper_wrapper::KeyKeeperSharedState,
     pub provision_shared_state: provision_wrapper::ProvisionSharedState,
     pub agent_status_shared_state: agent_status_wrapper::AgentStatusSharedState,
@@ -135,6 +137,8 @@ impl EventThreadsSharedState {
         EventThreadsSharedState {
             cancellation_token: shared_state.get_cancellation_token(),
             common_state: shared_state.get_common_state(),
+            access_control_shared_state: shared_state.get_access_control_shared_state(),
+            redirector_shared_state: shared_state.get_redirector_shared_state(),
             key_keeper_shared_state: shared_state.get_key_keeper_shared_state(),
             provision_shared_state: shared_state.get_provision_shared_state(),
             agent_status_shared_state: shared_state.get_agent_status_shared_state(),


### PR DESCRIPTION
- Move `update the redirect policy maps` from `redirector` module to `provision` module. It will help not enable the host http intercept by default when provisioning `redirector` module.
- Removed the configuration setting for HostGAPlugin endpoint
- Break down KeyKeepr loop_poll function into smaller, more manageable sub-functions to improve readability and maintainability
- HostGAPlugin to use WireServer rules to match its mode.
