### PR TITLE
Add Stale Status Timestamp Check 

### DIFF
--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -113,64 +113,6 @@ pub fn report_status(
     }
 }
 
-pub fn report_error_status(
-    status: &mut structs::StatusObj,
-    status_state_obj: &mut StatusState,
-    service_state: &mut crate::service_main::service_state::ServiceState,
-    error_key: &str,
-    error_message: String,
-) {
-    use proxy_agent_shared::logger::LoggerLevel;
-    use proxy_agent_shared::telemetry::event_logger;
-
-    status.status = status_state_obj.update_state(false);
-    if service_state.update_service_state_entry(
-        error_key,
-        constants::ERROR_STATUS,
-        crate::service_main::MAX_STATE_COUNT,
-    ) {
-        event_logger::write_event(
-            LoggerLevel::Info,
-            error_message.clone(),
-            "extension_substatus",
-            "service_main",
-            &logger::get_logger_key(),
-        );
-    }
-    status.configurationAppliedTime = misc_helpers::get_date_time_string();
-    status.substatus = {
-        vec![
-            structs::SubStatus {
-                name: constants::PLUGIN_CONNECTION_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-            structs::SubStatus {
-                name: constants::PLUGIN_STATUS_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-            structs::SubStatus {
-                name: constants::PLUGIN_FAILED_AUTH_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-        ]
-    };
-}
-
 /// Update the current seq no in the CURRENT_SEQ_NO_FILE
 /// If the seq no is different from the current seq no, update the seq no in the file
 /// If the seq no is same as the current seq no, do not update the seq no in the file

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -67,6 +67,11 @@ pub const MIN_SUPPORTED_OS_BUILD: u32 = 17763;
 
 pub const STATE_KEY_READ_PROXY_AGENT_STATUS_FILE: &str = "ReadProxyAgentStatusFile";
 pub const STATE_KEY_FILE_VERSION: &str = "FileVersion";
+pub const STATE_KEY_STALE_PROXY_AGENT_STATUS: &str = "StaleProxyAgentStatus";
+pub const STATE_KEY_PARSE_TIMESTAMP_ERROR: &str = "ParseTimestampError";
+
+// Max time in seconds before proxy agent status is considered stale
+pub const MAX_TIME_BEFORE_STALE_STATUS_SECS: u64 = 5 * 60;
 
 pub const EBPF_CORE: &str = "EbpfCore";
 pub const EBPF_EXT: &str = "NetEbpfExt";

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -432,11 +432,8 @@ fn report_error_status(
     use proxy_agent_shared::telemetry::event_logger;
 
     status.status = status_state_obj.update_state(false);
-    if service_state.update_service_state_entry(
-        error_key,
-        constants::ERROR_STATUS,
-        MAX_STATE_COUNT,
-    ) {
+    if service_state.update_service_state_entry(error_key, constants::ERROR_STATUS, MAX_STATE_COUNT)
+    {
         event_logger::write_event(
             LoggerLevel::Info,
             error_message.clone(),
@@ -554,21 +551,18 @@ fn extension_substatus(
         );
         match serde_json::to_string(&proxy_agent_aggregate_connection_status_obj) {
             Ok(proxy_agent_aggregate_connection_status) => {
-                substatus_proxy_agent_connection_message =
-                    proxy_agent_aggregate_connection_status;
+                substatus_proxy_agent_connection_message = proxy_agent_aggregate_connection_status;
             }
             Err(e) => {
-                let error_message = format!(
-                    "Error in serializing proxy agent aggregate connection status: {e}"
-                );
+                let error_message =
+                    format!("Error in serializing proxy agent aggregate connection status: {e}");
                 logger::write(error_message.to_string());
                 substatus_proxy_agent_connection_message = error_message;
             }
         }
     } else {
         logger::write("proxy connection summary is empty".to_string());
-        substatus_proxy_agent_connection_message =
-            "proxy connection summary is empty".to_string();
+        substatus_proxy_agent_connection_message = "proxy connection summary is empty".to_string();
     }
     let mut substatus_failed_auth_message: String;
     if !proxy_agent_aggregate_status_top_level
@@ -586,9 +580,8 @@ fn extension_substatus(
                 substatus_failed_auth_message = proxy_agent_aggregate_failed_auth_status;
             }
             Err(e) => {
-                let error_message = format!(
-                    "Error in serializing proxy agent aggregate failed auth status: {e}"
-                );
+                let error_message =
+                    format!("Error in serializing proxy agent aggregate failed auth status: {e}");
                 logger::write(error_message.to_string());
                 substatus_failed_auth_message = error_message;
             }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -23,7 +23,7 @@ pub mod windows_main;
 #[cfg(windows)]
 use proxy_agent_shared::service;
 
-const MAX_STATE_COUNT: u32 = 120;
+pub const MAX_STATE_COUNT: u32 = 120;
 
 pub fn run() {
     let message = format!(
@@ -235,57 +235,6 @@ fn write_state_event(
             logger_key,
         );
     }
-}
-
-fn report_error_status(
-    status: &mut StatusObj,
-    status_state_obj: &mut common::StatusState,
-    service_state: &mut ServiceState,
-    error_key: &str,
-    error_message: String,
-) {
-    status.status = status_state_obj.update_state(false);
-    write_state_event(
-        error_key,
-        constants::ERROR_STATUS,
-        error_message.to_string(),
-        "extension_substatus",
-        "service_main",
-        &logger::get_logger_key(),
-        service_state,
-    );
-    status.configurationAppliedTime = misc_helpers::get_date_time_string();
-    status.substatus = {
-        vec![
-            SubStatus {
-                name: constants::PLUGIN_CONNECTION_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-            SubStatus {
-                name: constants::PLUGIN_STATUS_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-            SubStatus {
-                name: constants::PLUGIN_FAILED_AUTH_NAME.to_string(),
-                status: constants::TRANSITIONING_STATUS.to_string(),
-                code: constants::STATUS_CODE_NOT_OK,
-                formattedMessage: FormattedMessage {
-                    lang: constants::LANG_EN_US.to_string(),
-                    message: error_message.to_string(),
-                },
-            },
-        ]
-    };
 }
 
 #[cfg(windows)]
@@ -503,10 +452,10 @@ fn extension_substatus(
 
     // Determine error for status reporting
     if let Some((error_key, error_message)) = timestamp_error {
-        report_error_status(status, status_state_obj, service_state, error_key, error_message);
+        common::report_error_status(status, status_state_obj, service_state, error_key, error_message);
     } else if proxy_agent_aggregate_status_file_version != *proxyagent_file_version_in_extension {
         let version_mismatch_message = format!("Proxy agent aggregate status file version {proxy_agent_aggregate_status_file_version} does not match proxy agent file version in extension {proxyagent_file_version_in_extension}");
-        report_error_status(status, status_state_obj, service_state, constants::STATE_KEY_FILE_VERSION, version_mismatch_message);
+        common::report_error_status(status, status_state_obj, service_state, constants::STATE_KEY_FILE_VERSION, version_mismatch_message);
     }
     // Success Status and report to status file for CRP to read from
     else {

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -428,7 +428,8 @@ fn extension_substatus(
     status_state_obj: &mut common::StatusState,
     service_state: &mut ServiceState,
 ) {
-    let proxy_agent_status_timestamp_result = proxy_agent_aggregate_status_top_level.get_status_timestamp();
+    let proxy_agent_status_timestamp_result =
+        proxy_agent_aggregate_status_top_level.get_status_timestamp();
     let proxy_agent_aggregate_status_obj = proxy_agent_aggregate_status_top_level.proxyAgentStatus;
     let proxy_agent_aggregate_status_file_version =
         proxy_agent_aggregate_status_obj.version.to_string();
@@ -483,10 +484,11 @@ fn extension_substatus(
                     ]
                 };
                 return;
-            } 
+            }
         }
         Err(e) => {
-            let error_message = format!("Error in parsing timestamp from proxy agent aggregate status file: {e}");
+            let error_message =
+                format!("Error in parsing timestamp from proxy agent aggregate status file: {e}");
             write_state_event(
                 constants::STATE_KEY_PARSE_TIMESTAMP_ERROR,
                 constants::ERROR_STATUS,
@@ -1290,9 +1292,15 @@ mod tests {
         // Verify that status is not successful due to stale timestamp
         assert_ne!(status.status, constants::SUCCESS_STATUS.to_string());
         assert_eq!(status.substatus.len(), 3);
-        assert_eq!(status.substatus[0].status, constants::TRANSITIONING_STATUS.to_string());
+        assert_eq!(
+            status.substatus[0].status,
+            constants::TRANSITIONING_STATUS.to_string()
+        );
         assert_eq!(status.substatus[0].code, constants::STATUS_CODE_NOT_OK);
-        assert!(status.substatus[0].formattedMessage.message.contains("stale"));
+        assert!(status.substatus[0]
+            .formattedMessage
+            .message
+            .contains("stale"));
     }
 
     #[test]
@@ -1377,7 +1385,10 @@ mod tests {
         // Verify that status is successful with fresh timestamp
         assert_eq!(status.status, constants::SUCCESS_STATUS.to_string());
         assert_eq!(status.substatus.len(), 3);
-        assert_eq!(status.substatus[0].status, constants::SUCCESS_STATUS.to_string());
+        assert_eq!(
+            status.substatus[0].status,
+            constants::SUCCESS_STATUS.to_string()
+        );
         assert_eq!(status.substatus[0].code, constants::STATUS_CODE_OK);
     }
 }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -445,17 +445,30 @@ fn extension_substatus(
                 None
             }
         }
-        Err(e) => {
-            Some((constants::STATE_KEY_PARSE_TIMESTAMP_ERROR, format!("Error in parsing timestamp from proxy agent aggregate status file: {e}")))
-        }
+        Err(e) => Some((
+            constants::STATE_KEY_PARSE_TIMESTAMP_ERROR,
+            format!("Error in parsing timestamp from proxy agent aggregate status file: {e}"),
+        )),
     };
 
     // Determine error for status reporting
     if let Some((error_key, error_message)) = timestamp_error {
-        common::report_error_status(status, status_state_obj, service_state, error_key, error_message);
+        common::report_error_status(
+            status,
+            status_state_obj,
+            service_state,
+            error_key,
+            error_message,
+        );
     } else if proxy_agent_aggregate_status_file_version != *proxyagent_file_version_in_extension {
         let version_mismatch_message = format!("Proxy agent aggregate status file version {proxy_agent_aggregate_status_file_version} does not match proxy agent file version in extension {proxyagent_file_version_in_extension}");
-        common::report_error_status(status, status_state_obj, service_state, constants::STATE_KEY_FILE_VERSION, version_mismatch_message);
+        common::report_error_status(
+            status,
+            status_state_obj,
+            service_state,
+            constants::STATE_KEY_FILE_VERSION,
+            version_mismatch_message,
+        );
     }
     // Success Status and report to status file for CRP to read from
     else {

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -57,6 +57,10 @@ pub fn get_date_time_unix_nano() -> i128 {
     OffsetDateTime::now_utc().unix_timestamp_nanos()
 }
 
+pub fn get_current_utc_time() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
 /// Parse a datetime string to OffsetDateTime (UTC)
 /// Supports multiple formats:
 /// - ISO 8601 with/without 'Z': "YYYY-MM-DDTHH:MM:SS" or "YYYY-MM-DDTHH:MM:SSZ"


### PR DESCRIPTION
When reading the GPA status.json file, it compares the GPA Version, we also need GPA VMExtension to check GPA status reported time. This is to report GPA is running or not and the status file up-to-date. Two scenarios could be detected by this improvement:
1. GPA service was down, hopefully it is in audit mode for WS. GPA VMExtension could report it (TBD report warning in subStatus) 
2. When the cx re-opt-in MSP feature with GPA VMExtension, the VM Extension should ignore the stale status.josn file.