### PR TITLE
Reduce the LoggerLevel for some proxying logs.

### DIFF
--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -246,7 +246,7 @@ impl ProxyServer {
         };
         let mut tcp_connection_logger = ConnectionLogger::new(tcp_connection_id, 0);
         tcp_connection_logger.write(
-            LoggerLevel::Info,
+            LoggerLevel::Trace,
             format!("Accepted new tcp connection [{tcp_connection_id}]."),
         );
 
@@ -393,7 +393,7 @@ impl ProxyServer {
             tcp_connection_context.clone(),
         );
         http_connection_context.log(
-            LoggerLevel::Info,
+            LoggerLevel::Trace,
             format!(
                 "Got request from {} for {} {}",
                 tcp_connection_context.client_addr,
@@ -471,7 +471,7 @@ impl ProxyServer {
                 return Ok(Self::closed_response(StatusCode::MISDIRECTED_REQUEST));
             }
         };
-        http_connection_context.log(LoggerLevel::Info, claim_details.to_string());
+        http_connection_context.log(LoggerLevel::Trace, claim_details.to_string());
 
         // authenticate the connection
         let access_control_rules = match proxy_authorizer::get_access_control_rules(


### PR DESCRIPTION
According to our current telemetry events, it sends out 4 events per new http request, while the first 3 are mainly at Trace level should not send out.
```
0[32] - Accepted new tcp connection [32].
32[32] - Got request from 127.0.0.1:57584 for GET /health
32[32] - {"userId":0,"userName":"root","userGroups":["root"],"processId":1254,"processName":{"Unix":[112,121,116,104,111,110,51,46,49,48]},"processFullPath":"/usr/bin/python3.10","processCmdLine":"python3 -u bin/WALinuxAgent-2.15.1.3-py3.12.egg -run-exthandlers","runAsElevated":true,"clientIp":"127.0.0.1","clientPort":57584}
{"id":32,"method":"GET","url":"/health","clientIp":"127.0.0.1","clientPort":57584,"ip":"168.63.129.16","port":32526,"userId":0,"userName":"root","userGroups":["root"],"processFullPath":"/usr/bin/python3.10","processCmdLine":"python3 -u bin/WALinuxAgent-2.15.1.3-py3.12.egg -run-exthandlers","runAsElevated":true,"responseStatus":"200 OK","elapsedTime":601,"errorDetails":""}
```
