### PR TITLE
Telemetry update: Split event_sender from event_reader

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run Code Coverage for proxy_agent_shared
         run: |
-          cargo llvm-cov --target x86_64-pc-windows-msvc --manifest-path ./proxy_agent_shared/Cargo.toml --output-path ./out/proxy_agent_shared_codeCov.txt --release
+          cargo llvm-cov --target x86_64-pc-windows-msvc --manifest-path ./proxy_agent_shared/Cargo.toml --output-path ./out/proxy_agent_shared_codeCov.txt --release -- --test-threads=1
           type ./out/proxy_agent_shared_codeCov.txt
 
       - name: Parse Code Coverage for proxy_agent_shared
@@ -325,7 +325,7 @@ jobs:
 
       - name: Run Code Coverage for proxy_agent_shared
         run: |
-          cargo llvm-cov --target x86_64-unknown-linux-musl --manifest-path ./proxy_agent_shared/Cargo.toml --output-path ./out/proxy_agent_shared_codeCov.txt --release
+          cargo llvm-cov --target x86_64-unknown-linux-musl --manifest-path ./proxy_agent_shared/Cargo.toml --output-path ./out/proxy_agent_shared_codeCov.txt --release -- --test-threads=1
           cat ./out/proxy_agent_shared_codeCov.txt
 
       - name: Parse Code Coverage for proxy_agent_shared

--- a/build.cmd
+++ b/build.cmd
@@ -134,12 +134,10 @@ if "%Target%"=="arm64" (
     xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_shared\target\%Configuration%\
 
     echo ======= run rust proxy_agent_shared tests
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    if  %ERRORLEVEL% NEQ 0 (
-        echo call cargo test proxy_agent_shared with exit-code: %errorlevel%
-        exit /b %errorlevel%
-    )
+    REM %ERRORLEVEL% inside a (...) block is expanded when the entire block is parsed, not when each line run
+    REM use exit /b 1 to propagate error codes inside a (...) block
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
+    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 
 echo ======= copy config file for windows platform
@@ -167,12 +165,9 @@ if "%Target%"=="arm64" (
     xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent\target\%Configuration%\
 
     echo ======= run rust proxy_agent tests
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    if  %ERRORLEVEL% NEQ 0 (
-        echo call cargo test proxy_agent with exit-code: %errorlevel%
-        exit /b %errorlevel%
-    )
+    REM use exit /b 1 to propagate error codes inside a (...) block
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture || exit /b 1
+    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 
 echo ======= build proxy_agent_extension
@@ -196,12 +191,9 @@ if "%Target%"=="arm64" (
     xcopy /Y /S /C /Q %out_dir% %root_path%proxy_agent_extension\target\%Configuration%\
 
     echo ======= run rust proxy_agent_extension tests
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture
-    if  %ERRORLEVEL% NEQ 0 (
-        echo call cargo test proxy_agent_extension with exit-code: %errorlevel%
-        exit /b %errorlevel%
-    )
+    REM use exit /b 1 to propagate error codes inside a (...) block
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture || exit /b 1
+    call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 
 echo ======= build proxy_agent_setup

--- a/build.cmd
+++ b/build.cmd
@@ -136,7 +136,7 @@ if "%Target%"=="arm64" (
     echo ======= run rust proxy_agent_shared tests
     REM %ERRORLEVEL% inside a (...) block is expanded when the entire block is parsed, not when each line run
     REM use exit /b 1 to propagate error codes inside a (...) block
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  ^|^| exit /b 1
     call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 
@@ -166,7 +166,7 @@ if "%Target%"=="arm64" (
 
     echo ======= run rust proxy_agent tests
     REM use exit /b 1 to propagate error codes inside a (...) block
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture || exit /b 1
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture ^|^| exit /b 1
     call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 
@@ -192,7 +192,7 @@ if "%Target%"=="arm64" (
 
     echo ======= run rust proxy_agent_extension tests
     REM use exit /b 1 to propagate error codes inside a (...) block
-    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture || exit /b 1
+    echo call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture ^|^| exit /b 1
     call cargo test --all-features  %release_flag% --manifest-path %cargo_toml% --target-dir %out_path% --target %build_target% -- --test-threads=1 --nocapture  || exit /b 1
 )
 

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -1059,7 +1059,7 @@ mod tests {
             interval: Duration::from_millis(10),
             cancellation_token: cancellation_token.clone(),
             key_keeper_shared_state: key_keeper::KeyKeeperSharedState::start_new(),
-            common_state: key_keeper::CommonState::start_new(),
+            common_state: key_keeper::CommonState::start_new(cancellation_token.clone()),
             redirector_shared_state: key_keeper::RedirectorSharedState::start_new(),
             provision_shared_state: key_keeper::ProvisionSharedState::start_new(),
             agent_status_shared_state: key_keeper::AgentStatusSharedState::start_new(),

--- a/proxy_agent/src/shared_state.rs
+++ b/proxy_agent/src/shared_state.rs
@@ -56,10 +56,12 @@ pub struct SharedState {
 
 impl SharedState {
     pub fn start_all() -> Self {
+        let cancellation_token = CancellationToken::new();
+
         SharedState {
-            cancellation_token: CancellationToken::new(),
+            cancellation_token: cancellation_token.clone(),
             key_keeper_shared_state: key_keeper_wrapper::KeyKeeperSharedState::start_new(),
-            common_state: CommonState::start_new(),
+            common_state: CommonState::start_new(cancellation_token.clone()),
             provision_shared_state: provision_wrapper::ProvisionSharedState::start_new(),
             agent_status_shared_state: agent_status_wrapper::AgentStatusSharedState::start_new(),
             redirector_shared_state: redirector_wrapper::RedirectorSharedState::start_new(),

--- a/proxy_agent_shared/src/common_state.rs
+++ b/proxy_agent_shared/src/common_state.rs
@@ -216,7 +216,10 @@ mod tests {
         let common_state = CommonState::start_new(cancellation_token);
 
         // Get non-existent key should return None
-        let value = common_state.get_state("non_existent_key".to_string()).await.unwrap();
+        let value = common_state
+            .get_state("non_existent_key".to_string())
+            .await
+            .unwrap();
         assert!(value.is_none(), "Non-existent key should return None");
 
         // Set and get a key-value pair
@@ -224,7 +227,10 @@ mod tests {
             .set_state(SECURE_KEY_GUID.to_string(), "test-guid-value".to_string())
             .await
             .unwrap();
-        let value = common_state.get_state(SECURE_KEY_GUID.to_string()).await.unwrap();
+        let value = common_state
+            .get_state(SECURE_KEY_GUID.to_string())
+            .await
+            .unwrap();
         assert_eq!(value, Some("test-guid-value".to_string()));
 
         // Set and get another key-value pair
@@ -232,19 +238,31 @@ mod tests {
             .set_state(SECURE_KEY_VALUE.to_string(), "test-key-value".to_string())
             .await
             .unwrap();
-        let value = common_state.get_state(SECURE_KEY_VALUE.to_string()).await.unwrap();
+        let value = common_state
+            .get_state(SECURE_KEY_VALUE.to_string())
+            .await
+            .unwrap();
         assert_eq!(value, Some("test-key-value".to_string()));
 
         // Update existing key
         common_state
-            .set_state(SECURE_KEY_GUID.to_string(), "updated-guid-value".to_string())
+            .set_state(
+                SECURE_KEY_GUID.to_string(),
+                "updated-guid-value".to_string(),
+            )
             .await
             .unwrap();
-        let value = common_state.get_state(SECURE_KEY_GUID.to_string()).await.unwrap();
+        let value = common_state
+            .get_state(SECURE_KEY_GUID.to_string())
+            .await
+            .unwrap();
         assert_eq!(value, Some("updated-guid-value".to_string()));
 
         // First key should still have its value
-        let value = common_state.get_state(SECURE_KEY_VALUE.to_string()).await.unwrap();
+        let value = common_state
+            .get_state(SECURE_KEY_VALUE.to_string())
+            .await
+            .unwrap();
         assert_eq!(value, Some("test-key-value".to_string()));
     }
 
@@ -257,7 +275,10 @@ mod tests {
         for i in 0..10 {
             let key = format!("key_{}", i);
             let value = format!("value_{}", i);
-            common_state.set_state(key.clone(), value.clone()).await.unwrap();
+            common_state
+                .set_state(key.clone(), value.clone())
+                .await
+                .unwrap();
             let retrieved = common_state.get_state(key).await.unwrap();
             assert_eq!(retrieved, Some(value));
         }

--- a/proxy_agent_shared/src/current_info.rs
+++ b/proxy_agent_shared/src/current_info.rs
@@ -45,6 +45,8 @@ static CURRENT_OS_INFO: Lazy<(String, String)> = Lazy::new(|| {
     (arch, os)
 });
 
+static CURRENT_EXE_VERSION: Lazy<String> = Lazy::new(misc_helpers::get_current_exe_version);
+
 pub fn get_ram_in_mb() -> u64 {
     CURRENT_SYS_INFO.0
 }
@@ -59,6 +61,10 @@ pub fn get_cpu_arch() -> String {
 
 pub fn get_long_os_version() -> String {
     CURRENT_OS_INFO.1.to_string()
+}
+
+pub fn get_current_exe_version() -> String {
+    CURRENT_EXE_VERSION.clone()
 }
 
 #[cfg(test)]

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -214,7 +214,7 @@ pub fn get_current_version() -> String {
 /// otherwise fallback to Cargo.toml version.
 /// # Returns
 /// A string representing the current executable version
-pub fn get_current_exe_version() -> String {
+pub(crate) fn get_current_exe_version() -> String {
     #[cfg(windows)]
     {
         match try_get_current_exe_version() {

--- a/proxy_agent_shared/src/telemetry.rs
+++ b/proxy_agent_shared/src/telemetry.rs
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: MIT
 pub mod event_logger;
 pub mod event_reader;
+pub mod event_sender;
 pub mod span;
 pub mod telemetry_event;
 
-use crate::misc_helpers;
+use crate::{current_info, misc_helpers};
 use serde_derive::{Deserialize, Serialize};
 
+pub const GENERIC_EVENT_FILE_SEARCH_PATTERN: &str = r"^[0-9]+\.json$";
+pub fn new_generic_event_file_name() -> String {
+    format!("{}.json", misc_helpers::get_date_time_unix_nano())
+}
+
+/// Represents a telemetry event for TelemetryGenericLogsEvent
 #[derive(Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Event {
@@ -26,7 +33,7 @@ impl Event {
         Event {
             EventLevel: level,
             Message: message,
-            Version: misc_helpers::get_current_exe_version(),
+            Version: current_info::get_current_exe_version(),
             TaskName: task_name,
             EventPid: std::process::id().to_string(),
             EventTid: misc_helpers::get_thread_identity(),

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -123,6 +123,8 @@ pub fn stop() {
     SHUT_DOWN.store(true, Ordering::Relaxed);
 }
 
+/// Write event and log to file
+/// This event will send out as `TelemetryGenericLogsEvent`
 pub fn write_event(
     level: Level,
     message: String,
@@ -136,6 +138,8 @@ pub fn write_event(
     logger_manager::log(logger_key.to_string(), level, message);
 }
 
+/// Write event only without logging to file
+/// This event will send out as `TelemetryGenericLogsEvent`
 pub fn write_event_only(level: Level, message: String, method_name: &str, module_name: &str) {
     let event_message = if message.len() > MAX_MESSAGE_LENGTH {
         message[..MAX_MESSAGE_LENGTH].to_string()

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -72,7 +72,10 @@ pub async fn start<F, Fut>(
 
         // Check the event file counts,
         // if it exceeds the max file number, drop the new events
-        match misc_helpers::get_files(&event_dir) {
+        match misc_helpers::search_files(
+            &event_dir,
+            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+        ) {
             Ok(files) => {
                 if files.len() >= max_event_file_count {
                     logger_manager::write_log(Level::Warn, format!(

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -1,63 +1,19 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-//! This module contains the logic to read the telemetry event files and send them to the wire server.
-//! The telemetry event files are written by the event_logger module.
+//! This module contains the logic to read the telemetry event files.
+//! //! The telemetry event files are written by the event_logger module.
 
-use crate::common_state;
 use crate::common_state::CommonState;
-use crate::host_clients::imds_client::ImdsClient;
-use crate::host_clients::wire_server_client::WireServerClient;
 use crate::logger::logger_manager;
 use crate::misc_helpers;
-use crate::result::Result;
-use crate::telemetry::telemetry_event::TelemetryData;
+use crate::telemetry::event_sender;
 use crate::telemetry::telemetry_event::TelemetryEvent;
+use crate::telemetry::telemetry_event::TelemetryGenericLogsEvent;
 use crate::telemetry::Event;
 use std::fs::remove_file;
 use std::path::PathBuf;
 use std::time::Duration;
-use tokio_util::sync::CancellationToken;
-
-#[cfg(test)]
-const EMPTY_GUID: &str = "00000000-0000-0000-0000-000000000000";
-
-const WIRE_SERVER_IP: &str = "168.63.129.16";
-const WIRE_SERVER_PORT: u16 = 80u16;
-const IMDS_IP: &str = "169.254.169.254";
-const IMDS_PORT: u16 = 80u16;
-
-/// VmMetaData contains the metadata of the VM.
-/// The metadata is used to identify the VM and the image origin.
-/// It will be part of the telemetry data send to the wire server.
-/// The metadata is updated by the wire server and the IMDS client.
-#[derive(Clone, Debug)]
-pub struct VmMetaData {
-    pub container_id: String,
-    pub tenant_name: String,
-    pub role_name: String,
-    pub role_instance_name: String,
-    pub subscription_id: String,
-    pub resource_group_name: String,
-    pub vm_id: String,
-    pub image_origin: u64,
-}
-
-impl VmMetaData {
-    #[cfg(test)]
-    pub fn empty() -> Self {
-        VmMetaData {
-            container_id: EMPTY_GUID.to_string(),
-            tenant_name: EMPTY_GUID.to_string(),
-            role_name: EMPTY_GUID.to_string(),
-            role_instance_name: EMPTY_GUID.to_string(),
-            subscription_id: EMPTY_GUID.to_string(),
-            resource_group_name: EMPTY_GUID.to_string(),
-            vm_id: EMPTY_GUID.to_string(),
-            image_origin: 3, // unknown
-        }
-    }
-}
 
 /// Configuration for limiting EventReader behavior
 #[derive(Default, Clone)]
@@ -90,8 +46,6 @@ impl EventReaderLimits {
 
 pub struct EventReader {
     dir_path: PathBuf,
-    delay_start: bool,
-    cancellation_token: CancellationToken,
     common_state: CommonState,
     execution_mode: String,
     event_name: String,
@@ -107,16 +61,12 @@ impl EventReader {
     /// The event_name is used to indicate the name of the event reader.
     pub fn new(
         dir_path: PathBuf,
-        delay_start: bool,
-        cancellation_token: CancellationToken,
         common_state: CommonState,
         execution_mode: String,
         event_name: String,
     ) -> EventReader {
         EventReader {
             dir_path,
-            delay_start,
-            cancellation_token,
             common_state,
             execution_mode,
             event_name,
@@ -127,8 +77,6 @@ impl EventReader {
     /// Create a new EventReader with limits configuration.
     pub fn new_with_limits(
         dir_path: PathBuf,
-        delay_start: bool,
-        cancellation_token: CancellationToken,
         common_state: CommonState,
         execution_mode: String,
         event_name: String,
@@ -136,8 +84,6 @@ impl EventReader {
     ) -> EventReader {
         EventReader {
             dir_path,
-            delay_start,
-            cancellation_token,
             common_state,
             execution_mode,
             event_name,
@@ -145,91 +91,41 @@ impl EventReader {
         }
     }
 
-    pub async fn start(
-        &self,
-        interval: Option<Duration>,
-        server_ip: Option<&str>,
-        server_port: Option<u16>,
-    ) {
+    pub async fn start(&self, delay_start: bool, interval: Option<Duration>) {
+        if delay_start {
+            // delay start the event_reader task to give additional CPU cycles to more important threads
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }
         logger_manager::write_info("telemetry event reader task started.".to_string());
 
-        let wire_server_client = WireServerClient::new(
-            server_ip.unwrap_or(WIRE_SERVER_IP),
-            server_port.unwrap_or(WIRE_SERVER_PORT),
-        );
-        let imds_client = ImdsClient::new(
-            server_ip.unwrap_or(IMDS_IP),
-            server_port.unwrap_or(IMDS_PORT),
-        );
-
         let interval = interval.unwrap_or(Duration::from_secs(300));
+        let cancellation_token = self.common_state.get_cancellation_token();
         tokio::select! {
-            _ = self.loop_reader(interval,  wire_server_client, imds_client ) => {}
-            _ = self.cancellation_token.cancelled() => {
+            _ = self.loop_reader(interval) => {}
+            _ = cancellation_token.cancelled() => {
                 logger_manager::write_warn("cancellation token signal received, stop the telemetry event reader task.".to_string());
             }
         }
     }
 
-    async fn loop_reader(
-        &self,
-        interval: Duration,
-        wire_server_client: WireServerClient,
-        imds_client: ImdsClient,
-    ) {
-        let mut first = true;
-
+    async fn loop_reader(&self, interval: Duration) {
         loop {
-            if first {
-                if self.delay_start {
-                    // delay start the event_reader task to give additional CPU cycles to more important threads
-                    tokio::time::sleep(Duration::from_secs(60)).await;
-                }
-                first = false;
-            }
-
-            // refresh vm metadata
-            match self
-                .update_vm_meta_data(&wire_server_client, &imds_client)
-                .await
-            {
-                Ok(()) => {
-                    logger_manager::write_info("success updated the vm metadata.".to_string());
-                }
-                Err(e) => {
-                    logger_manager::write_warn(format!(
-                        "Failed to read vm metadata with error {e}."
-                    ));
-                }
-            }
-
-            self.process_once(&wire_server_client).await;
+            self.process_once().await;
             tokio::time::sleep(interval).await;
         }
     }
 
     /// Process the event files from the directory once.
-    pub async fn process_once(&self, wire_server_client: &WireServerClient) -> usize {
-        if let Ok(Some(vm_meta_data)) = self.common_state.get_vm_meta_data().await {
-            self.process_events(wire_server_client, &vm_meta_data).await
-        } else {
-            0
-        }
-    }
-
-    async fn process_events(
-        &self,
-        wire_server_client: &WireServerClient,
-        vm_meta_data: &VmMetaData,
-    ) -> usize {
+    pub async fn process_once(&self) -> usize {
         let event_count: usize;
         // get all [0-9]+.json event filenames with numbers in the directory
-        match misc_helpers::search_files(&self.dir_path, r"^[0-9]+\.json$") {
+        match misc_helpers::search_files(
+            &self.dir_path,
+            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+        ) {
             Ok(files) => {
                 let file_count = files.len();
-                event_count = self
-                    .process_events_and_clean(files, wire_server_client, vm_meta_data)
-                    .await;
+                event_count = self.process_events_and_clean(files).await;
                 let message = format!(
                     "Telemetry event reader sent {event_count} events from {file_count} files"
                 );
@@ -247,59 +143,7 @@ impl EventReader {
         event_count
     }
 
-    pub async fn update_vm_meta_data(
-        &self,
-        wire_server_client: &WireServerClient,
-        imds_client: &ImdsClient,
-    ) -> Result<()> {
-        let guid = self
-            .common_state
-            .get_state(common_state::SECURE_KEY_GUID.to_string())
-            .await
-            .unwrap_or(None);
-        let key = self
-            .common_state
-            .get_state(common_state::SECURE_KEY_VALUE.to_string())
-            .await
-            .unwrap_or(None);
-        let goal_state = wire_server_client
-            .get_goalstate(guid.clone(), key.clone())
-            .await?;
-        let shared_config = wire_server_client
-            .get_shared_config(
-                goal_state.get_shared_config_uri(),
-                guid.clone(),
-                key.clone(),
-            )
-            .await?;
-
-        let instance_info = imds_client
-            .get_imds_instance_info(guid.clone(), key.clone())
-            .await?;
-        let vm_meta_data = VmMetaData {
-            container_id: goal_state.get_container_id(),
-            role_name: shared_config.get_role_name(),
-            role_instance_name: shared_config.get_role_instance_name(),
-            tenant_name: shared_config.get_deployment_name(),
-            subscription_id: instance_info.get_subscription_id(),
-            resource_group_name: instance_info.get_resource_group_name(),
-            vm_id: instance_info.get_vm_id(),
-            image_origin: instance_info.get_image_origin(),
-        };
-
-        self.common_state
-            .set_vm_meta_data(Some(vm_meta_data))
-            .await?;
-
-        Ok(())
-    }
-
-    async fn process_events_and_clean(
-        &self,
-        files: Vec<PathBuf>,
-        wire_server_client: &WireServerClient,
-        vm_meta_data: &VmMetaData,
-    ) -> usize {
+    async fn process_events_and_clean(&self, files: Vec<PathBuf>) -> usize {
         let mut num_events_logged = 0;
         for file in files {
             if let Some(max_events) = self.limits.max_events_per_round {
@@ -341,8 +185,7 @@ impl EventReader {
             match misc_helpers::json_read_from_file::<Vec<Event>>(&file) {
                 Ok(events) => {
                     num_events_logged += events.len();
-                    self.send_events(events, wire_server_client, vm_meta_data)
-                        .await;
+                    self.handle_events(events).await;
                 }
                 Err(e) => {
                     logger_manager::write_warn(format!(
@@ -357,81 +200,32 @@ impl EventReader {
         num_events_logged
     }
 
-    const MAX_MESSAGE_SIZE: usize = 1024 * 64;
-    async fn send_events(
-        &self,
-        mut events: Vec<Event>,
-        wire_server_client: &WireServerClient,
-        vm_meta_data: &VmMetaData,
-    ) {
+    async fn handle_events(&self, mut events: Vec<Event>) {
+        let mut queued_event = false;
         while !events.is_empty() {
-            let mut telemetry_data = TelemetryData::new();
-            let mut add_more_events = true;
-            while !events.is_empty() && add_more_events {
-                match events.pop() {
-                    Some(event) => {
-                        telemetry_data.add_event(TelemetryEvent::from_event_log(
-                            &event,
-                            vm_meta_data.clone(),
-                            self.execution_mode.clone(),
-                            self.event_name.clone(),
-                            self.limits.version.clone(),
-                        ));
-
-                        if telemetry_data.get_size() >= Self::MAX_MESSAGE_SIZE {
-                            telemetry_data.remove_last_event();
-                            if telemetry_data.event_count() == 0 {
-                                match serde_json::to_string(&event) {
-                                    Ok(json) => {
-                                        logger_manager::write_warn(format!(
-                                            "Event data too large. Not sending to wire-server. Event: {json}.",
-                                        ));
-                                    }
-                                    Err(_) => {
-                                        logger_manager::write_warn(
-                                        "Event data too large. Not sending to wire-server. Event cannot be displayed.".to_string()
-                                        );
-                                    }
-                                }
-                            } else {
-                                events.push(event);
-                            }
-                            add_more_events = false;
-                        }
-                    }
-                    None => {
-                        break;
-                    }
+            match events.pop() {
+                Some(event) => {
+                    let telemetry_event = TelemetryGenericLogsEvent::from_event_log(
+                        &event,
+                        self.execution_mode.clone(),
+                        self.event_name.clone(),
+                        self.limits.version.clone(),
+                    );
+                    let telemetry_event = TelemetryEvent::GenericLogsEvent(telemetry_event);
+                    event_sender::enqueue_event(telemetry_event);
+                    queued_event = true;
                 }
-            }
-
-            Self::send_data_to_wire_server(telemetry_data, wire_server_client).await;
-        }
-    }
-
-    async fn send_data_to_wire_server(
-        telemetry_data: TelemetryData,
-        wire_server_client: &WireServerClient,
-    ) {
-        if telemetry_data.event_count() == 0 {
-            return;
-        }
-
-        for _ in [0; 5] {
-            match wire_server_client
-                .send_telemetry_data(telemetry_data.to_xml())
-                .await
-            {
-                Ok(()) => {
+                None => {
                     break;
                 }
-                Err(e) => {
-                    logger_manager::write_warn(format!(
-                        "Failed to send telemetry data to host with error: {e}"
-                    ));
-                    // wait 15 seconds and retry
-                    tokio::time::sleep(Duration::from_secs(15)).await;
-                }
+            }
+        }
+
+        if queued_event {
+            if let Err(e) = self.common_state.notify_telemetry_event().await {
+                logger_manager::write_warn(format!(
+                    "Failed to notify telemetry event with error: {e}"
+                ));
             }
         }
     }
@@ -456,8 +250,8 @@ impl EventReader {
 mod tests {
     use super::*;
     use crate::misc_helpers;
-    use crate::server_mock;
     use std::{env, fs};
+    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn test_event_reader_thread() {
@@ -468,42 +262,13 @@ mod tests {
         let mut events_dir = temp_dir.to_path_buf();
         events_dir.push("Events");
 
-        // start wire_server listener
-        let ip = "127.0.0.1";
-        let port = 7071u16;
-        let cancellation_token = CancellationToken::new();
-        let common_state = CommonState::start_new();
-        let wire_server_client = WireServerClient::new(ip, port);
-        let imds_client = ImdsClient::new(ip, port);
-        tokio::spawn(server_mock::start(
-            ip.to_string(),
-            port,
-            cancellation_token.clone(),
-        ));
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        logger_manager::write_info("server_mock started.".to_string());
-
+        let common_state = CommonState::start_new(CancellationToken::new());
         let event_reader = EventReader::new(
             events_dir.clone(),
-            false,
-            cancellation_token.clone(),
             common_state.clone(),
             "Test".to_string(),
             "test_event_reader_thread".to_string(),
         );
-
-        // refresh vm metadata
-        match event_reader
-            .update_vm_meta_data(&wire_server_client, &imds_client)
-            .await
-        {
-            Ok(()) => {
-                logger_manager::write_info("success updated the vm metadata.".to_string());
-            }
-            Err(e) => {
-                logger_manager::write_warn(format!("Failed to read vm metadata with error {}.", e));
-            }
-        }
 
         // Write events to events dir
         let message = r#"{\"method\":\"GET\",\"url\":\"/machine/37569ad2-69a3-44fd-b653-813e62a177cf/68938c06%2D5233%2D4ff9%2Da173%2D0ac0a2754f8a.%5FWS2022?comp=config&type=hostingEnvironmentConfig&incarnation=2\",\"ip\":\"168.63.129.16\",\"port\":80,\"userId\":999,\"userName\":\"WS2022$\",\"processName\":\"C:\\\\WindowsAzure\\\\GuestAgent_2.7.41491.1071_2023-03-02_185502\\\\WindowsAzureGuestAgent.exe\",\"runAsElevated\":true,\"responseStatus\":\"200 OK\",\"elapsedTime\":8}"#;
@@ -533,26 +298,20 @@ mod tests {
             .with_version("test_version".to_string());
         let event_reader_with_limits = EventReader::new_with_limits(
             events_dir.clone(),
-            false,
-            cancellation_token.clone(),
             common_state.clone(),
             "Test".to_string(),
             "test_event_reader_thread".to_string(),
             event_reader_limits.clone(),
         );
         // Check the events processed
-        let events_processed = event_reader_with_limits
-            .process_once(&wire_server_client)
-            .await;
+        let events_processed = event_reader_with_limits.process_once().await;
         logger_manager::write_info(format!("Send {} events from event files", events_processed));
         //Should be 10 events processed and read into events Vector
         assert_eq!(events_processed, 10, "Events processed should be 10");
         let files = misc_helpers::get_files(&events_dir).unwrap();
         assert_eq!(1, files.len(), "Must still have 1 event file.");
         // test EventReader with limits - second round
-        let events_processed = event_reader_with_limits
-            .process_once(&wire_server_client)
-            .await;
+        let events_processed = event_reader_with_limits.process_once().await;
         logger_manager::write_info(format!("Send {} events from event files", events_processed));
         //Should be 10 events processed and read into events Vector
         assert_eq!(events_processed, 10, "Events processed should be 10");
@@ -572,7 +331,7 @@ mod tests {
         assert_eq!(2, files.len(), "Must have 2 event files.");
 
         // test EventReader without limits
-        let events_processed = event_reader.process_once(&wire_server_client).await;
+        let events_processed = event_reader.process_once().await;
         logger_manager::write_info(format!("Send {} events from event files", events_processed));
         //Should be 20 events processed and read into events Vector
         assert_eq!(events_processed, 20, "Events processed should be 20");
@@ -589,7 +348,7 @@ mod tests {
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("a{}.json", misc_helpers::get_date_time_unix_nano()));
         misc_helpers::json_write_to_file(&events, &file_path).unwrap();
-        let events_processed = event_reader.process_once(&wire_server_client).await;
+        let events_processed = event_reader.process_once().await;
         assert_eq!(0, events_processed, "events_processed must be 0.");
         let files = misc_helpers::get_files(&events_dir).unwrap();
         assert!(
@@ -597,7 +356,7 @@ mod tests {
             ".notjson files should not been cleaned up."
         );
 
-        cancellation_token.cancel();
+        common_state.cancel_cancellation_token();
         _ = fs::remove_dir_all(&temp_dir);
     }
 }

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+//! This module contains the logic to send the telemetry event to the wire server.
+use std::time::Duration;
+
+use crate::common_state::{self, CommonState};
+use crate::host_clients::imds_client::ImdsClient;
+use crate::host_clients::wire_server_client::WireServerClient;
+use crate::logger::logger_manager;
+use crate::result::Result;
+use crate::telemetry::telemetry_event::{
+    TelemetryData, TelemetryEvent, TelemetryEventVMData, VmMetaData,
+};
+use concurrent_queue::ConcurrentQueue;
+use once_cell::sync::Lazy;
+
+static TELEMETRY_EVENT_QUEUE: Lazy<ConcurrentQueue<TelemetryEvent>> =
+    Lazy::new(|| ConcurrentQueue::<TelemetryEvent>::bounded(1000));
+
+const MAX_MESSAGE_SIZE: usize = 1024 * 64;
+const WIRE_SERVER_IP: &str = "168.63.129.16";
+const WIRE_SERVER_PORT: u16 = 80u16;
+const IMDS_IP: &str = "169.254.169.254";
+const IMDS_PORT: u16 = 80u16;
+
+pub struct EventSender {
+    common_state: CommonState,
+}
+
+impl EventSender {
+    pub fn new(common_state: CommonState) -> Self {
+        EventSender { common_state }
+    }
+
+    pub async fn start(&self, server_ip: Option<&str>, server_port: Option<u16>) {
+        logger_manager::write_info("telemetry event sender task started.".to_string());
+        let notify = match self.common_state.get_telemetry_event_notify().await {
+            Ok(notify) => notify,
+            Err(e) => {
+                logger_manager::write_err(format!("Failed to get notify: {e}"));
+                return;
+            }
+        };
+        let cancellation_token = self.common_state.get_cancellation_token();
+
+        loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    logger_manager::write_info("telemetry event sender task cancelled.".to_string());
+                    // Close the event queue to stop accepting new events
+                    TELEMETRY_EVENT_QUEUE.close();
+                    break;
+                }
+                _ = notify.notified() => {
+                    self.process_event_queue(server_ip, server_port).await;
+                }
+            }
+        }
+    }
+
+    async fn process_event_queue(&self, server_ip: Option<&str>, server_port: Option<u16>) {
+        if TELEMETRY_EVENT_QUEUE.is_empty() {
+            return;
+        }
+
+        let wire_server_client = WireServerClient::new(
+            server_ip.unwrap_or(WIRE_SERVER_IP),
+            server_port.unwrap_or(WIRE_SERVER_PORT),
+        );
+        let imds_client = ImdsClient::new(
+            server_ip.unwrap_or(IMDS_IP),
+            server_port.unwrap_or(IMDS_PORT),
+        );
+        // refresh vm metadata
+        match self
+            .update_vm_meta_data(&wire_server_client, &imds_client)
+            .await
+        {
+            Ok(()) => {
+                logger_manager::write_info("success updated the vm metadata.".to_string());
+            }
+            Err(e) => {
+                logger_manager::write_warn(format!("Failed to update vm metadata with error {e}."));
+            }
+        }
+
+        if let Ok(Some(vm_meta_data)) = self.common_state.get_vm_meta_data().await {
+            let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
+            self.send_events(&wire_server_client, &vm_data).await
+        } else {
+            logger_manager::write_warn(
+                "VmMetaData is not available. Skipping sending telemetry events.".to_string(),
+            );
+        }
+    }
+
+    pub async fn update_vm_meta_data(
+        &self,
+        wire_server_client: &WireServerClient,
+        imds_client: &ImdsClient,
+    ) -> Result<()> {
+        let guid = self
+            .common_state
+            .get_state(common_state::SECURE_KEY_GUID.to_string())
+            .await
+            .unwrap_or(None);
+        let key = self
+            .common_state
+            .get_state(common_state::SECURE_KEY_VALUE.to_string())
+            .await
+            .unwrap_or(None);
+        let goal_state = wire_server_client
+            .get_goalstate(guid.clone(), key.clone())
+            .await?;
+        let shared_config = wire_server_client
+            .get_shared_config(
+                goal_state.get_shared_config_uri(),
+                guid.clone(),
+                key.clone(),
+            )
+            .await?;
+
+        let instance_info = imds_client
+            .get_imds_instance_info(guid.clone(), key.clone())
+            .await?;
+        let vm_meta_data = VmMetaData {
+            container_id: goal_state.get_container_id(),
+            role_name: shared_config.get_role_name(),
+            role_instance_name: shared_config.get_role_instance_name(),
+            tenant_name: shared_config.get_deployment_name(),
+            subscription_id: instance_info.get_subscription_id(),
+            resource_group_name: instance_info.get_resource_group_name(),
+            vm_id: instance_info.get_vm_id(),
+            image_origin: instance_info.get_image_origin(),
+        };
+
+        self.common_state
+            .set_vm_meta_data(Some(vm_meta_data))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn send_events(
+        &self,
+        wire_server_client: &WireServerClient,
+        vm_data: &TelemetryEventVMData,
+    ) {
+        while !TELEMETRY_EVENT_QUEUE.close() && !TELEMETRY_EVENT_QUEUE.is_empty() {
+            let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data.clone());
+            let mut add_more_events = true;
+            while !TELEMETRY_EVENT_QUEUE.is_empty() && add_more_events {
+                match TELEMETRY_EVENT_QUEUE.pop() {
+                    Ok(event) => {
+                        telemetry_data.add_event(event.clone());
+
+                        if telemetry_data.get_size() >= MAX_MESSAGE_SIZE {
+                            _ = telemetry_data.remove_last_event(event.clone());
+                            if telemetry_data.event_count() == 0 {
+                                logger_manager::write_warn(format!(
+                                    "Event data too large. Not sending to wire-server. Event: {}.",
+                                    event.to_xml_event(vm_data),
+                                ));
+                            } else if let Err(e) = TELEMETRY_EVENT_QUEUE.push(event) {
+                                logger_manager::write_warn(format!(
+                                    "Failed to re-enqueue telemetry event with error: {e}"
+                                ));
+                            }
+                            add_more_events = false;
+                        }
+                    }
+                    Err(err) => {
+                        logger_manager::write_warn(format!(
+                            "Failed to pop telemetry event from queue with error: {err}"
+                        ));
+                        break;
+                    }
+                }
+            }
+
+            Self::send_data_to_wire_server(telemetry_data, wire_server_client).await;
+        }
+    }
+
+    async fn send_data_to_wire_server(
+        telemetry_data: TelemetryData,
+        wire_server_client: &WireServerClient,
+    ) {
+        if telemetry_data.event_count() == 0 {
+            return;
+        }
+
+        for _ in [0; 5] {
+            match wire_server_client
+                .send_telemetry_data(telemetry_data.to_xml())
+                .await
+            {
+                Ok(()) => {
+                    break;
+                }
+                Err(e) => {
+                    logger_manager::write_warn(format!(
+                        "Failed to send telemetry data to host with error: {e}"
+                    ));
+                    // wait 15 seconds and retry
+                    tokio::time::sleep(Duration::from_secs(15)).await;
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn enqueue_event(event: TelemetryEvent) {
+    if let Err(e) = TELEMETRY_EVENT_QUEUE.push(event) {
+        logger_manager::write_warn(format!("Failed to enqueue telemetry event with error: {e}"));
+    }
+}

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -417,7 +417,7 @@ mod tests {
         // Give it a moment to start event sender task
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Notifiy to process events
+        // Notify to process events
         process_common_state.notify_telemetry_event().await.unwrap();
 
         // Give it a moment to process the events while the VM data is still not set as Mock server not started yet

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -362,7 +362,7 @@ mod tests {
 
         // Mock server details
         let ip = "127.0.0.1";
-        let port = 7076u16;
+        let port = 7071u16;
 
         // Create EventSender
         let cancellation_token = CancellationToken::new();
@@ -439,8 +439,8 @@ mod tests {
         // Notify again to process events now that VM data can be retrieved
         process_common_state.notify_telemetry_event().await.unwrap();
 
-        // Give it a moment to process the events
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Give it a moment to process the events (needs enough time for HTTP requests)
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Verify queue is empty after processing
         assert_eq!(

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -147,7 +147,7 @@ impl EventSender {
         wire_server_client: &WireServerClient,
         vm_data: &TelemetryEventVMData,
     ) {
-        while !TELEMETRY_EVENT_QUEUE.close() && !TELEMETRY_EVENT_QUEUE.is_empty() {
+        while !TELEMETRY_EVENT_QUEUE.is_closed() && !TELEMETRY_EVENT_QUEUE.is_empty() {
             let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data.clone());
             let mut add_more_events = true;
             while !TELEMETRY_EVENT_QUEUE.is_empty() && add_more_events {
@@ -214,5 +214,278 @@ impl EventSender {
 pub(crate) fn enqueue_event(event: TelemetryEvent) {
     if let Err(e) = TELEMETRY_EVENT_QUEUE.push(event) {
         logger_manager::write_warn(format!("Failed to enqueue telemetry event with error: {e}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host_clients::wire_server_client::WireServerClient;
+    use crate::telemetry::telemetry_event::{TelemetryGenericLogsEvent, VmMetaData};
+    use crate::telemetry::Event;
+    use tokio_util::sync::CancellationToken;
+
+    fn create_test_vm_meta_data() -> VmMetaData {
+        VmMetaData {
+            container_id: "test-container-id".to_string(),
+            tenant_name: "test-tenant".to_string(),
+            role_name: "test-role".to_string(),
+            role_instance_name: "test-role-instance".to_string(),
+            subscription_id: "test-subscription-id".to_string(),
+            resource_group_name: "test-resource-group".to_string(),
+            vm_id: "test-vm-id".to_string(),
+            image_origin: 1,
+        }
+    }
+
+    fn create_test_event(message: &str) -> TelemetryEvent {
+        let event_log = Event::new(
+            "Informational".to_string(),
+            message.to_string(),
+            "test_task".to_string(),
+            "test_module".to_string(),
+        );
+        TelemetryEvent::GenericLogsEvent(TelemetryGenericLogsEvent::from_event_log(
+            &event_log,
+            "test_execution_mode".to_string(),
+            "test_event_name".to_string(),
+            Some("1.0.0".to_string()),
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_common_state_vm_meta_data() {
+        let cancellation_token = CancellationToken::new();
+        let common_state = CommonState::start_new(cancellation_token);
+
+        // Initially should be None
+        let vm_meta_data = common_state.get_vm_meta_data().await.unwrap();
+        assert!(vm_meta_data.is_none());
+
+        // Set vm_meta_data
+        let test_meta_data = create_test_vm_meta_data();
+        common_state
+            .set_vm_meta_data(Some(test_meta_data))
+            .await
+            .unwrap();
+
+        // Verify it was set and TelemetryEventVMData conversion works
+        let retrieved = common_state.get_vm_meta_data().await.unwrap().unwrap();
+        let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&retrieved);
+
+        assert_eq!(vm_data.container_id, "test-container-id");
+        assert_eq!(vm_data.tenant_name, "test-tenant");
+        assert_eq!(vm_data.role_name, "test-role");
+        assert_eq!(vm_data.role_instance_name, "test-role-instance");
+        assert_eq!(vm_data.subscription_id, "test-subscription-id");
+        assert_eq!(vm_data.resource_group_name, "test-resource-group");
+        assert_eq!(vm_data.vm_id, "test-vm-id");
+        assert_eq!(vm_data.image_origin, 1);
+
+        // Test notify functionality
+        let notify_result = common_state.get_telemetry_event_notify().await;
+        assert!(notify_result.is_ok());
+        assert!(common_state.notify_telemetry_event().await.is_ok());
+    }
+
+    #[test]
+    fn test_queue_bounded_capacity() {
+        // Create a local bounded queue for testing capacity behavior
+        let test_queue: ConcurrentQueue<TelemetryEvent> = ConcurrentQueue::bounded(10);
+
+        // Fill the queue
+        for i in 0..10 {
+            let event = create_test_event(&format!("Test message {}", i));
+            assert!(
+                test_queue.push(event).is_ok(),
+                "Should be able to push event {}",
+                i
+            );
+        }
+
+        // Queue should be full now
+        assert!(test_queue.is_full(), "Queue should be full after 10 pushes");
+
+        // Try to push one more - should fail
+        let extra_event = create_test_event("Extra event");
+        assert!(
+            test_queue.push(extra_event).is_err(),
+            "Push should fail when queue is full"
+        );
+    }
+
+    #[test]
+    fn test_telemetry_event_xml_format() {
+        let vm_meta_data = create_test_vm_meta_data();
+        let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
+
+        // Test single event XML
+        let event = create_test_event("Test XML message");
+        let event_xml = event.to_xml_event(&vm_data);
+        assert!(event_xml.contains("<Event id=\"7\">"));
+        assert!(event_xml.contains("<![CDATA["));
+        assert!(event_xml.contains("]]></Event>"));
+        assert!(event_xml.contains("TenantName"));
+        assert!(event_xml.contains("test-tenant"));
+
+        // Test provider ID
+        assert_eq!(
+            event.get_provider_id(),
+            "FFF0196F-EE4C-4EAF-9AA5-776F622DEB4F"
+        );
+
+        // Test full TelemetryData XML structure
+        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data);
+        telemetry_data.add_event(event);
+        let xml = telemetry_data.to_xml();
+
+        assert!(xml.starts_with("<?xml version=\"1.0\"?>"));
+        assert!(xml.contains("<TelemetryData version=\"1.0\">"));
+        assert!(xml.contains("</TelemetryData>"));
+        assert!(xml.contains("<Provider id=\"FFF0196F-EE4C-4EAF-9AA5-776F622DEB4F\">"));
+        assert!(xml.contains("</Provider>"));
+    }
+
+    /// Consolidated test for all TELEMETRY_EVENT_QUEUE and wire server operations.
+    /// This test must run in a single test function because the global static queue
+    /// cannot be reopened once closed. The test covers:
+    /// 1. Enqueue events and verify FIFO order
+    /// 2. Process empty queue
+    /// 3. Send data to wire server (empty and with events)
+    /// 4. Enqueue and process events with mock server
+    /// 5. EventSender lifecycle (cancellation) - must be last as it closes the queue
+    #[tokio::test]
+    async fn test_telemetry_event_queue_operations() {
+        // ===== Part 1: Test enqueue and FIFO order =====
+        // Clear the queue first
+        while TELEMETRY_EVENT_QUEUE.pop().is_ok() {}
+
+        // Mock server details
+        let ip = "127.0.0.1";
+        let port = 7076u16;
+
+        // Create EventSender
+        let cancellation_token = CancellationToken::new();
+        let process_common_state = CommonState::start_new(cancellation_token.clone());
+        let event_sender = EventSender::new(process_common_state.clone());
+
+        // Enqueue events
+        let event1 = create_test_event("Test message 1");
+        let event2 = create_test_event("Test message 2");
+        let event3 = create_test_event("Test message 3");
+
+        enqueue_event(event1.clone());
+        assert!(
+            !TELEMETRY_EVENT_QUEUE.is_empty(),
+            "Queue should not be empty after enqueue"
+        );
+
+        enqueue_event(event2.clone());
+        enqueue_event(event3.clone());
+        assert_eq!(TELEMETRY_EVENT_QUEUE.len(), 3, "Queue should have 3 events");
+
+        // Verify FIFO order
+        assert!(TELEMETRY_EVENT_QUEUE.pop().unwrap() == event1);
+        assert!(TELEMETRY_EVENT_QUEUE.pop().unwrap() == event2);
+        assert!(TELEMETRY_EVENT_QUEUE.pop().unwrap() == event3);
+        assert!(TELEMETRY_EVENT_QUEUE.is_empty());
+
+        // ===== Part 2: Test process empty queue - should return without error =====
+        event_sender.process_event_queue(None, None).await;
+        assert!(TELEMETRY_EVENT_QUEUE.is_empty());
+
+        // ===== Part 3: Test enqueue and process with mock server =====
+        // Enqueue events
+        let event_a = create_test_event("Test event A for processing");
+        let event_b = create_test_event("Test event B for processing");
+        let event_c = create_test_event("Test event C for processing");
+
+        enqueue_event(event_a);
+        enqueue_event(event_b);
+        enqueue_event(event_c);
+        assert_eq!(
+            TELEMETRY_EVENT_QUEUE.len(),
+            3,
+            "Queue should have 3 events after enqueue"
+        );
+
+        // Start the event sender in a separate task
+        let handle = tokio::spawn(async move {
+            event_sender.start(Some(ip), Some(port)).await;
+        });
+
+        // Give it a moment to start event sender task
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Notifiy to process events
+        process_common_state.notify_telemetry_event().await.unwrap();
+
+        // Give it a moment to process the events while the VM data is still not set as Mock server not started yet
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            TELEMETRY_EVENT_QUEUE.len(),
+            3,
+            "Queue should have 3 events after notify_telemetry_event but without VM data"
+        );
+
+        // Start mock server to respond to goalstate and shared config requests
+        tokio::spawn(crate::server_mock::start(
+            ip.to_string(),
+            port,
+            cancellation_token.clone(),
+        ));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Notify again to process events now that VM data can be retrieved
+        process_common_state.notify_telemetry_event().await.unwrap();
+
+        // Give it a moment to process the events
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Verify queue is empty after processing
+        assert_eq!(
+            TELEMETRY_EVENT_QUEUE.len(),
+            0,
+            "Queue should be empty after processing"
+        );
+
+        // Verify queue is NOT closed after processing
+        assert!(
+            !TELEMETRY_EVENT_QUEUE.is_closed(),
+            "Queue should not be closed after processing"
+        );
+
+        // ===== Part 4: Test send_data_to_wire_server =====
+        let wire_server_client = WireServerClient::new(ip, port);
+        let vm_meta_data = create_test_vm_meta_data();
+        let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
+
+        // Test sending empty data - should return early without error
+        let empty_data = TelemetryData::new_with_vm_data(vm_data.clone());
+        assert_eq!(empty_data.event_count(), 0);
+        EventSender::send_data_to_wire_server(empty_data, &wire_server_client).await;
+
+        // Test sending data with events
+        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data);
+        telemetry_data.add_event(create_test_event("Test event 1"));
+        telemetry_data.add_event(create_test_event("Test event 2"));
+        assert_eq!(telemetry_data.event_count(), 2);
+        EventSender::send_data_to_wire_server(telemetry_data, &wire_server_client).await;
+
+        // ===== Part 5: Test EventSender lifecycle (cancellation) =====
+        // This MUST be last as it closes the queue permanently
+
+        // Cancel the token - this will close the queue, stop the event sender task and stop mock server
+        process_common_state.cancel_cancellation_token();
+
+        // Wait for the task to complete
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(result.is_ok(), "Event sender should stop when cancelled");
+
+        // Verify queue is now closed
+        assert!(
+            TELEMETRY_EVENT_QUEUE.is_closed(),
+            "Queue should be closed after cancellation"
+        );
     }
 }

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -440,7 +440,7 @@ mod tests {
         process_common_state.notify_telemetry_event().await.unwrap();
 
         // Give it a moment to process the events
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
         // Verify queue is empty after processing
         assert_eq!(

--- a/proxy_agent_shared/src/telemetry/telemetry_event.rs
+++ b/proxy_agent_shared/src/telemetry/telemetry_event.rs
@@ -534,7 +534,10 @@ mod tests {
         // Test provider ID
         let event = create_test_telemetry_event("Test message");
         assert_eq!(event.get_provider_id(), METRICS_PROVIDER_ID);
-        assert_eq!(TelemetryGenericLogsEvent::get_provider_id(), METRICS_PROVIDER_ID);
+        assert_eq!(
+            TelemetryGenericLogsEvent::get_provider_id(),
+            METRICS_PROVIDER_ID
+        );
 
         // Test XML event generation
         let vm_data = create_test_vm_data();


### PR DESCRIPTION
- Add enum `TelemetryEvent` for current `TelemetryGenericLogsEvent`, help add more telemetry event types.
- Add struct `TelemetryEventVMData` for common fields shared between all telemetry event types.
- Refactor event_log bit to able start accept other types of telemetry events.
- Move telemetry sender business logic out of event reader module
