### PR TITLE
 update `bytes` to the latest compatible version (1.11.1 or newer) in our Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
Cargo-audit caught a vulnerability at bytes crate https://github.com/Azure/GuestProxyAgent/actions/runs/21640414410/job/62378073614?pr=311

Scanning Cargo.lock for vulnerabilities (189 crate dependencies)
Crate:     bytes
Version:   1.7.1
Title:     Integer overflow in `BytesMut::reserve`
Date:      2026-02-03
error: 1 vulnerability found!
ID:        RUSTSEC-2026-0007
URL:       https://github.com/advisories/GHSA-434x-w66g-qw3r
Solution:  Upgrade to >=1.11.1

Action: run the command `cargo update -p bytes` to update bytes to the latest compatible version 
