### PR TITLE
Fix UT in internal build pipeline

### DIFF
--- a/proxy_agent_shared/src/etw/etw_reader.rs
+++ b/proxy_agent_shared/src/etw/etw_reader.rs
@@ -32,21 +32,25 @@ pub struct System {
     pub provider: Provider,
     #[serde(rename = "EventID")]
     pub event_id: u32,
-    #[serde(rename = "Version")]
+    /// Version is only present in ETW events, not classic event log entries
+    #[serde(rename = "Version", default)]
     pub version: u8,
     #[serde(rename = "Level")]
     pub level: u8,
-    #[serde(rename = "Task")]
+    /// Task is only present in ETW events, not classic event log entries
+    #[serde(rename = "Task", default)]
     pub task: u8,
-    #[serde(rename = "Opcode")]
+    /// Opcode is only present in ETW events, not classic event log entries
+    #[serde(rename = "Opcode", default)]
     pub opcode: u8,
-    #[serde(rename = "Keywords")]
+    #[serde(rename = "Keywords", default)]
     pub keywords: String,
     #[serde(rename = "TimeCreated")]
     pub time_created: TimeCreated,
     #[serde(rename = "EventRecordID")]
     pub event_record_id: u64,
-    #[serde(rename = "Execution")]
+    /// Execution may not be present in some classic event log entries
+    #[serde(rename = "Execution", default)]
     pub execution: Execution,
     #[serde(rename = "Channel")]
     pub channel: String,
@@ -68,11 +72,11 @@ pub struct TimeCreated {
     pub system_time: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Execution {
-    #[serde(rename = "@ProcessID")]
+    #[serde(rename = "@ProcessID", default)]
     pub process_id: u32,
-    #[serde(rename = "@ThreadID")]
+    #[serde(rename = "@ThreadID", default)]
     pub thread_id: u32,
 }
 


### PR DESCRIPTION
After enable the cargo test failure at build.cmd, our internal build pipeline starts to fail. Copilot tells me some of the fields that may not exist in classic event log entries （written via ReportEventW）.

```
test etw::etw_writter::tests::write_event_log_test ... Verifying event log for source: Azure_GuestProxyAgent_TestApplication

thread 'etw::etw_writter::tests::write_event_log_test' (8380) panicked at proxy_agent_shared\src\etw\etw_writter.rs:187:22:
called `Result::unwrap()` on an `Err` value: Io(Custom { kind: InvalidData, error: "Failed to parse event XML: Custom: missing field `Version`" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
FAILED
```