### PR TITLE
regex perf improvements

### DIFF
--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -200,7 +200,7 @@ impl Process {
         }
 
         // redact the secrets in the command line
-        let cmd = proxy_agent_shared::secrets_redactor::redact_secrets(cmd);
+        let cmd = proxy_agent_shared::secrets_redactor::redact_secrets_string(cmd);
 
         let process_name = process_full_path
             .file_name()

--- a/proxy_agent_setup/src/running.rs
+++ b/proxy_agent_setup/src/running.rs
@@ -26,8 +26,7 @@ pub fn proxy_agent_running_folder(_service_name: &str) -> PathBuf {
 pub fn proxy_agent_parent_folder() -> PathBuf {
     #[cfg(windows)]
     {
-        let path = misc_helpers::resolve_env_variables("%SYSTEMDRIVE%\\WindowsAzure\\ProxyAgent")
-            .unwrap_or("C:\\WindowsAzure\\ProxyAgent".to_string());
+        let path = misc_helpers::resolve_env_variables("%SYSTEMDRIVE%\\WindowsAzure\\ProxyAgent");
         PathBuf::from(path)
     }
     #[cfg(not(windows))]

--- a/proxy_agent_shared/src/etw/etw_writter.rs
+++ b/proxy_agent_shared/src/etw/etw_writter.rs
@@ -45,7 +45,7 @@ impl WindowsEventWritter {
         );
         let value = crate::misc_helpers::resolve_env_variables(
             r"%SystemRoot%\Microsoft.NET\Framework64\v4.0.30319\EventLogMessages.dll",
-        )?;
+        );
         crate::windows::set_reg_string(&key_name, "EventMessageFile", value)?;
 
         let source_name_wide = super::to_wide(source_name);

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -12,8 +12,7 @@ const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "/var/log/azure-proxy-agent/";
 pub const PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME: &str = "status.json";
 
 pub fn get_proxy_agent_aggregate_status_folder() -> std::path::PathBuf {
-    let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER)
-        .unwrap_or(PROXY_AGENT_AGGREGATE_STATUS_FOLDER.to_string());
+    let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER);
     PathBuf::from(path)
 }
 

--- a/proxy_agent_shared/src/telemetry.rs
+++ b/proxy_agent_shared/src/telemetry.rs
@@ -10,10 +10,15 @@ use crate::{current_info, misc_helpers};
 use serde_derive::{Deserialize, Serialize};
 
 pub const GENERIC_EVENT_FILE_SEARCH_PATTERN: &str = r"^[0-9]+\.json$";
+pub static GENERIC_EVENT_FILE_SEARCH_REGEX: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(GENERIC_EVENT_FILE_SEARCH_PATTERN).unwrap());
 pub fn new_generic_event_file_name() -> String {
     format!("{}.json", misc_helpers::get_date_time_unix_nano())
 }
 pub const EXTENSION_EVENT_FILE_SEARCH_PATTERN: &str = r"^extension_[0-9]+\.json$";
+pub static EXTENSION_EVENT_FILE_SEARCH_REGEX: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(EXTENSION_EVENT_FILE_SEARCH_PATTERN).unwrap());
+
 pub fn new_extension_event_file_name() -> String {
     format!("extension_{}.json", misc_helpers::get_date_time_unix_nano())
 }

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -82,7 +82,7 @@ pub async fn start<F, Fut>(
         // if it exceeds the max file number, drop the new events
         match misc_helpers::search_files(
             &event_dir,
-            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::GENERIC_EVENT_FILE_SEARCH_REGEX,
         ) {
             Ok(files) => {
                 if files.len() >= max_event_file_count {
@@ -188,7 +188,7 @@ pub fn report_extension_status_event(
     // if it exceeds the max file number, drop the new events
     match misc_helpers::search_files(
         &event_dir,
-        crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
     ) {
         Ok(files) => {
             if files.len() >= MAX_EXTENSION_EVENT_FILE_COUNT {
@@ -334,7 +334,7 @@ mod tests {
         // Verify extension event file was created
         let files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert!(

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -123,7 +123,7 @@ impl EventReader {
         // get all [0-9]+.json event filenames with numbers in the directory
         match misc_helpers::search_files(
             &self.dir_path,
-            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::GENERIC_EVENT_FILE_SEARCH_REGEX,
         ) {
             Ok(files) => {
                 let file_count = files.len();
@@ -282,7 +282,7 @@ impl EventReader {
         // get all extension status event filenames in the directory
         match misc_helpers::search_files(
             &self.dir_path,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         ) {
             Ok(files) => {
                 let file_count = files.len();
@@ -503,7 +503,7 @@ mod tests {
         // Verify files were created
         let files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert_eq!(2, files.len(), "Should have 2 extension event files");
@@ -518,7 +518,7 @@ mod tests {
         // Verify files were cleaned up after processing
         let files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert!(
@@ -578,7 +578,7 @@ mod tests {
         // Verify the file was processed
         let files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert!(
@@ -661,14 +661,14 @@ mod tests {
         // Verify all files were created
         let generic_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::GENERIC_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert_eq!(2, generic_files.len(), "Should have 2 generic event files");
 
         let extension_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert_eq!(
@@ -687,7 +687,7 @@ mod tests {
         // Verify only generic files were cleaned up
         let generic_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::GENERIC_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert!(
@@ -697,7 +697,7 @@ mod tests {
 
         let extension_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert_eq!(
@@ -716,7 +716,7 @@ mod tests {
         // Verify extension files were cleaned up
         let extension_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert!(
@@ -744,7 +744,7 @@ mod tests {
         // Generic file should still exist
         let generic_files = misc_helpers::search_files(
             &events_dir,
-            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+            &crate::telemetry::GENERIC_EVENT_FILE_SEARCH_REGEX,
         )
         .unwrap();
         assert_eq!(

--- a/proxy_agent_shared/src/telemetry/telemetry_event.rs
+++ b/proxy_agent_shared/src/telemetry/telemetry_event.rs
@@ -309,20 +309,23 @@ impl TelemetryGenericLogsEvent {
         // if ga_version is None, use event_log.Version as ga_version and keep event_name unchanged
         let (ga_version, event_name) = match ga_version {
             Some(version) => (version, format!("{}-{}", event_name, event_log.Version)),
-            None => (event_log.Version.to_string(), event_name),
+            None => (event_log.Version.clone(), event_name),
         };
+        // redact secrets in the message before sending to telemetry
+        let message = event_log.Message.clone();
+        let message = crate::secrets_redactor::redact_secrets_string(message);
         TelemetryGenericLogsEvent {
             event_name,
             ga_version,
             execution_mode,
             event_pid: event_log.EventPid.parse::<u64>().unwrap_or(0),
             event_tid: event_log.EventTid.parse::<u64>().unwrap_or(0),
-            task_name: event_log.TaskName.to_string(),
-            opcode_name: event_log.TimeStamp.to_string(),
-            capability_used: event_log.EventLevel.to_string(),
-            context1: event_log.Message.to_string(),
-            context2: event_log.TimeStamp.to_string(),
-            context3: event_log.OperationId.to_string(),
+            task_name: event_log.TaskName.clone(),
+            opcode_name: event_log.TimeStamp.clone(),
+            capability_used: event_log.EventLevel.clone(),
+            context1: message,
+            context2: event_log.TimeStamp.clone(),
+            context3: event_log.OperationId.clone(),
         }
     }
 
@@ -413,20 +416,23 @@ impl TelemetryExtensionEventsEvent {
         execution_mode: String,
         ga_version: String,
     ) -> Self {
+        // redact secrets in the message before sending to telemetry
+        let message = event.operation_status.message.clone();
+        let message = crate::secrets_redactor::redact_secrets_string(message);
         TelemetryExtensionEventsEvent {
             ga_version,
             execution_mode,
             event_pid: event.event_pid.parse::<u64>().unwrap_or(0),
             event_tid: event.event_tid.parse::<u64>().unwrap_or(0),
-            opcode_name: event.time_stamp.to_string(),
-            extension_type: event.extension.extension_type.to_string(),
+            opcode_name: event.time_stamp.clone(),
+            extension_type: event.extension.extension_type.clone(),
             is_internal: event.extension.is_internal,
-            name: event.extension.name.to_string(),
-            version: event.extension.version.to_string(),
-            operation: event.operation_status.operation.to_string(),
-            task_name: event.operation_status.task_name.to_string(),
+            name: event.extension.name.clone(),
+            version: event.extension.version.clone(),
+            operation: event.operation_status.operation.clone(),
+            task_name: event.operation_status.task_name.clone(),
             operation_success: event.operation_status.operation_success,
-            message: event.operation_status.message.to_string(),
+            message,
             duration: event.operation_status.duration as u64,
         }
     }


### PR DESCRIPTION
- `Regex::New` is performance-sensitive - use `LazyLock` to compile it only once as a static regex and reuse it for subsequent calls
- `search_files` should not create a new regex instance each time, and the caller should cache the regex if it is used frequently.
- Config setting value `get_xxx` in Config invoked `resolve_env_variables` at each call - resolve all the config values at new when first read & parse our config file.
- `regex.replace_all`'s time-complexity is` O(m * n^2)` in `redact_secrets` - first check for indicators, just simple substrings to check for before running the more expensive regexes.
