### PR TITLE
perf improvement: remove hyper_client::host_port_from_uri

### DIFF
--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -661,16 +661,11 @@ pub mod provision_query {
         //  bool - true provision finished; false provision not finished
         //  String - provision error message, empty means provision success or provision failed.
         async fn get_current_provision_status(&self, notify: bool) -> Result<ProvisionState> {
-            let provision_url: String = format!(
-                "http://{}:{}{}",
-                Ipv4Addr::LOCALHOST,
+            let endpoint = hyper_client::HostEndpoint::new(
+                Ipv4Addr::LOCALHOST.to_string(),
                 self.port,
-                PROVISION_URL_PATH
+                PROVISION_URL_PATH,
             );
-
-            let provision_url: hyper::Uri = provision_url
-                .parse::<hyper::Uri>()
-                .map_err(|e| Error::ParseUrl(provision_url, e.to_string()))?;
 
             let mut headers = HashMap::new();
             headers.insert(
@@ -684,7 +679,7 @@ pub mod provision_query {
             if notify {
                 headers.insert(constants::NOTIFY_HEADER.to_string(), "true".to_string());
             }
-            hyper_client::get(&provision_url, &headers, None, None, logger::write_warning)
+            hyper_client::get(&endpoint, &headers, None, None, logger::write_warning)
                 .await
                 .map_err(Error::ProxyAgentSharedError)
         }

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -1071,10 +1071,10 @@ mod tests {
         let sleep_duration = Duration::from_millis(100);
         tokio::time::sleep(sleep_duration).await;
 
-        let url: hyper::Uri = format!("http://{}:{}/", host, port).parse().unwrap();
+        let endpoint = hyper_client::HostEndpoint::new(host, port, "/");
         let request = hyper_client::build_request(
             Method::GET,
-            &url,
+            &endpoint,
             &HashMap::new(),
             None,
             key_keeper_shared_state
@@ -1111,12 +1111,10 @@ mod tests {
         );
 
         // test with traversal characters
-        let url: hyper::Uri = format!("http://{}:{}/test/../", host, port)
-            .parse()
-            .unwrap();
+        let endpoint = hyper_client::HostEndpoint::new(host, port, "/test/../");
         let request = hyper_client::build_request(
             Method::GET,
-            &url,
+            &endpoint,
             &HashMap::new(),
             None,
             key_keeper_shared_state
@@ -1142,7 +1140,7 @@ mod tests {
         let body = vec![88u8; super::REQUEST_BODY_LOW_LIMIT_SIZE + 1];
         let request = hyper_client::build_request(
             Method::POST,
-            &url,
+            &endpoint,
             &HashMap::new(),
             Some(body.as_slice()),
             key_keeper_shared_state

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -57,9 +57,8 @@ pub async fn start_service(shared_state: SharedState) {
 
     tokio::spawn({
         let key_keeper = KeyKeeper::new(
-            (format!("http://{}/", constants::WIRE_SERVER_IP))
-                .parse()
-                .unwrap(),
+            constants::WIRE_SERVER_IP.to_string(),
+            80,
             config::get_keys_dir(),
             proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder(),
             config::get_poll_key_status_duration(),

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -10,6 +10,7 @@ use crate::proxy::proxy_server::ProxyServer;
 use crate::redirector::{self, Redirector};
 use crate::shared_state::SharedState;
 use proxy_agent_shared::current_info;
+use proxy_agent_shared::hyper_client::HostEndpoint;
 use proxy_agent_shared::logger::rolling_logger::RollingLogger;
 use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
 use proxy_agent_shared::proxy_agent_aggregate_status;
@@ -58,7 +59,7 @@ pub async fn start_service(shared_state: SharedState) {
     tokio::spawn({
         let key_keeper = KeyKeeper::new(
             constants::WIRE_SERVER_IP.to_string(),
-            80,
+            HostEndpoint::DEFAULT_HTTP_PORT,
             config::get_keys_dir(),
             proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder(),
             config::get_poll_key_status_duration(),

--- a/proxy_agent_shared/src/hyper_client.rs
+++ b/proxy_agent_shared/src/hyper_client.rs
@@ -44,7 +44,7 @@ pub struct HostEndpoint {
 impl HostEndpoint {
     pub const DEFAULT_HTTP_PORT: u16 = 80;
     pub const DEFAULT_HTTPS_PORT: u16 = 443;
-    
+
     /// Create a new HostEndpoint with explicit components
     pub fn new(host: impl Into<String>, port: u16, path_and_query: impl Into<String>) -> Self {
         Self {

--- a/proxy_agent_shared/src/hyper_client.rs
+++ b/proxy_agent_shared/src/hyper_client.rs
@@ -31,8 +31,91 @@ pub const CLAIMS_IS_ROOT: &str = "isRoot";
 
 const LF: &str = "\n";
 
+/// Pre-parsed HTTP endpoint containing host, port, and path/query.
+/// Use this to avoid re-parsing URIs multiple times which is performance-sensitive.
+#[derive(Debug, Clone)]
+pub struct HostEndpoint {
+    pub host: String,
+    pub port: u16,
+    /// The path and query portion of the URI (e.g., "/api/status?version=1")
+    pub path_and_query: String,
+}
+
+impl HostEndpoint {
+    /// Create a new HostEndpoint with explicit components
+    pub fn new(host: impl Into<String>, port: u16, path_and_query: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            path_and_query: path_and_query.into(),
+        }
+    }
+
+    /// Create a HostEndpoint from a full URI string (e.g., "http://host:port/path?query")
+    /// This will parse the URI and extract the host, port, and path/query components.
+    /// Remark: Do not use this function in performance-sensitive code paths, as URI parsing can be relatively expensive.
+    ///     Instead, use the `new` constructor with pre-parsed components when possible.
+    /// Remark: This function assumes the URI is well-formed and contains a host. It will return an error if the URI is invalid or missing required components.
+    pub fn from_full_uri(uri: Uri) -> Result<Self> {
+        let host = match uri.host() {
+            Some(h) => h.to_string(),
+            None => {
+                return Err(Error::Hyper(HyperErrorType::RequestBuilder(
+                    "URI must have a host".to_string(),
+                )));
+            }
+        };
+        let default_port = if uri.scheme_str() == Some("https") {
+            443
+        } else {
+            80
+        };
+        let port = uri.port_u16().unwrap_or(default_port);
+        let path_and_query = match uri.path_and_query() {
+            Some(pq) => pq.as_str().to_string(),
+            None => "/".to_string(), // default to root path
+        };
+
+        Ok(Self {
+            host,
+            port,
+            path_and_query,
+        })
+    }
+
+    /// Create a HostEndpoint from a URI string (e.g., "http://host:port/path?query")
+    /// This will parse the URI and extract the host, port, and path/query components.
+    /// Remark: Do not use this function in performance-sensitive code paths, as URI parsing can be relatively expensive.
+    ///     Instead, use the `new` constructor with pre-parsed components when possible.
+    pub fn from_uri_str(uri_str: &str) -> Result<Self> {
+        let uri = uri_str.parse::<Uri>().map_err(|e| {
+            Error::Hyper(HyperErrorType::RequestBuilder(format!(
+                "Failed to parse URI string: {uri_str} with error: {e}"
+            )))
+        })?;
+        Self::from_full_uri(uri)
+    }
+
+    /// Get the address string for TCP connection (host:port)
+    #[inline]
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+impl std::fmt::Display for HostEndpoint {
+    /// Format as full URI string (e.g., "http://host:port/path?query")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "http://{}:{}{}",
+            self.host, self.port, self.path_and_query
+        )
+    }
+}
+
 pub async fn get<T, F>(
-    full_url: &Uri,
+    endpoint: &HostEndpoint,
     headers: &HashMap<String, String>,
     key_guid: Option<String>,
     key: Option<String>,
@@ -42,14 +125,13 @@ where
     T: DeserializeOwned,
     F: Fn(String) + Send + 'static,
 {
-    let request = build_request(Method::GET, full_url, headers, None, key_guid, key)?;
+    let request = build_request(Method::GET, endpoint, headers, None, key_guid, key)?;
 
-    let (host, port) = host_port_from_uri(full_url)?;
-    let response = send_request(&host, port, request, log_fun).await?;
+    let response = send_request(&endpoint.host, endpoint.port, request, log_fun).await?;
     let status = response.status();
     if !status.is_success() {
         return Err(Error::Hyper(HyperErrorType::ServerError(
-            full_url.to_string(),
+            endpoint.to_string(),
             status,
         )));
     }
@@ -162,22 +244,20 @@ where
 
 pub fn build_request(
     method: http::Method,
-    full_url: &Uri,
+    endpoint: &HostEndpoint,
     headers: &HashMap<String, String>,
     body: Option<&[u8]>,
     key_guid: Option<String>,
     key: Option<String>,
 ) -> Result<Request<BoxBody<Bytes, hyper::Error>>> {
-    let (host, _) = host_port_from_uri(full_url)?;
-
     let mut request_builder = Request::builder()
         .method(method)
-        .uri(match full_url.path_and_query() {
-            Some(pq) => pq.as_str(),
-            None => full_url.path(),
-        })
+        .uri(&endpoint.path_and_query)
         .header(DATE_HEADER, misc_helpers::get_date_time_rfc1123_string())
-        .header(hyper::header::HOST, host)
+        // The header() method accepts types that implement Into<HeaderValue>, and &str implements this trait.
+        // The HeaderValue will internally copy the bytes (which is unavoidable since it needs to own the data),
+        // So you're not creating any intermediate String allocations.
+        .header(hyper::header::HOST, &endpoint.host)
         .header(
             CLAIMS_HEADER,
             format!("{{ \"{}\": \"{}\"}}", CLAIMS_IS_ROOT, true,),
@@ -276,21 +356,6 @@ where
     });
 
     Ok(sender)
-}
-
-pub fn host_port_from_uri(full_url: &Uri) -> Result<(String, u16)> {
-    let host = match full_url.host() {
-        Some(h) => h.to_string(),
-        None => {
-            return Err(Error::ParseUrl(
-                full_url.to_string(),
-                "Failed to get host from uri".to_string(),
-            ))
-        }
-    };
-    let port = full_url.port_u16().unwrap_or(80);
-
-    Ok((host, port))
 }
 
 /*

--- a/proxy_agent_shared/src/hyper_client.rs
+++ b/proxy_agent_shared/src/hyper_client.rs
@@ -42,6 +42,9 @@ pub struct HostEndpoint {
 }
 
 impl HostEndpoint {
+    pub const DEFAULT_HTTP_PORT: u16 = 80;
+    pub const DEFAULT_HTTPS_PORT: u16 = 443;
+    
     /// Create a new HostEndpoint with explicit components
     pub fn new(host: impl Into<String>, port: u16, path_and_query: impl Into<String>) -> Self {
         Self {
@@ -66,9 +69,9 @@ impl HostEndpoint {
             }
         };
         let default_port = if uri.scheme_str() == Some("https") {
-            443
+            Self::DEFAULT_HTTPS_PORT
         } else {
-            80
+            Self::DEFAULT_HTTP_PORT
         };
         let port = uri.port_u16().unwrap_or(default_port);
         let path_and_query = match uri.path_and_query() {


### PR DESCRIPTION

Parse Host & Port from UrI multiple times per each proxied requests - Removed host_port_from_uri(full_url: &Uri) and added struct HostEndpoint with host, port and path_and_query
