### PR TITLE
perf improvements in misc_helpers functions

### DIFF
--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -154,7 +154,8 @@ impl ProxyAgentStatusTask {
                         message: status,
                         duration: status_report_time.elapsed().as_millis() as i64,
                     },
-                );
+                )
+                .await;
                 status_report_time = Instant::now();
             }
             // write the aggregate status to status.json file
@@ -290,7 +291,7 @@ impl ProxyAgentStatusTask {
 
     async fn write_aggregate_status_to_file(&self, status: GuestProxyAgentAggregateStatus) {
         let full_file_path = self.status_dir.join("status.json");
-        if let Err(e) = misc_helpers::json_write_to_file(&status, &full_file_path) {
+        if let Err(e) = misc_helpers::json_write_to_file_async(&status, &full_file_path).await {
             self.update_agent_status_message(format!(
                 "Error writing aggregate status to status file: {e}"
             ))

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.91"         # json Deserializer
 serde-xml-rs = "0.8.1"        # xml Deserializer with xml attribute
 regex = "1.11"               # match file name 
 thiserror = "1.0.64"
-tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "rt", "macros", "net", "sync", "time"] }
 tokio-util = "0.7.11"
 libc = "0.2.147"
 log = { version = "0.4.26", features = ["std"] }

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -102,7 +102,7 @@ pub async fn start<F, Fut>(
 
         let mut file_path = event_dir.to_path_buf();
         file_path.push(crate::telemetry::new_generic_event_file_name());
-        match misc_helpers::json_write_to_file(&events, &file_path) {
+        match misc_helpers::json_write_to_file_async(&events, &file_path).await {
             Ok(()) => {
                 logger_manager::write_log(
                     Level::Trace,
@@ -169,7 +169,7 @@ pub fn write_event_only(level: Level, message: String, method_name: &str, module
     };
 }
 
-pub fn report_extension_status_event(
+pub async fn report_extension_status_event(
     extension: crate::telemetry::Extension,
     operation_status: crate::telemetry::OperationStatus,
 ) {
@@ -210,7 +210,7 @@ pub fn report_extension_status_event(
     let event = crate::telemetry::ExtensionStatusEvent::new(extension, operation_status);
     let mut file_path = event_dir.to_path_buf();
     file_path.push(crate::telemetry::new_extension_event_file_name());
-    if let Err(e) = misc_helpers::json_write_to_file(&event, &file_path) {
+    if let Err(e) = misc_helpers::json_write_to_file_async(&event, &file_path).await {
         logger_manager::write_log(
             Level::Warn,
             format!(

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -261,7 +261,7 @@ mod tests {
         };
 
         // This should not panic even if EVENTS_DIR is not set
-        super::report_extension_status_event(extension, operation_status);
+        super::report_extension_status_event(extension, operation_status).await;
 
         // Start the event logger loop and set the EVENTS_DIR
         let cloned_events_dir = events_dir.to_path_buf();
@@ -326,7 +326,7 @@ mod tests {
         };
 
         // Call report_extension_status_event
-        super::report_extension_status_event(extension.clone(), operation_status.clone());
+        super::report_extension_status_event(extension.clone(), operation_status.clone()).await;
 
         // Wait for the file to be written
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -376,12 +376,11 @@ mod tests {
         misc_helpers::try_create_folder(&events_dir).unwrap();
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
-
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         // test EventReader with limits
         let event_reader_limits = EventReaderLimits::new()
             .with_max_event_file_size_bytes(1024 * 10)
@@ -413,11 +412,11 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         let files = misc_helpers::get_files(&events_dir).unwrap();
         assert_eq!(2, files.len(), "Must have 2 event files.");
 
@@ -435,10 +434,10 @@ mod tests {
             "{}.notjson",
             misc_helpers::get_date_time_unix_nano()
         ));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("a{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file(&events, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
         let events_processed = event_reader.process_once().await;
         assert_eq!(0, events_processed, "events_processed must be 0.");
         let files = misc_helpers::get_files(&events_dir).unwrap();
@@ -492,13 +491,13 @@ mod tests {
         // Write extension event files with proper naming pattern
         let mut file_path = events_dir.to_path_buf();
         file_path.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file(&event, &file_path).unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path).await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
 
         let mut file_path2 = events_dir.to_path_buf();
         file_path2.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file(&event, &file_path2).unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path2).await.unwrap();
 
         // Verify files were created
         let files = misc_helpers::search_files(
@@ -529,7 +528,7 @@ mod tests {
         // Test with non-matching file names (should not be processed)
         let mut non_matching_file = events_dir.to_path_buf();
         non_matching_file.push("not_extension_event.json");
-        misc_helpers::json_write_to_file(&event, &non_matching_file).unwrap();
+        misc_helpers::json_write_to_file_async(&event, &non_matching_file).await.unwrap();
 
         let events_processed = event_reader.process_extension_status_events().await;
         assert_eq!(
@@ -547,7 +546,7 @@ mod tests {
         // Write another event file
         let mut file_path3 = events_dir.to_path_buf();
         file_path3.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file(&event, &file_path3).unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path3).await.unwrap();
 
         // Start the processor in a separate task
         let event_reader_for_task = EventReader::new(
@@ -623,13 +622,13 @@ mod tests {
         // Write 2 generic event files
         let mut generic_file1 = events_dir.to_path_buf();
         generic_file1.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file(&generic_events, &generic_file1).unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file1).await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
 
         let mut generic_file2 = events_dir.to_path_buf();
         generic_file2.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file(&generic_events, &generic_file2).unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file2).await.unwrap();
 
         // Create extension status event files
         let extension = crate::telemetry::Extension {
@@ -654,7 +653,7 @@ mod tests {
         for _ in 0..3 {
             let mut ext_file = events_dir.to_path_buf();
             ext_file.push(crate::telemetry::new_extension_event_file_name());
-            misc_helpers::json_write_to_file(&extension_event, &ext_file).unwrap();
+            misc_helpers::json_write_to_file_async(&extension_event, &ext_file).await.unwrap();
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
 
@@ -728,11 +727,11 @@ mod tests {
         // Write one of each type again
         let mut generic_file = events_dir.to_path_buf();
         generic_file.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file(&generic_events, &generic_file).unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file).await.unwrap();
 
         let mut ext_file = events_dir.to_path_buf();
         ext_file.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file(&extension_event, &ext_file).unwrap();
+        misc_helpers::json_write_to_file_async(&extension_event, &ext_file).await.unwrap();
 
         // Process extension events - should only process extension file
         let extension_events_processed = event_reader.process_extension_status_events().await;

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -376,11 +376,15 @@ mod tests {
         misc_helpers::try_create_folder(&events_dir).unwrap();
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         // test EventReader with limits
         let event_reader_limits = EventReaderLimits::new()
             .with_max_event_file_size_bytes(1024 * 10)
@@ -412,11 +416,15 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         tokio::time::sleep(Duration::from_millis(1)).await;
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         let files = misc_helpers::get_files(&events_dir).unwrap();
         assert_eq!(2, files.len(), "Must have 2 event files.");
 
@@ -434,10 +442,14 @@ mod tests {
             "{}.notjson",
             misc_helpers::get_date_time_unix_nano()
         ));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         let mut file_path = events_dir.to_path_buf();
         file_path.push(format!("a{}.json", misc_helpers::get_date_time_unix_nano()));
-        misc_helpers::json_write_to_file_async(&events, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&events, &file_path)
+            .await
+            .unwrap();
         let events_processed = event_reader.process_once().await;
         assert_eq!(0, events_processed, "events_processed must be 0.");
         let files = misc_helpers::get_files(&events_dir).unwrap();
@@ -491,13 +503,17 @@ mod tests {
         // Write extension event files with proper naming pattern
         let mut file_path = events_dir.to_path_buf();
         file_path.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file_async(&event, &file_path).await.unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path)
+            .await
+            .unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
 
         let mut file_path2 = events_dir.to_path_buf();
         file_path2.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file_async(&event, &file_path2).await.unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path2)
+            .await
+            .unwrap();
 
         // Verify files were created
         let files = misc_helpers::search_files(
@@ -528,7 +544,9 @@ mod tests {
         // Test with non-matching file names (should not be processed)
         let mut non_matching_file = events_dir.to_path_buf();
         non_matching_file.push("not_extension_event.json");
-        misc_helpers::json_write_to_file_async(&event, &non_matching_file).await.unwrap();
+        misc_helpers::json_write_to_file_async(&event, &non_matching_file)
+            .await
+            .unwrap();
 
         let events_processed = event_reader.process_extension_status_events().await;
         assert_eq!(
@@ -546,7 +564,9 @@ mod tests {
         // Write another event file
         let mut file_path3 = events_dir.to_path_buf();
         file_path3.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file_async(&event, &file_path3).await.unwrap();
+        misc_helpers::json_write_to_file_async(&event, &file_path3)
+            .await
+            .unwrap();
 
         // Start the processor in a separate task
         let event_reader_for_task = EventReader::new(
@@ -622,13 +642,17 @@ mod tests {
         // Write 2 generic event files
         let mut generic_file1 = events_dir.to_path_buf();
         generic_file1.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file_async(&generic_events, &generic_file1).await.unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file1)
+            .await
+            .unwrap();
 
         tokio::time::sleep(Duration::from_millis(1)).await;
 
         let mut generic_file2 = events_dir.to_path_buf();
         generic_file2.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file_async(&generic_events, &generic_file2).await.unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file2)
+            .await
+            .unwrap();
 
         // Create extension status event files
         let extension = crate::telemetry::Extension {
@@ -653,7 +677,9 @@ mod tests {
         for _ in 0..3 {
             let mut ext_file = events_dir.to_path_buf();
             ext_file.push(crate::telemetry::new_extension_event_file_name());
-            misc_helpers::json_write_to_file_async(&extension_event, &ext_file).await.unwrap();
+            misc_helpers::json_write_to_file_async(&extension_event, &ext_file)
+                .await
+                .unwrap();
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
 
@@ -727,11 +753,15 @@ mod tests {
         // Write one of each type again
         let mut generic_file = events_dir.to_path_buf();
         generic_file.push(crate::telemetry::new_generic_event_file_name());
-        misc_helpers::json_write_to_file_async(&generic_events, &generic_file).await.unwrap();
+        misc_helpers::json_write_to_file_async(&generic_events, &generic_file)
+            .await
+            .unwrap();
 
         let mut ext_file = events_dir.to_path_buf();
         ext_file.push(crate::telemetry::new_extension_event_file_name());
-        misc_helpers::json_write_to_file_async(&extension_event, &ext_file).await.unwrap();
+        misc_helpers::json_write_to_file_async(&extension_event, &ext_file)
+            .await
+            .unwrap();
 
         // Process extension events - should only process extension file
         let extension_events_processed = event_reader.process_extension_status_events().await;


### PR DESCRIPTION
- Update `json_write_to_file` to use `BufWriter `to reduce system calls and improve performance
- Introduced new `json_write_to_file_async` using `tokio::fs`, provides better throughput in async contexts
- At get date_time string functions, started to use static LazyLock format descriptors. The format strings are now parsed once on first use and reused for all subsequent calls
