### PR TITLE
Use SockRef.set_read_timeout without conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
+ "socket2",
  "static_vcruntime",
  "sysinfo",
  "thiserror",

--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { version = "0.6.2", features = ["limit"] }
 clap = { version = "4.5.17", features =["derive"] } # Command Line Argument Parser 
 thiserror = "1.0.64"
 libc = "0.2.147"
+socket2 = "0.5"               # Set socket options without tokio/std conversion
 
 [dependencies.uuid]
 version = "1.3.0"

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -327,7 +327,7 @@ impl ProxyServer {
 
     // Set the read timeout for the stream
     // Uses socket2::SockRef to set socket options directly on the tokio stream
-    // socket2 crate alreasdy used by tokio internally, so it won't cause extra dependency
+    // socket2 crate already used by tokio internally, so it won't cause extra dependency
     fn set_stream_read_time_out(stream: &TcpStream, connection_logger: &mut ConnectionLogger) {
         use socket2::SockRef;
 


### PR DESCRIPTION
`set_stream_read_time_out` to use `socket2::SockRef.set_read_timeout`, it avoids 2 moderate system calls (tokio TcpStream.into_std and TcpStream.from _std)