### PR TITLE
Fix: Privilege match must be case insensitive.

### DIFF
--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -213,12 +213,20 @@ impl Clone for Privilege {
 }
 
 impl Privilege {
-    pub fn is_match(&self, logger: &mut ConnectionLogger, request_url: &Uri) -> bool {
+    /// Note: `self.path` and `self.queryParameters` keys/values are expected to be
+    /// pre-lowercased (done in `ComputedAuthorizationItem::from_authorization_item`).
+    /// `lowered_request_path` should be `request_url.path().to_lowercase()`, hoisted by the caller.
+    pub fn is_match(
+        &self,
+        logger: &mut ConnectionLogger,
+        request_url: &Uri,
+        lowered_request_path: &str,
+    ) -> bool {
         logger.write(
             LoggerLevel::Trace,
             format!("Start to match privilege '{}'", self.name),
         );
-        if request_url.path().to_lowercase().starts_with(&self.path) {
+        if lowered_request_path.starts_with(&self.path) {
             logger.write(
                 LoggerLevel::Trace,
                 format!("Matched privilege path '{}'", self.path),
@@ -236,10 +244,10 @@ impl Privilege {
                 for (key, value) in query_parameters {
                     match hyper_client::query_pairs(request_url)
                         .into_iter()
-                        .find(|(k, _)| k.to_lowercase() == key.to_lowercase())
+                        .find(|(k, _)| k.to_lowercase() == *key)
                     {
                         Some((_, v)) => {
-                            if v.to_lowercase() == value.to_lowercase() {
+                            if v.to_lowercase() == *value {
                                 logger.write(
                                     LoggerLevel::Trace,
                                     format!(
@@ -1400,7 +1408,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            privilege.is_match(&mut logger, &url),
+            privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should be matched"
         );
 
@@ -1408,13 +1416,13 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            !privilege.is_match(&mut logger, &url),
+            !privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
 
         let url = "http://localhost/test?key1=value1".parse().unwrap();
         assert!(
-            !privilege.is_match(&mut logger, &url),
+            !privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
 
@@ -1427,7 +1435,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            privilege1.is_match(&mut logger, &url),
+            privilege1.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should be matched"
         );
 
@@ -1444,7 +1452,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            !privilege2.is_match(&mut logger, &url),
+            !privilege2.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
     }

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -242,6 +242,8 @@ impl Privilege {
                 );
 
                 for (key, value) in query_parameters {
+                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future, 
+                    // but currently we expect only a few query parameters at most, so the performance impact should be minimal.
                     match hyper_client::query_pairs(request_url)
                         .into_iter()
                         .find(|(k, _)| k.to_lowercase() == *key)

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -242,7 +242,7 @@ impl Privilege {
                 );
 
                 for (key, value) in query_parameters {
-                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future, 
+                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future,
                     // but currently we expect only a few query parameters at most, so the performance impact should be minimal.
                     match hyper_client::query_pairs(request_url)
                         .into_iter()


### PR DESCRIPTION
- Fix Privilege path match case insensitive issue
- Updated UT to verify the path case insensitive match.
- Optimize: store lowercased versions of path, query parameter keys, and query parameter values in ComputedAuthorizationItem at construction time
- Optimize: lowercase the request URL path once before iterating over privileges
