### PR TITLE
Fix Windows GPA VMExtension expectedProxyAgentVersion check logic.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -211,6 +211,7 @@ pgpkey
 pgrep
 pidof
 pkgversion
+pls
 portaddr
 portpair
 postinst
@@ -319,6 +320,7 @@ Unregistering
 unregisters
 unspec
 uzers
+VCpus
 vcruntime
 vendored
 vflji

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -100,7 +100,7 @@ exampleosdiskname
 examplevmname
 exthandlers
 fde
-FFF
+fff
 FFFF
 FFFFFFFF
 fffi

--- a/e2etest/GuestProxyAgentTest/Extensions/ModelExtensions.cs
+++ b/e2etest/GuestProxyAgentTest/Extensions/ModelExtensions.cs
@@ -12,7 +12,7 @@ namespace GuestProxyAgentTest.Extensions
     /// </summary>
     public static class ModelExtensions
     {
-        public static TestCaseResultDetails ToTestResultDetails(this RunCommandOutputDetails runCommandOutputDetails, Action<string> logger = null!, bool downloadContentFromBlob = true)
+        public static TestCaseResultDetails ToTestResultDetails(this RunCommandOutputDetails runCommandOutputDetails, TestLogger logger = null!, bool downloadContentFromBlob = true)
         {
             return new TestCaseResultDetails
             {
@@ -24,7 +24,7 @@ namespace GuestProxyAgentTest.Extensions
             }.DownloadContentIfFromBlob(logger);
         }
 
-        public static TestCaseResultDetails DownloadContentIfFromBlob(this TestCaseResultDetails testCaseResultDetails, Action<string> logger = null!)
+        public static TestCaseResultDetails DownloadContentIfFromBlob(this TestCaseResultDetails testCaseResultDetails, TestLogger logger = null!)
         {
             if(!testCaseResultDetails.FromBlob)
             {
@@ -96,7 +96,7 @@ namespace GuestProxyAgentTest.Extensions
         /// <typeparam name="T"></typeparam>
         /// <param name="testCaseResultDetails"></param>
         /// <returns></returns>
-        public static T SafeDeserializedCustomOutAs<T>(this TestCaseResultDetails testCaseResultDetails) where T: class
+        public static T SafeDeserializedCustomOutAs<T>(this TestCaseResultDetails testCaseResultDetails, TestLogger logger) where T: class
         {
             try
             {
@@ -104,7 +104,7 @@ namespace GuestProxyAgentTest.Extensions
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Deserialized custom out json string failed with exception: " + ex.ToString());
+                logger.Log("Deserialized custom out json string failed with exception: " + ex.ToString());
             }
             return null;
         }

--- a/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
+++ b/e2etest/GuestProxyAgentTest/GuestProxyAgentScenarioTests.cs
@@ -13,6 +13,12 @@ namespace GuestProxyAgentTest
     /// </summary>
     public class GuestProxyAgentScenarioTests
     {
+        private readonly TestLogger logger;
+        public GuestProxyAgentScenarioTests(TestLogger logger)
+        {
+            this.logger = logger;
+        }
+
         /// <summary>
         /// Main function to start each scenario test
         /// </summary>
@@ -74,7 +80,7 @@ namespace GuestProxyAgentTest
                     var message = string.Format("Test Group: {0}, Test Scenario: {1}: {2} ({3})"
                         , testScenario.testGroupName, testScenario.testScenarioName
                         , testScenarioStatusDetails.Result, testScenarioStatusDetails.ErrorMessage);
-                    Console.WriteLine(message);
+                    logger.Log(message);
                 }
             }
             var stopMonitor = new ManualResetEvent(false);
@@ -92,14 +98,14 @@ namespace GuestProxyAgentTest
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Test execution exception: {ex.Message}");
+                logger.Log($"Test execution exception: {ex.Message}");
             }
 
             stopMonitor.Set();
 
             foreach (var groupName in groupTestResultBuilderMap.Keys)
             {
-                Console.WriteLine("building test result report for test group: " + groupName);
+                logger.Log("building test result report for test group: " + groupName);
                 groupTestResultBuilderMap[groupName].Build();
             }
 
@@ -114,7 +120,7 @@ namespace GuestProxyAgentTest
                 $", running {testScenarioStatusDetailsList.Where(x => x.Status == ScenarioTestStatus.Running).Count()}" +
                 $", failed {testScenarioStatusDetailsList.Where(x => x.Status == ScenarioTestStatus.Completed && x.Result == ScenarioTestResult.Failed).Count()}" +
                 $", success {testScenarioStatusDetailsList.Where(x => x.Status == ScenarioTestStatus.Completed && x.Result == ScenarioTestResult.Succeed).Count()}. ";
-            Console.WriteLine(message);
+            logger.Log(message);
         }
 
         private void ConsolePrintTestScenariosDetailsSummary(IEnumerable<TestScenarioStatusDetails> testScenariosStatusDetailsList)
@@ -130,7 +136,7 @@ namespace GuestProxyAgentTest
                     + $"Failed Test Cases Summary: {fc.TestCasesErrorMessage}" + Environment.NewLine;
                 i++;
             }
-            Console.WriteLine(message);
+            logger.Log(message);
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/Program.cs
+++ b/e2etest/GuestProxyAgentTest/Program.cs
@@ -20,6 +20,7 @@ namespace GuestProxyAgentTest
         /// </param>
         static async Task Main(string[] args)
         {
+            TestLogger logger = new TestLogger("GuestProxyAgentTests");
             var testConfigFilePath = args[0];
             var testResultFolder = args[1];
             var guestProxyAgentZipFilePath = args[2];
@@ -29,14 +30,14 @@ namespace GuestProxyAgentTest
             {
                 test_arm64 = true;
             }
-          
+
 
             TestCommonUtilities.TestSetup(guestProxyAgentZipFilePath, testConfigFilePath, testResultFolder, proxyAgentVersion);
 
             VMHelper.Instance.CleanupOldTestResourcesAndForget();
 
-            await new GuestProxyAgentScenarioTests().StartAsync(TestMapReader.ReadFlattenTestScenarioSettingFromTestMap(test_arm64));
-            Console.WriteLine("E2E Test run completed.");
+            await new GuestProxyAgentScenarioTests(logger).StartAsync(TestMapReader.ReadFlattenTestScenarioSettingFromTestMap(test_arm64));
+            logger.Log("E2E Test run completed.");
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/Scripts/GuestProxyAgentExtensionValidation.ps1
+++ b/e2etest/GuestProxyAgentTest/Scripts/GuestProxyAgentExtensionValidation.ps1
@@ -125,7 +125,7 @@ if ($guestProxyAgentExtensionVersion) {
     if ($expectedProxyAgentVersion -ne "0") {
         $cleanExpectedProxyAgentVersion = $expectedProxyAgentVersion.Trim()
         # Compare only the major, minor, and patch versions, ignoring any additional labels
-        # as the inputed expectedProxyAgentVersion only contains 3 parts, but the extractedVersion, it is file version, starts to have 4 parts in windows
+        # as the inputted expectedProxyAgentVersion only contains 3 parts, but the extractedVersion, it is file version, starts to have 4 parts in windows
         if (([System.Version]$extractedVersion).ToString(3) -eq ([System.Version]$cleanExpectedProxyAgentVersion).ToString(3)){ 
             Write-Output "$((Get-Date).ToUniversalTime()) - After Update Version check: The proxy agent version matches the expected and extracted version"
         } else {

--- a/e2etest/GuestProxyAgentTest/Scripts/GuestProxyAgentExtensionValidation.ps1
+++ b/e2etest/GuestProxyAgentTest/Scripts/GuestProxyAgentExtensionValidation.ps1
@@ -117,13 +117,16 @@ if ($guestProxyAgentExtensionVersion) {
     $proxyAgentStatus = $json.status.substatus[1].formattedMessage.message
     $jsonObject = $proxyAgentStatus | ConvertFrom-json
     $extractedVersion = $jsonObject.version
+    # Compare the extracted version with the version obtained from the executable
     if ($extractedVersion -ne $proxyAgentVersion) {
-        Write-Output "$((Get-Date).ToUniversalTime()) - Error, the proxy agent version [ $extractedVersions ] does not match the version [ $proxyAgentVersion ]"
+        Write-Output "$((Get-Date).ToUniversalTime()) - Error, the proxy agent version [ $extractedVersion ] does not match the version [ $proxyAgentVersion ]"
         $guestProxyAgentExtensionVersion = $false
     }
     if ($expectedProxyAgentVersion -ne "0") {
         $cleanExpectedProxyAgentVersion = $expectedProxyAgentVersion.Trim()
-        if ($extractedVersion -eq $cleanExpectedProxyAgentVersion){ 
+        # Compare only the major, minor, and patch versions, ignoring any additional labels
+        # as the inputed expectedProxyAgentVersion only contains 3 parts, but the extractedVersion, it is file version, starts to have 4 parts in windows
+        if (([System.Version]$extractedVersion).ToString(3) -eq ([System.Version]$cleanExpectedProxyAgentVersion).ToString(3)){ 
             Write-Output "$((Get-Date).ToUniversalTime()) - After Update Version check: The proxy agent version matches the expected and extracted version"
         } else {
             Write-Output "$((Get-Date).ToUniversalTime()) - After Update Version check: Error, the proxy agent version [ $extractedVersion ] does not match expected version [ $cleanExpectedProxyAgentVersion ]"

--- a/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentExtensionValidationCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentExtensionValidationCase.cs
@@ -21,10 +21,10 @@ namespace GuestProxyAgentTest.TestCases
         {
             List<(string, string)> parameterList = new List<(string, string)>();
             parameterList.Add(("expectedProxyAgentVersion", expectedProxyAgentVersion));
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.GUEST_PROXY_AGENT_EXTENSION_VALIDATION_SCRIPT_NAME, parameterList)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.GUEST_PROXY_AGENT_EXTENSION_VALIDATION_SCRIPT_NAME, parameterList)).ToTestResultDetails(context.Logger);
             if (context.TestResultDetails.Succeed && context.TestResultDetails.CustomOut != null)
             {
-                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<GuestProxyAgentExtensionValidationDetails>();
+                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<GuestProxyAgentExtensionValidationDetails>(context.Logger);
                 if (validationDetails != null
                     && validationDetails.guestProxyAgentExtensionServiceExist
                     && validationDetails.guestProxyAgentExtensionProcessExist

--- a/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentLoadedModulesValidationCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentLoadedModulesValidationCase.cs
@@ -22,11 +22,11 @@ namespace GuestProxyAgentTest.TestCases
             context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "GuestProxyAgentLoadedModulesValidation.ps1", new List<(string, string)> 
             {
                 ("loadedModulesBaseLineSAS", System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(baseLineModulesSas)))
-            })).ToTestResultDetails(ConsoleLog);
+            })).ToTestResultDetails(context.Logger);
 
             if (context.TestResultDetails.Succeed && context.TestResultDetails.CustomOut != null)
             {
-                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<LoadedModulesValidationDetails>();
+                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<LoadedModulesValidationDetails>(context.Logger);
                 // if the validation result is match or no new added modules, then consider the case as succeed.
                 if (validationDetails != null
                     && (validationDetails.IsMatch || validationDetails.NewAddedModules == null || validationDetails.NewAddedModules.Count == 0))

--- a/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentValidationCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/GuestProxyAgentValidationCase.cs
@@ -38,10 +38,10 @@ namespace GuestProxyAgentTest.TestCases
         {
             List<(string, string)> parameterList = new List<(string, string)>();
             parameterList.Add(("expectedSecureChannelState", expectedSecureChannelState));
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.GUEST_PROXY_AGENT_VALIDATION_SCRIPT_NAME, parameterList)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.GUEST_PROXY_AGENT_VALIDATION_SCRIPT_NAME, parameterList)).ToTestResultDetails(context.Logger);
             if (context.TestResultDetails.Succeed && context.TestResultDetails.CustomOut != null)
             {
-                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<GuestProxyAgentValidationDetails>();
+                var validationDetails = context.TestResultDetails.SafeDeserializedCustomOutAs<GuestProxyAgentValidationDetails>(context.Logger);
                 // check the validation json output, if the guest proxy agent service was installed and runing and guest proxy agent process exists and log was generate,
                 // then consider it as succeed, otherwise fail the case.
                 if (validationDetails != null

--- a/e2etest/GuestProxyAgentTest/TestCases/IMDSPingTestCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/IMDSPingTestCase.cs
@@ -19,7 +19,7 @@ namespace GuestProxyAgentTest.TestCases
         {
             List<(string, string)> parameterList = new List<(string, string)>();
             parameterList.Add(("imdsSecureChannelEnabled", ImdsSecureChannelEnabled.ToString()));
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.IMDS_PING_TEST_SCRIPT_NAME, parameterList, false)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, Constants.IMDS_PING_TEST_SCRIPT_NAME, parameterList, false)).ToTestResultDetails(context.Logger);
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentCase.cs
@@ -18,7 +18,7 @@ namespace GuestProxyAgentTest.TestCases
 
         public override async Task StartAsync(TestCaseExecutionContext context)
         {
-            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.VirtualMachineResource, new RunCommandSettingBuilder()
+            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.Logger, context.VirtualMachineResource, new RunCommandSettingBuilder()
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallOrUpdateProxyAgentMsi")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_GUEST_PROXY_AGENT_SCRIPT_NAME))

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentExtensionCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentExtensionCase.cs
@@ -18,7 +18,7 @@ namespace GuestProxyAgentTest.TestCases
 
         public override async Task StartAsync(TestCaseExecutionContext context)
         {
-            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.VirtualMachineResource, new RunCommandSettingBuilder()
+            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.Logger, context.VirtualMachineResource, new RunCommandSettingBuilder()
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallGuestProxyAgentExtension")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_GUEST_PROXY_AGENT_EXTENSION_SCRIPT_NAME))

--- a/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentPackageCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/InstallOrUpdateGuestProxyAgentPackageCase.cs
@@ -17,7 +17,7 @@ namespace GuestProxyAgentTest.TestCases
 
         public override async Task StartAsync(TestCaseExecutionContext context)
         {
-            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.VirtualMachineResource, new RunCommandSettingBuilder()
+            var runCommandRes = await RunCommandRunner.ExecuteRunCommandOnVM(context.Logger, context.VirtualMachineResource, new RunCommandSettingBuilder()
                     .TestScenarioSetting(context.ScenarioSetting)
                     .RunCommandName("InstallOrUpdateProxyAgentPackage")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.INSTALL_LINUX_GUEST_PROXY_AGENT_PACKAGE_SCRIPT_NAME))

--- a/e2etest/GuestProxyAgentTest/TestCases/LocalIPBindingCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/LocalIPBindingCase.cs
@@ -18,7 +18,7 @@ namespace GuestProxyAgentTest.TestCases
         {
             List<(string, string)> parameterList = new List<(string, string)>();
             parameterList.Add(("imdsSecureChannelEnabled", ImdsSecureChannelEnabled.ToString()));
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "PingTestOnBindingLocalIP.ps1", parameterList, false)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "PingTestOnBindingLocalIP.ps1", parameterList, false)).ToTestResultDetails(context.Logger);
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/TestCases/TCPPortScalabilityCase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/TCPPortScalabilityCase.cs
@@ -16,7 +16,7 @@ namespace GuestProxyAgentTest.TestCases
 
         public override async Task StartAsync(TestCaseExecutionContext context)
         {
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "ConfigTCPPortScalability.ps1", null!, false)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "ConfigTCPPortScalability.ps1", null!, false)).ToTestResultDetails(context.Logger);
             if(!context.TestResultDetails.Succeed)
             {
                 return;
@@ -26,7 +26,7 @@ namespace GuestProxyAgentTest.TestCases
             await vmr.RestartAsync(Azure.WaitUntil.Completed);
             List<(string, string)> parameterList = new List<(string, string)>();
             parameterList.Add(("imdsSecureChannelEnabled", ImdsSecureChannelEnabled.ToString()));
-            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "IMDSPingTest.ps1", parameterList, false)).ToTestResultDetails(ConsoleLog);
+            context.TestResultDetails = (await RunScriptViaRunCommandV2Async(context, "IMDSPingTest.ps1", parameterList, false)).ToTestResultDetails(context.Logger);
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestCases/TestCaseBase.cs
@@ -65,10 +65,10 @@ namespace GuestProxyAgentTest.TestCases
             if (includeCustomJsonOutputSasParam)
             {
                 var custJsonPath = Path.Combine(Path.GetTempPath(), $"{testScenarioSetting.testGroupName}_{testScenarioSetting.testScenarioName}_{TestCaseName}.json");
-                using (File.CreateText(custJsonPath)) ConsoleLog("Created empty test file for customized json output file.");
+                using (File.CreateText(custJsonPath)) context.Logger.Log("Created empty test file for customized json output file.");
                 custJsonSas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_E2E_TEST_OUTPUT_CONTAINER_NAME, custJsonPath, "customOutputJson.json", testScenarioSetting.TestScenarioStorageFolderPrefix);
             }
-            return await RunCommandRunner.ExecuteRunCommandOnVM(context.VirtualMachineResource, new RunCommandSettingBuilder()
+            return await RunCommandRunner.ExecuteRunCommandOnVM(context.Logger, context.VirtualMachineResource, new RunCommandSettingBuilder()
                                                                                                     .TestScenarioSetting(testScenarioSetting)
                                                                                                     .RunCommandName(TestCaseName)
                                                                                                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, scriptFileName))
@@ -77,8 +77,6 @@ namespace GuestProxyAgentTest.TestCases
                         .CustomOutputSas(custJsonSas)
                         .AddParameters(parameterList));
         }
-
-        protected void ConsoleLog(string message) { Console.WriteLine($"[{TestCaseName}]: " + message); }
 
         protected string FormatVMExtensionData(VirtualMachineExtensionData data)
         {

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -214,6 +214,14 @@ namespace GuestProxyAgentTest.TestScenarios
                                 }
                             }
                         }
+                        else
+                        {
+                            ConsoleLog("AllocationFailed but no alternative VM sizes found in the error message, last retry with available VM size.");
+                            var availableVMSize = await _vmBuilder.GetAvailableVmSizeAsync();
+                            vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, availableVMSize, false, cancellationToken);
+                            ConsoleLog($"VM Create succeed with available VM size {availableVMSize}.");
+                            retrySucceeded = true;
+                        }
 
                         if (!retrySucceeded)
                         {

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -195,6 +195,8 @@ namespace GuestProxyAgentTest.TestScenarios
                 }
                 catch (Exception ex)
                 {
+                    ConsoleLog($"VM first create failed with exception: {ex.GetType().Name} - {ex.Message}");
+
                     // catch ErrorCode: AllocationFailed and retry with different VMSize if possible,
                     // as sometimes the allocation failure is caused by the specific VM size is not available in the region,
                     // but other VM sizes are still available.

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+using Azure;
 using Azure.ResourceManager.Compute;
 using GuestProxyAgentTest.Extensions;
 using GuestProxyAgentTest.Models;
@@ -7,6 +8,7 @@ using GuestProxyAgentTest.Settings;
 using GuestProxyAgentTest.TestCases;
 using GuestProxyAgentTest.Utilities;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace GuestProxyAgentTest.TestScenarios
 {
@@ -142,6 +144,22 @@ namespace GuestProxyAgentTest.TestScenarios
             }
         }
 
+        /// <summary>
+        /// Try to parse alternative VM sizes from the AllocationFailed error message.
+        /// Expected pattern: "Alternative VM sizes for the same region: Standard_D2as_v5, Standard_D4as_v5."
+        /// </summary>
+        private static List<string> ParseAlternativeVmSizes(string errorMessage)
+        {
+            var alternativeSizes = new List<string>();
+            var match = Regex.Match(errorMessage, @"Alternative VM sizes for the same region:\s*(.+?)\.?\s*$", RegexOptions.Multiline);
+            if (match.Success)
+            {
+                var sizes = match.Groups[1].Value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                alternativeSizes.AddRange(sizes.Where(s => !string.IsNullOrWhiteSpace(s)));
+            }
+            return alternativeSizes;
+        }
+
         private async Task DoStartAsync(TestScenarioStatusDetails testScenarioStatusDetails, CancellationToken cancellationToken)
         {
             try
@@ -162,6 +180,50 @@ namespace GuestProxyAgentTest.TestScenarios
                 }
                 catch (Exception ex)
                 {
+                    // catch ErrorCode: AllocationFailed and retry with different VMSize if possible,
+                    // as sometimes the allocation failure is caused by the specific VM size is not available in the region,
+                    // but other VM sizes are still available.
+                    if (ex is RequestFailedException rfEx && rfEx.ErrorCode == "AllocationFailed")
+                    {
+                        var alternativeSizes = ParseAlternativeVmSizes(rfEx.Message);
+                        bool retrySucceeded = false;
+                        if (alternativeSizes.Count > 0)
+                        {
+                            ConsoleLog($"AllocationFailed for VM size '{TestSetting.Instance.vmSize}'. Retrying with alternative VM sizes: {string.Join(", ", alternativeSizes)}");
+                            foreach (var altSize in alternativeSizes)
+                            {
+                                try
+                                {
+                                    ConsoleLog($"Retrying VM creation with VM size: {altSize}");
+                                    vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, altSize, false, cancellationToken);
+                                    ConsoleLog($"VM Create succeed with alternative VM size: {altSize}");
+                                    retrySucceeded = true;
+                                    break;
+                                }
+                                catch (RequestFailedException retryRfEx) when (retryRfEx.ErrorCode == "AllocationFailed")
+                                {
+                                    ConsoleLog($"AllocationFailed for alternative VM size '{altSize}', trying next alternative if available.");
+                                    continue;
+                                }
+                                catch (Exception retryEx)
+                                {
+                                    // NOT AllocationFailed exception, assume retry succeeded but with other exception, break the loop to avoid retrying other sizes
+                                    retrySucceeded = true;
+                                    ConsoleLog($"VM creation failed with alternative VM size '{altSize}' with exception: {retryEx.Message}. Not retrying other sizes.");
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!retrySucceeded)
+                        {
+                            // All alternative sizes also failed, rethrow the original exception
+                            sw.Stop();
+                            _junitTestResultBuilder.AddFailureTestResult(testScenarioStatusDetails.ScenarioName, vmCreateTestName, "", ex.Message + ex.StackTrace ?? "", "", sw.ElapsedMilliseconds);
+                            throw;
+                        }
+                    }
+
                     // if the VM Creation operation failed, try check the VM instance view for 5 minutes
                     var startTime = DateTime.UtcNow;
                     while (true)

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -31,8 +31,8 @@ namespace GuestProxyAgentTest.TestScenarios
 
         public TestScenarioBase()
         {
-            TestScenarioSetup();
             Logger = new TestLogger(this.LogPrefix);
+            TestScenarioSetup();
         }
 
         public TestScenarioBase TestScenarioSetting(TestScenarioSetting testScenarioSetting)
@@ -69,7 +69,14 @@ namespace GuestProxyAgentTest.TestScenarios
             get
             {
                 // _testScenarioSetting may still null in constructor functions
-                return "Test Group: " + _testScenarioSetting?.testGroupName + ", Test Scenario: " + _testScenarioSetting?.testScenarioName + ": ";
+                if (_testScenarioSetting == null)
+                {
+                    return "Test Scenario: "+this.GetType().Name;
+                }
+                else
+                {
+                    return "Test Group: " + _testScenarioSetting?.testGroupName + ", Test Scenario: " + _testScenarioSetting?.testScenarioName;
+                }
             }
         }
 

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -257,6 +257,7 @@ namespace GuestProxyAgentTest.TestScenarios
             }
             catch (Exception ex)
             {
+                ConsoleLog("ExceptionType: " + ex.GetType().FullName);
                 testScenarioStatusDetails.ErrorMessage = ex.Message;
                 testScenarioStatusDetails.Result = ScenarioTestResult.Failed;
                 ConsoleLog("Exception occurs: " + ex.Message);

--- a/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
+++ b/e2etest/GuestProxyAgentTest/TestScenarios/TestScenarioBase.cs
@@ -21,17 +21,25 @@ namespace GuestProxyAgentTest.TestScenarios
         private VMBuilder _vmBuilder = null!;
         private JunitTestResultBuilder _junitTestResultBuilder = null!;
         private List<TestCaseBase> _testCases = new List<TestCaseBase>();
+        protected TestLogger Logger
+        {
+            get; private set;
+        }
+
         protected bool EnableProxyAgentForNewVM { get; set; }
 
 
         public TestScenarioBase()
         {
             TestScenarioSetup();
+            Logger = new TestLogger(this.LogPrefix);
         }
 
         public TestScenarioBase TestScenarioSetting(TestScenarioSetting testScenarioSetting)
         {
             this._testScenarioSetting = testScenarioSetting;
+            // refresh the Logger with new LogPrefix which is based on the test scenario setting
+            Logger = new TestLogger(this.LogPrefix);
             this._vmBuilder = new VMBuilder().LoadTestCaseSetting(testScenarioSetting);
             return this;
         }
@@ -67,7 +75,7 @@ namespace GuestProxyAgentTest.TestScenarios
 
         protected void ConsoleLog(string msg)
         {
-            Console.WriteLine(LogPrefix + msg);
+            Logger.Log(msg);
         }
 
         protected void PreCheck()
@@ -129,7 +137,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Collect GA Logs error: " + ex.Message);
+                    ConsoleLog("Collect GA Logs error: " + ex.Message);
                 }
 
                 try
@@ -139,7 +147,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Cleanup azure resources exception: " + ex.Message);
+                    ConsoleLog("Cleanup azure resources exception: " + ex.Message);
                 }
             }
         }
@@ -173,7 +181,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 try
                 {
                     ConsoleLog(string.Format("Creating {0} VM...", _testScenarioSetting.VMImageDetails.IsArm64 ? "ARM64" : "AMD64"));
-                    vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, cancellationToken);
+                    vmr = await _vmBuilder.Build(this.Logger, this.EnableProxyAgentForNewVM, cancellationToken);
                     ConsoleLog("VM Create succeed");
                     sw.Stop();
                     _junitTestResultBuilder.AddSuccessTestResult(_testScenarioSetting.testScenarioName, vmCreateTestName, "VM Create succeed", "", sw.ElapsedMilliseconds);
@@ -195,7 +203,7 @@ namespace GuestProxyAgentTest.TestScenarios
                                 try
                                 {
                                     ConsoleLog($"Retrying VM creation with VM size: {altSize}");
-                                    vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, altSize, false, cancellationToken);
+                                    vmr = await _vmBuilder.Build(this.Logger, this.EnableProxyAgentForNewVM, altSize, false, cancellationToken);
                                     ConsoleLog($"VM Create succeed with alternative VM size: {altSize}");
                                     retrySucceeded = true;
                                     break;
@@ -216,9 +224,9 @@ namespace GuestProxyAgentTest.TestScenarios
                         }
                         else
                         {
-                            ConsoleLog("AllocationFailed but no alternative VM sizes found in the error message, last retry with available VM size.");
-                            var availableVMSize = await _vmBuilder.GetAvailableVmSizeAsync();
-                            vmr = await _vmBuilder.Build(this.EnableProxyAgentForNewVM, availableVMSize, false, cancellationToken);
+                            var availableVMSize = await _vmBuilder.GetAvailableVmSizeAsync(this.Logger);
+                            ConsoleLog($"AllocationFailed but no alternative VM sizes found in the error message, last retry with available VM size `{availableVMSize}`.");
+                            vmr = await _vmBuilder.Build(this.Logger, this.EnableProxyAgentForNewVM, availableVMSize, false, cancellationToken);
                             ConsoleLog($"VM Create succeed with available VM size {availableVMSize}.");
                             retrySucceeded = true;
                         }
@@ -288,11 +296,12 @@ namespace GuestProxyAgentTest.TestScenarios
                     break;
                 }
 
-                TestCaseExecutionContext context = new TestCaseExecutionContext(vmr, _testScenarioSetting, cancellationToken);
+                TestCaseExecutionContext context = new TestCaseExecutionContext(this.Logger, vmr, _testScenarioSetting, cancellationToken);
                 Stopwatch sw = Stopwatch.StartNew();
 
                 try
                 {
+                    ConsoleLog($"Starting test case: {testCase.TestCaseName}");
                     testCase.Result = TestCaseResult.Running;
                     await testCase.StartAsync(context);
                     sw.Stop();
@@ -321,7 +330,7 @@ namespace GuestProxyAgentTest.TestScenarios
                 finally
                 {
                     testCase.Result = context.TestResultDetails.Succeed ? TestCaseResult.Succeed : TestCaseResult.Failed;
-                    ConsoleLog($"Scenario case {testCase.TestCaseName} finished with result: {(context.TestResultDetails.Succeed ? "Succeed" : "Failed")} and duration: " + sw.ElapsedMilliseconds + "ms");
+                    ConsoleLog($"Test case {testCase.TestCaseName} finished with result: {(context.TestResultDetails.Succeed ? "Succeed" : "Failed")} and duration: " + sw.ElapsedMilliseconds + "ms");
                     SaveResultFile(context.TestResultDetails.CustomOut, $"TestCases/{testCase.TestCaseName}", "customOut.txt", context.TestResultDetails.FromBlob);
                     SaveResultFile(context.TestResultDetails.StdErr, $"TestCases/{testCase.TestCaseName}", "stdErr.txt", context.TestResultDetails.FromBlob);
                     SaveResultFile(context.TestResultDetails.StdOut, $"TestCases/{testCase.TestCaseName}", "stdOut.txt", context.TestResultDetails.FromBlob);
@@ -340,7 +349,7 @@ namespace GuestProxyAgentTest.TestScenarios
             }
             var logZipSas = StorageHelper.Instance.Upload2SharedBlob(Constants.SHARED_E2E_TEST_OUTPUT_CONTAINER_NAME, logZipPath, _testScenarioSetting.TestScenarioStorageFolderPrefix);
 
-            var collectGALogOutput = await RunCommandRunner.ExecuteRunCommandOnVM(vmr, new RunCommandSettingBuilder()
+            var collectGALogOutput = await RunCommandRunner.ExecuteRunCommandOnVM(this.Logger, vmr, new RunCommandSettingBuilder()
                     .TestScenarioSetting(_testScenarioSetting)
                     .RunCommandName("CollectInVMGALog")
                     .ScriptFullPath(Path.Combine(TestSetting.Instance.scriptsFolder, Constants.COLLECT_INVM_GA_LOG_SCRIPT_NAME))
@@ -367,7 +376,7 @@ namespace GuestProxyAgentTest.TestScenarios
 
             if (isFromSas)
             {
-                TestCommonUtilities.DownloadFile(fileContentOrSas, filePath, ConsoleLog);
+                TestCommonUtilities.DownloadFile(fileContentOrSas, filePath, this.Logger);
             }
             else
             {
@@ -386,11 +395,20 @@ namespace GuestProxyAgentTest.TestScenarios
         private VirtualMachineResource _vmr = null!;
         private TestScenarioSetting _testScenarioSetting = null!;
         private CancellationToken _cancellationToken;
+        private TestLogger _logger = null!;
 
         /// <summary>
         /// TestResultDetails for a particular test case
         /// </summary>
         public TestCaseResultDetails TestResultDetails { get; set; } = new TestCaseResultDetails();
+
+        public TestLogger Logger
+        {
+            get
+            {
+                return _logger;
+            }
+        }
 
         public TestScenarioSetting ScenarioSetting
         {
@@ -419,8 +437,9 @@ namespace GuestProxyAgentTest.TestScenarios
             }
         }
 
-        public TestCaseExecutionContext(VirtualMachineResource vmr, TestScenarioSetting testScenarioSetting, CancellationToken cancellationToken)
+        public TestCaseExecutionContext(TestLogger logger, VirtualMachineResource vmr, TestScenarioSetting testScenarioSetting, CancellationToken cancellationToken)
         {
+            _logger = logger;
             _vmr = vmr;
             _testScenarioSetting = testScenarioSetting;
             _cancellationToken = cancellationToken;

--- a/e2etest/GuestProxyAgentTest/Utilities/RunCommandRunner.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/RunCommandRunner.cs
@@ -21,13 +21,14 @@ namespace GuestProxyAgentTest.Utilities
         /// <param name="cancellationToken">cancellation token</param>
         /// <param name="runCommandParameterSetter">parameter setter for the run command script</param>
         /// <returns></returns>
-        public static async Task<RunCommandOutputDetails> ExecuteRunCommandOnVM(VirtualMachineResource vmr
+        public static async Task<RunCommandOutputDetails> ExecuteRunCommandOnVM(TestLogger logger,
+            VirtualMachineResource vmr
             , RunCommandSettingBuilder runCommandSettingBuilder
             , CancellationToken cancellationToken
             , Func<RunCommandSettingBuilder, RunCommandSettingBuilder> runCommandParameterSetter = null!)
         {
             var vmrcs = vmr.GetVirtualMachineRunCommands();
-            Console.WriteLine("Creating runcommand on vm.");
+            logger.Log("Creating runcommand on vm.");
 
             if (null != runCommandParameterSetter)
             {

--- a/e2etest/GuestProxyAgentTest/Utilities/TestCommonUtilities.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/TestCommonUtilities.cs
@@ -32,7 +32,7 @@ namespace GuestProxyAgentTest.Utilities
         /// <param name="url">download url</param>
         /// <param name="retryCnt">retry count, default value is 5</param>
         /// <returns></returns>
-        public static (bool, string) DownloadContentAsString(string url, Action<string> logger = null!, int retryCnt = 5)
+        public static (bool, string) DownloadContentAsString(string url, TestLogger logger = null!, int retryCnt = 5)
         {
             if (url == null || url.Length == 0)
             {
@@ -58,14 +58,14 @@ namespace GuestProxyAgentTest.Utilities
                 catch (Exception ex)
                 {
                     errMessage = string.Format("Download content failed, attempted: {0} times, exception: {1}", cnt, ex.ToString());
-                    logger?.Invoke(errMessage);
+                    logger?.Log(errMessage);
                 }
                 Thread.Sleep(1000);
             }
             return (false, errMessage);
         }
 
-        public static bool DownloadFile(string url, string filePath, Action<string> logger = null!, int retryCnt = 5)
+        public static bool DownloadFile(string url, string filePath, TestLogger logger = null!, int retryCnt = 5)
         {
             if (null == url || url.Length == 0)
             {
@@ -93,7 +93,7 @@ namespace GuestProxyAgentTest.Utilities
                 catch (Exception ex)
                 {
                     var errMessage = string.Format("Download file failed, attempted: {0} times, exception: {1}", cnt, ex.ToString());
-                    logger?.Invoke(errMessage);
+                    logger.Log(errMessage);
                 }
             }
             return false;

--- a/e2etest/GuestProxyAgentTest/Utilities/TestLogger.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/TestLogger.cs
@@ -1,0 +1,17 @@
+﻿namespace GuestProxyAgentTest.Utilities
+{
+    public class TestLogger
+    {
+        public TestLogger(string prefix)
+        {
+            this.Prefix = prefix;
+        }
+
+        public string Prefix { get; }
+
+        public void Log(string message)
+        {
+            Console.WriteLine($"[{this.Prefix}] - {DateTime.Now:HH:mm:ss.fff} - {message}");
+        }
+    }
+}

--- a/e2etest/GuestProxyAgentTest/Utilities/TestLogger.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/TestLogger.cs
@@ -11,7 +11,7 @@
 
         public void Log(string message)
         {
-            Console.WriteLine($"[{this.Prefix}] - {DateTime.Now:HH:mm:ss.fff} - {message}");
+            Console.WriteLine($"[{this.Prefix}] - {DateTime.Now:yyyy-MM-ddTHH:mm:ss.fff} - {message}");
         }
     }
 }

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -91,7 +91,7 @@ namespace GuestProxyAgentTest.Utilities
             if (vmSizeOverride == null)
             {
                 // Resolve an available VM size before creating resources
-                var resolvedVmSize = await GetAvailableVmSizeAsync(sub);
+                var resolvedVmSize = await GetAvailableVmSizeAsync();
                 Console.WriteLine($"Resolved VM size: {resolvedVmSize}");
                 vmSizeToUse = resolvedVmSize;
             }
@@ -118,8 +118,11 @@ namespace GuestProxyAgentTest.Utilities
         /// Check if the configured VM size is available in the target location.
         /// If not, try fallback sizes. Returns the first available VM size.
         /// </summary>
-        private async Task<string> GetAvailableVmSizeAsync(SubscriptionResource sub)
+        internal async Task<string> GetAvailableVmSizeAsync()
         {
+            ArmClient client = new(new GuestProxyAgentE2ETokenCredential(), defaultSubscriptionId: TestSetting.Instance.subscriptionId);
+            var sub = await client.GetDefaultSubscriptionAsync();
+
             // Collect available VM SKUs with their vCPU count and architecture
             var availableSkus = new List<(string Name, int VCpus, string Architecture)>();
             await foreach (var sku in sub.GetComputeResourceSkusAsync(filter: $"location eq '{TestSetting.Instance.location}'"))

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -69,17 +69,35 @@ namespace GuestProxyAgentTest.Utilities
 
         public async Task<VirtualMachineResource> Build(bool enableProxyAgent, CancellationToken cancellationToken)
         {
+            return await Build(enableProxyAgent, null, true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Build and return the VirtualMachine based on the setting, with an optional VM size override
+        /// </summary>
+        /// <param name="enableProxyAgent"></param>
+        /// <param name="vmSizeOverride">If not null, overrides the default VM size from TestSetting</param>
+        /// <param name="deleteExistingResourceGroup">true to delete RG if already exists</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<VirtualMachineResource> Build(bool enableProxyAgent, string vmSizeOverride, bool deleteExistingResourceGroup, CancellationToken cancellationToken)
+        {
             PreCheck();
             ArmClient client = new(new GuestProxyAgentE2ETokenCredential(), defaultSubscriptionId: TestSetting.Instance.subscriptionId);
 
             var sub = await client.GetDefaultSubscriptionAsync();
 
-            // Resolve an available VM size before creating resources
-            var resolvedVmSize = await GetAvailableVmSizeAsync(sub);
-            Console.WriteLine($"Resolved VM size: {resolvedVmSize}");
+            string vmSizeToUse = vmSizeOverride ?? TestSetting.Instance.vmSize;
+            if (vmSizeOverride == null)
+            {
+                // Resolve an available VM size before creating resources
+                var resolvedVmSize = await GetAvailableVmSizeAsync(sub);
+                Console.WriteLine($"Resolved VM size: {resolvedVmSize}");
+                vmSizeToUse = resolvedVmSize;
+            }
 
             var rgs = sub.GetResourceGroups();
-            if (await rgs.ExistsAsync(rgName))
+            if (deleteExistingResourceGroup && await rgs.ExistsAsync(rgName))
             {
                 Console.WriteLine($"Resource group: {rgName} already exists, cleaning it up.");
                 await (await rgs.GetAsync(rgName)).Value.DeleteAsync(WaitUntil.Completed);
@@ -91,7 +109,7 @@ namespace GuestProxyAgentTest.Utilities
 
             VirtualMachineCollection vmCollection = rgr.GetVirtualMachines();
             Console.WriteLine("Creating virtual machine...");
-            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName, await DoCreateVMData(rgr, enableProxyAgent, resolvedVmSize), cancellationToken: cancellationToken)).Value;
+            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName, await DoCreateVMData(rgr, enableProxyAgent, vmSizeToUse), cancellationToken: cancellationToken)).Value;
             Console.WriteLine("Virtual machine created, with id: " + vmr.Id);
             return vmr;
         }

--- a/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
+++ b/e2etest/GuestProxyAgentTest/Utilities/VMBuilder.cs
@@ -67,9 +67,9 @@ namespace GuestProxyAgentTest.Utilities
             "Standard_B2pls_v5",
         };
 
-        public async Task<VirtualMachineResource> Build(bool enableProxyAgent, CancellationToken cancellationToken)
+        public async Task<VirtualMachineResource> Build(TestLogger logger, bool enableProxyAgent, CancellationToken cancellationToken)
         {
-            return await Build(enableProxyAgent, null, true, cancellationToken);
+            return await Build(logger, enableProxyAgent, null, true, cancellationToken);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace GuestProxyAgentTest.Utilities
         /// <param name="deleteExistingResourceGroup">true to delete RG if already exists</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<VirtualMachineResource> Build(bool enableProxyAgent, string vmSizeOverride, bool deleteExistingResourceGroup, CancellationToken cancellationToken)
+        public async Task<VirtualMachineResource> Build(TestLogger logger, bool enableProxyAgent, string vmSizeOverride, bool deleteExistingResourceGroup, CancellationToken cancellationToken)
         {
             PreCheck();
             ArmClient client = new(new GuestProxyAgentE2ETokenCredential(), defaultSubscriptionId: TestSetting.Instance.subscriptionId);
@@ -91,26 +91,27 @@ namespace GuestProxyAgentTest.Utilities
             if (vmSizeOverride == null)
             {
                 // Resolve an available VM size before creating resources
-                var resolvedVmSize = await GetAvailableVmSizeAsync();
-                Console.WriteLine($"Resolved VM size: {resolvedVmSize}");
+                var resolvedVmSize = await GetAvailableVmSizeAsync(logger);
+                logger.Log($"Resolved VM size: {resolvedVmSize}");
                 vmSizeToUse = resolvedVmSize;
             }
 
             var rgs = sub.GetResourceGroups();
             if (deleteExistingResourceGroup && await rgs.ExistsAsync(rgName))
             {
-                Console.WriteLine($"Resource group: {rgName} already exists, cleaning it up.");
+                logger.Log($"Resource group: {rgName} already exists, cleaning it up.");
                 await (await rgs.GetAsync(rgName)).Value.DeleteAsync(WaitUntil.Completed);
             }
-            Console.WriteLine("Creating resource group: " + rgName);
+            logger.Log("Creating resource group: " + rgName);
             var rgData = new ResourceGroupData(TestSetting.Instance.location);
             rgData.Tags.Add(Constants.COULD_CLEANUP_TAG_NAME, "true");
             var rgr = rgs.CreateOrUpdate(WaitUntil.Completed, rgName, rgData).Value;
 
             VirtualMachineCollection vmCollection = rgr.GetVirtualMachines();
-            Console.WriteLine("Creating virtual machine...");
-            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName, await DoCreateVMData(rgr, enableProxyAgent, vmSizeToUse), cancellationToken: cancellationToken)).Value;
-            Console.WriteLine("Virtual machine created, with id: " + vmr.Id);
+            logger.Log("Creating virtual machine...");
+            var vmr = (await vmCollection.CreateOrUpdateAsync(WaitUntil.Completed, this.vmName,
+                await DoCreateVMData(logger, rgr, enableProxyAgent, vmSizeToUse), cancellationToken: cancellationToken)).Value;
+            logger.Log("Virtual machine created, with id: " + vmr.Id);
             return vmr;
         }
 
@@ -118,7 +119,7 @@ namespace GuestProxyAgentTest.Utilities
         /// Check if the configured VM size is available in the target location.
         /// If not, try fallback sizes. Returns the first available VM size.
         /// </summary>
-        internal async Task<string> GetAvailableVmSizeAsync()
+        internal async Task<string> GetAvailableVmSizeAsync(TestLogger logger)
         {
             ArmClient client = new(new GuestProxyAgentE2ETokenCredential(), defaultSubscriptionId: TestSetting.Instance.subscriptionId);
             var sub = await client.GetDefaultSubscriptionAsync();
@@ -148,11 +149,11 @@ namespace GuestProxyAgentTest.Utilities
             var configuredSize = TestSetting.Instance.vmSize;
             if (availableNames.Contains(configuredSize))
             {
-                Console.WriteLine($"Configured VM size '{configuredSize}' is available.");
+                logger.Log($"Configured VM size '{configuredSize}' is available.");
                 return configuredSize;
             }
 
-            Console.WriteLine($"WARNING: Configured VM size '{configuredSize}' is not available in '{TestSetting.Instance.location}'. Searching for a fallback...");
+            logger.Log($"WARNING: Configured VM size '{configuredSize}' is not available in '{TestSetting.Instance.location}'. Searching for a fallback...");
 
             // First try the explicit fallback list
             var fallbacks = isArm64 ? FALLBACK_VM_SIZES_ARM64 : FALLBACK_VM_SIZES_X64;
@@ -160,7 +161,7 @@ namespace GuestProxyAgentTest.Utilities
             {
                 if (availableNames.Contains(fallback))
                 {
-                    Console.WriteLine($"Using fallback VM size: '{fallback}'");
+                    logger.Log($"Using fallback VM size: '{fallback}'");
                     return fallback;
                 }
             }
@@ -172,12 +173,12 @@ namespace GuestProxyAgentTest.Utilities
                 .FirstOrDefault();
             if (autoSelected != null)
             {
-                Console.WriteLine($"Using auto-selected 2 vCPU {requiredArch} VM size: '{autoSelected}'");
+                logger.Log($"Using auto-selected 2 vCPU {requiredArch} VM size: '{autoSelected}'");
                 return autoSelected;
             }
 
             // If none of the preferred fallbacks are available, return the configured size and let Azure report the error.
-            Console.WriteLine($"WARNING: No fallback VM size is available either. Proceeding with configured size '{configuredSize}'.");
+            logger.Log($"WARNING: No fallback VM size is available either. Proceeding with configured size '{configuredSize}'.");
             return configuredSize;
         }
 
@@ -189,7 +190,7 @@ namespace GuestProxyAgentTest.Utilities
             return sub.GetResourceGroups().Get(this.rgName).Value.GetVirtualMachine(this.vmName);
         }
 
-        private async Task<VirtualMachineData> DoCreateVMData(ResourceGroupResource rgr, bool enableProxyAgent, string vmSize)
+        private async Task<VirtualMachineData> DoCreateVMData(TestLogger logger, ResourceGroupResource rgr, bool enableProxyAgent, string vmSize)
         {
             var vmData = new VirtualMachineData(TestSetting.Instance.location)
             {
@@ -222,7 +223,7 @@ namespace GuestProxyAgentTest.Utilities
                     AdminUsername = this.adminUsername,
                     AdminPassword = this.adminPassword,
                 },
-                NetworkProfile = await DoCreateVMNetWorkProfile(rgr),
+                NetworkProfile = await DoCreateVMNetWorkProfile(logger, rgr),
             };
 
             if (enableProxyAgent)
@@ -291,9 +292,9 @@ namespace GuestProxyAgentTest.Utilities
             return vmData;
         }
 
-        private async Task<VirtualMachineNetworkProfile> DoCreateVMNetWorkProfile(ResourceGroupResource rgr)
+        private async Task<VirtualMachineNetworkProfile> DoCreateVMNetWorkProfile(TestLogger logger, ResourceGroupResource rgr)
         {
-            Console.WriteLine("Creating network profile");
+            logger.Log("Creating network profile");
             var vns = rgr.GetVirtualNetworks();
             await vns.CreateOrUpdateAsync(WaitUntil.Completed, this.vNetName, new VirtualNetworkData
             {
@@ -316,7 +317,7 @@ namespace GuestProxyAgentTest.Utilities
 
             var pips = rgr.GetPublicIPAddresses();
 
-            Console.WriteLine("Creating public ip address.");
+            logger.Log("Creating public ip address.");
             await pips.CreateOrUpdateAsync(WaitUntil.Completed, this.pubIpName, new PublicIPAddressData
             {
                 Location = TestSetting.Instance.location
@@ -324,7 +325,7 @@ namespace GuestProxyAgentTest.Utilities
 
             var nifs = rgr.GetNetworkInterfaces();
 
-            Console.WriteLine("Creating network interface.");
+            logger.Log("Creating network interface.");
             await nifs.CreateOrUpdateAsync(WaitUntil.Completed, this.netInfName, new NetworkInterfaceData()
             {
                 IPConfigurations =

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -213,12 +213,20 @@ impl Clone for Privilege {
 }
 
 impl Privilege {
-    pub fn is_match(&self, logger: &mut ConnectionLogger, request_url: &Uri) -> bool {
+    /// Note: `self.path` and `self.queryParameters` keys/values are expected to be
+    /// pre-lowercased (done in `ComputedAuthorizationItem::from_authorization_item`).
+    /// `lowered_request_path` should be `request_url.path().to_lowercase()`, hoisted by the caller.
+    pub fn is_match(
+        &self,
+        logger: &mut ConnectionLogger,
+        request_url: &Uri,
+        lowered_request_path: &str,
+    ) -> bool {
         logger.write(
             LoggerLevel::Trace,
             format!("Start to match privilege '{}'", self.name),
         );
-        if request_url.path().to_lowercase().starts_with(&self.path) {
+        if lowered_request_path.starts_with(&self.path) {
             logger.write(
                 LoggerLevel::Trace,
                 format!("Matched privilege path '{}'", self.path),
@@ -236,10 +244,10 @@ impl Privilege {
                 for (key, value) in query_parameters {
                     match hyper_client::query_pairs(request_url)
                         .into_iter()
-                        .find(|(k, _)| k.to_lowercase() == key.to_lowercase())
+                        .find(|(k, _)| k.to_lowercase() == *key)
                     {
                         Some((_, v)) => {
-                            if v.to_lowercase() == value.to_lowercase() {
+                            if v.to_lowercase() == *value {
                                 logger.write(
                                     LoggerLevel::Trace,
                                     format!(
@@ -1400,7 +1408,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            privilege.is_match(&mut logger, &url),
+            privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should be matched"
         );
 
@@ -1408,13 +1416,13 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            !privilege.is_match(&mut logger, &url),
+            !privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
 
         let url = "http://localhost/test?key1=value1".parse().unwrap();
         assert!(
-            !privilege.is_match(&mut logger, &url),
+            !privilege.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
 
@@ -1427,7 +1435,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            privilege1.is_match(&mut logger, &url),
+            privilege1.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should be matched"
         );
 
@@ -1444,7 +1452,7 @@ mod tests {
             .parse()
             .unwrap();
         assert!(
-            !privilege2.is_match(&mut logger, &url),
+            !privilege2.is_match(&mut logger, &url, &url.path().to_lowercase()),
             "privilege should not be matched"
         );
     }

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -242,6 +242,8 @@ impl Privilege {
                 );
 
                 for (key, value) in query_parameters {
+                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future, 
+                    // but currently we expect only a few query parameters at most, so the performance impact should be minimal.
                     match hyper_client::query_pairs(request_url)
                         .into_iter()
                         .find(|(k, _)| k.to_lowercase() == *key)

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -242,7 +242,7 @@ impl Privilege {
                 );
 
                 for (key, value) in query_parameters {
-                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future, 
+                    // We may need to optimize this like `lowered_request_path` if there are too many query parameters in the future,
                     // but currently we expect only a few query parameters at most, so the performance impact should be minimal.
                     match hyper_client::query_pairs(request_url)
                         .into_iter()


### PR DESCRIPTION
- Fix Windows GPA VMExtension expectedProxyAgentVersion check logic.
- Retry with different VMSize at AllocationFailed error
- Use common TestLogger to replace the random Console.WriteLine
