### PR TITLE
Fix GPA VMExtension could resume from previous interrupted update

### DIFF
--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -83,7 +83,7 @@ enum UpdateAction {
 
 /// Resolves the file version of the proxy agent bundled with the extension.
 /// Returns `None` (and reports an error status) if the version cannot be read yet.
-fn resolve_proxyagent_file_version_in_extension(
+fn resolve_proxy_agent_file_version_in_extension(
     cached: &str,
     status: &mut StatusObj,
     status_state_obj: &mut common::StatusState,
@@ -188,7 +188,7 @@ async fn monitor_thread() {
     let handler_environment = common::get_handler_environment(&exe_path);
     let status_folder_path: PathBuf = handler_environment.statusFolder.to_string().into();
     let mut cache_seq_no = String::new();
-    let mut proxyagent_file_version_in_extension = String::new();
+    let mut proxy_agent_file_version_in_extension = String::new();
     let mut service_state = ServiceState::default();
     let mut status = StatusObj {
         name: constants::PLUGIN_NAME.to_string(),
@@ -211,12 +211,12 @@ async fn monitor_thread() {
         let current_seq_no: String = common::get_current_seq_no(&exe_path);
 
         // Step 1: Resolve the extension-bundled proxy agent version (retry each iteration until available)
-        match resolve_proxyagent_file_version_in_extension(
-            &proxyagent_file_version_in_extension,
+        match resolve_proxy_agent_file_version_in_extension(
+            &proxy_agent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
         ) {
-            Some(version) => proxyagent_file_version_in_extension = version,
+            Some(version) => proxy_agent_file_version_in_extension = version,
             None => {
                 common::report_status(status_folder_path.to_path_buf(), &current_seq_no, &status);
                 tokio::time::sleep(loop_interval).await;
@@ -240,15 +240,15 @@ async fn monitor_thread() {
 
             let proxy_agent_service_version = get_proxy_agent_service_file_version();
             if let Some(action) = determine_update_action(
-                &proxyagent_file_version_in_extension,
+                &proxy_agent_file_version_in_extension,
                 &proxy_agent_service_version,
                 None,
                 logger_key,
             ) {
                 if matches!(action, UpdateAction::VersionMismatch) {
-                    backup_proxyagent(
-                        &misc_helpers::path_to_string(&common::setup_tool_exe_path()),
-                    );
+                    backup_proxy_agent(&misc_helpers::path_to_string(
+                        &common::setup_tool_exe_path(),
+                    ));
 
                     // reset this flag in case the previous restore was done due to an error,
                     // but now the version mismatch indicates a new update attempt rather than a resume of a previous interrupted update
@@ -279,7 +279,7 @@ async fn monitor_thread() {
 
         // Step 3: Read and evaluate the proxy agent aggregate status
         report_proxy_agent_aggregate_status(
-            &proxyagent_file_version_in_extension,
+            &proxy_agent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
             &mut service_state,
@@ -287,7 +287,7 @@ async fn monitor_thread() {
 
         // Step 4: Restore (on error) or purge (on success) the backed-up proxy agent, once
         if !restored_in_error {
-            restored_in_error = restore_purge_proxyagent(&mut status);
+            restored_in_error = restore_purge_proxy_agent(&mut status);
         }
 
         // Step 5: Track time-to-success after an update
@@ -405,7 +405,7 @@ fn report_ebpf_status(status_obj: &mut StatusObj) {
     }
 }
 
-fn backup_proxyagent(setup_tool: &String) {
+fn backup_proxy_agent(setup_tool: &String) {
     match Command::new(setup_tool).arg("backup").output() {
         Ok(output) => {
             let event_level = if output.status.success() {
@@ -421,7 +421,7 @@ fn backup_proxyagent(setup_tool: &String) {
             telemetry::event_logger::write_event(
                 event_level,
                 message.clone(),
-                "backup_proxyagent",
+                "backup_proxy_agent",
                 "service_main",
                 &logger::get_logger_key(),
             );
@@ -431,7 +431,7 @@ fn backup_proxyagent(setup_tool: &String) {
             telemetry::event_logger::write_event(
                 LoggerLevel::Warn,
                 message.clone(),
-                "backup_proxyagent",
+                "backup_proxy_agent",
                 "service_main",
                 &logger::get_logger_key(),
             );
@@ -443,7 +443,7 @@ fn backup_proxyagent(setup_tool: &String) {
 /// This can happen when a VM is force-restarted during a proxy agent service update, causing the new service to not start properly.
 /// Return true if the versions match, return false if the versions do not match or if not able to read the service status version at all.
 fn check_version_in_proxy_agent_status_file(
-    proxyagent_file_version_in_extension: &str,
+    proxy_agent_file_version_in_extension: &str,
     status_file_path: Option<PathBuf>,
 ) -> bool {
     let aggregate_status_file_path = match status_file_path {
@@ -456,9 +456,9 @@ fn check_version_in_proxy_agent_status_file(
     ) {
         Ok(aggregate_status) => {
             let running_version = &aggregate_status.proxyAgentStatus.version;
-            if running_version != proxyagent_file_version_in_extension {
+            if running_version != proxy_agent_file_version_in_extension {
                 logger::write(format!(
-                    "Reported GPA service version {running_version} differs from installed file version {proxyagent_file_version_in_extension}."
+                    "Reported GPA service version {running_version} differs from installed file version {proxy_agent_file_version_in_extension}."
                 ));
                 false
             } else {
@@ -477,7 +477,7 @@ fn check_version_in_proxy_agent_status_file(
 }
 
 fn report_proxy_agent_aggregate_status(
-    proxyagent_file_version_in_extension: &String,
+    proxy_agent_file_version_in_extension: &String,
     status: &mut StatusObj,
     status_state_obj: &mut common::StatusState,
     service_state: &mut ServiceState,
@@ -503,7 +503,7 @@ fn report_proxy_agent_aggregate_status(
             proxy_agent_aggregate_status_top_level = ok;
             extension_substatus(
                 proxy_agent_aggregate_status_top_level,
-                proxyagent_file_version_in_extension,
+                proxy_agent_file_version_in_extension,
                 status,
                 status_state_obj,
                 service_state,
@@ -614,7 +614,7 @@ fn report_error_status(
 
 fn extension_substatus(
     proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus,
-    proxyagent_file_version_in_extension: &String,
+    proxy_agent_file_version_in_extension: &String,
     status: &mut StatusObj,
     status_state_obj: &mut common::StatusState,
     service_state: &mut ServiceState,
@@ -652,8 +652,8 @@ fn extension_substatus(
             error_message,
         );
         return;
-    } else if proxy_agent_aggregate_status_file_version != *proxyagent_file_version_in_extension {
-        let version_mismatch_message = format!("Proxy agent aggregate status file version {proxy_agent_aggregate_status_file_version} does not match proxy agent file version in extension {proxyagent_file_version_in_extension}");
+    } else if proxy_agent_aggregate_status_file_version != *proxy_agent_file_version_in_extension {
+        let version_mismatch_message = format!("Proxy agent aggregate status file version {proxy_agent_aggregate_status_file_version} does not match proxy agent file version in extension {proxy_agent_file_version_in_extension}");
         report_error_status(
             status,
             status_state_obj,
@@ -808,7 +808,7 @@ fn get_top_proxy_connection_summary(
     summary
 }
 
-fn restore_purge_proxyagent(status: &mut StatusObj) -> bool {
+fn restore_purge_proxy_agent(status: &mut StatusObj) -> bool {
     let setup_tool = misc_helpers::path_to_string(&common::setup_tool_exe_path());
     if status.status == *constants::ERROR_STATUS {
         let output = Command::new(&setup_tool).arg("restore").output();
@@ -826,7 +826,7 @@ fn restore_purge_proxyagent(status: &mut StatusObj) -> bool {
                         String::from_utf8_lossy(&output.stdout),
                         String::from_utf8_lossy(&output.stderr)
                     ),
-                    "restore_purge_proxyagent",
+                    "restore_purge_proxy_agent",
                     "service_main",
                     &logger::get_logger_key(),
                 );
@@ -835,7 +835,7 @@ fn restore_purge_proxyagent(status: &mut StatusObj) -> bool {
                 telemetry::event_logger::write_event(
                     LoggerLevel::Info,
                     format!("Error in running Restore Proxy Agent command: {e}"),
-                    "restore_purge_proxyagent",
+                    "restore_purge_proxy_agent",
                     "service_main",
                     &logger::get_logger_key(),
                 );
@@ -858,7 +858,7 @@ fn restore_purge_proxyagent(status: &mut StatusObj) -> bool {
                         String::from_utf8_lossy(&output.stdout),
                         String::from_utf8_lossy(&output.stderr)
                     ),
-                    "restore_purge_proxyagent",
+                    "restore_purge_proxy_agent",
                     "service_main",
                     &logger::get_logger_key(),
                 );
@@ -867,7 +867,7 @@ fn restore_purge_proxyagent(status: &mut StatusObj) -> bool {
                 telemetry::event_logger::write_event(
                     LoggerLevel::Info,
                     format!("Error in running Purge Proxy Agent command: {e}"),
-                    "restore_purge_proxyagent",
+                    "restore_purge_proxy_agent",
                     "service_main",
                     &logger::get_logger_key(),
                 );
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_proxyagent_service_success_status() {
+    fn test_proxy_agent_service_success_status() {
         let toplevel_status =
             make_test_aggregate_status(misc_helpers::get_date_time_string(), "1.0.0");
         let result = toplevel_status.get_status_timestamp();
@@ -1116,12 +1116,12 @@ mod tests {
 
         let mut status_state_obj = super::common::StatusState::new();
 
-        let proxyagent_file_version_in_extension: &String = &"1.0.0".to_string();
+        let proxy_agent_file_version_in_extension: &String = &"1.0.0".to_string();
         let mut service_state = super::service_state::ServiceState::default();
 
         super::extension_substatus(
             toplevel_status,
-            proxyagent_file_version_in_extension,
+            proxy_agent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
             &mut service_state,
@@ -1276,12 +1276,12 @@ mod tests {
         );
 
         let mut status_state_obj = super::common::StatusState::new();
-        let proxyagent_file_version_in_extension: &String = &"1.0.0".to_string();
+        let proxy_agent_file_version_in_extension: &String = &"1.0.0".to_string();
         let mut service_state = super::service_state::ServiceState::default();
 
         super::extension_substatus(
             toplevel_status,
-            proxyagent_file_version_in_extension,
+            proxy_agent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
             &mut service_state,
@@ -1314,12 +1314,12 @@ mod tests {
         );
 
         let mut status_state_obj = super::common::StatusState::new();
-        let proxyagent_file_version_in_extension: &String = &"1.0.0".to_string();
+        let proxy_agent_file_version_in_extension: &String = &"1.0.0".to_string();
         let mut service_state = super::service_state::ServiceState::default();
 
         super::extension_substatus(
             toplevel_status,
-            proxyagent_file_version_in_extension,
+            proxy_agent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
             &mut service_state,
@@ -1341,7 +1341,7 @@ mod tests {
             make_test_status_obj(constants::SUCCESS_STATUS, constants::STATUS_CODE_OK, "test");
         let mut status_state_obj = super::common::StatusState::new();
 
-        let result = super::resolve_proxyagent_file_version_in_extension(
+        let result = super::resolve_proxy_agent_file_version_in_extension(
             "1.0.39",
             &mut status,
             &mut status_state_obj,
@@ -1361,7 +1361,7 @@ mod tests {
         let mut status_state_obj = super::common::StatusState::new();
 
         // Empty cache forces file read; the proxy agent exe doesn't exist in test env
-        let result = super::resolve_proxyagent_file_version_in_extension(
+        let result = super::resolve_proxy_agent_file_version_in_extension(
             "",
             &mut status,
             &mut status_state_obj,
@@ -1457,9 +1457,9 @@ mod tests {
             "test error",
         );
 
-        // restore_purge_proxyagent should return true when status is ERROR
+        // restore_purge_proxy_agent should return true when status is ERROR
         // (the restore command will fail since setup tool doesn't exist, but that's OK in unit test)
-        let result = super::restore_purge_proxyagent(&mut status);
+        let result = super::restore_purge_proxy_agent(&mut status);
         assert!(result);
     }
 
@@ -1471,9 +1471,9 @@ mod tests {
             "test success",
         );
 
-        // restore_purge_proxyagent should return true when status is SUCCESS
+        // restore_purge_proxy_agent should return true when status is SUCCESS
         // (the purge command will fail since setup tool doesn't exist, but that's OK in unit test)
-        let result = super::restore_purge_proxyagent(&mut status);
+        let result = super::restore_purge_proxy_agent(&mut status);
         assert!(result);
     }
 
@@ -1485,8 +1485,8 @@ mod tests {
             "test transitioning",
         );
 
-        // restore_purge_proxyagent should return false when status is TRANSITIONING
-        let result = super::restore_purge_proxyagent(&mut status);
+        // restore_purge_proxy_agent should return false when status is TRANSITIONING
+        let result = super::restore_purge_proxy_agent(&mut status);
         assert!(!result);
     }
 }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -257,7 +257,7 @@ async fn monitor_thread() {
                         "Retry install for interrupted update completed"
                     }
                 };
-                update_span.write_event(span_message, "monitor_thread", "service_main", logger_key);
+                update_span.write_event(span_message, "install_proxy_agent", "service_main", logger_key);
             }
         }
 
@@ -279,7 +279,7 @@ async fn monitor_thread() {
             if let Some(span) = proxy_agent_update_reported.as_ref() {
                 span.write_event(
                     "Proxy Agent Service is updated and reporting successful status",
-                    "monitor_thread",
+                    "updated_proxy_agent",
                     "service_main",
                     logger_key,
                 );

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -71,6 +71,111 @@ async fn heartbeat_thread() {
     }
 }
 
+/// Describes the reason for running the setup tool install command.
+enum UpdateAction {
+    /// Service file version differs from extension — a fresh update.
+    VersionMismatch,
+    /// Service files already match but the running process reports an older version —
+    /// an interrupted update (e.g., VM force-restarted mid-eBPF-update).
+    ResumeInterruptedUpdate,
+}
+
+/// Resolves the file version of the proxy agent bundled with the extension.
+/// Returns `None` (and reports an error status) if the version cannot be read yet.
+fn resolve_proxyagent_file_version_in_extension(
+    cached: &str,
+    status: &mut StatusObj,
+    status_state_obj: &mut common::StatusState,
+) -> Option<String> {
+    if !cached.is_empty() {
+        return Some(cached.to_string());
+    }
+    let path = common::get_proxy_agent_exe_path();
+    match misc_helpers::get_proxy_agent_version(&path) {
+        Ok(version) => Some(version),
+        Err(e) => {
+            let error_message = format!(
+                "Failed to get GuestProxyAgent version from file {} with error: {}",
+                misc_helpers::path_to_string(&path),
+                e
+            );
+            logger::write(error_message.clone());
+            status.formattedMessage.message = error_message;
+            status.code = constants::STATUS_CODE_NOT_OK;
+            status.status = status_state_obj.update_state(false);
+            None
+        }
+    }
+}
+
+/// Gets the file version of the currently installed GPA service executable.
+fn get_proxy_agent_service_file_version() -> String {
+    let path = common::get_proxy_agent_service_path();
+    match misc_helpers::get_proxy_agent_version(&path) {
+        Ok(version) => version,
+        Err(e) => {
+            logger::write(format!(
+                "Failed to get GuestProxyAgent version from file {} with error: {}",
+                misc_helpers::path_to_string(&path),
+                e
+            ));
+            String::new()
+        }
+    }
+}
+
+/// Determines what update action (if any) is needed for the proxy agent service.
+fn determine_update_action(extension_version: &str, logger_key: &str) -> Option<UpdateAction> {
+    let service_file_version = get_proxy_agent_service_file_version();
+
+    if extension_version != service_file_version {
+        telemetry::event_logger::write_event(
+            LoggerLevel::Info,
+            format!(
+                "Version mismatch between file versions. \
+                 ProxyAgentService File Version: {service_file_version}, \
+                 ProxyAgent in Extension File Version: {extension_version}"
+            ),
+            "monitor_thread",
+            "service_main",
+            logger_key,
+        );
+        Some(UpdateAction::VersionMismatch)
+    } else if !check_version_in_proxy_agent_status_file(extension_version) {
+        telemetry::event_logger::write_event(
+            LoggerLevel::Info,
+            format!(
+                "Service file version matches extension version {extension_version} but \
+                 running service reports a different version. \
+                 Re-running install to complete the interrupted update."
+            ),
+            "monitor_thread",
+            "service_main",
+            logger_key,
+        );
+        Some(UpdateAction::ResumeInterruptedUpdate)
+    } else {
+        None
+    }
+}
+
+/// Runs the setup tool install command and reports the result.
+fn run_setup_tool_install(
+    status_folder: PathBuf,
+    seq_no: &str,
+    status: &mut StatusObj,
+    status_state_obj: &mut common::StatusState,
+) {
+    let setup_tool = misc_helpers::path_to_string(&common::setup_tool_exe_path());
+    let mut install_command = Command::new(&setup_tool);
+    // Set the current directory to the directory of the current executable
+    // for the setup tool to work properly
+    install_command.current_dir(misc_helpers::get_current_exe_dir());
+    install_command.arg("install");
+    let output = install_command.output();
+    report_proxy_agent_service_status(output, status_folder, seq_no, status, status_state_obj);
+}
+
 async fn monitor_thread() {
     let exe_path = misc_helpers::get_current_exe_dir();
     let handler_environment = common::get_handler_environment(&exe_path);
@@ -94,34 +199,26 @@ async fn monitor_thread() {
     let logger_key: &String = &logger::get_logger_key();
     let mut restored_in_error = false;
     let mut proxy_agent_update_reported: Option<telemetry::span::SimpleSpan> = None;
+    let loop_interval = Duration::from_secs(15);
     loop {
         let current_seq_no: String = common::get_current_seq_no(&exe_path);
-        if proxyagent_file_version_in_extension.is_empty() {
-            // File version of proxy agent service already downloaded by VM Agent
-            let path = common::get_proxy_agent_exe_path();
-            proxyagent_file_version_in_extension =
-                match misc_helpers::get_proxy_agent_version(&path) {
-                    Ok(version) => version,
-                    Err(e) => {
-                        let error_message = format!(
-                            "Failed to get GuestProxyAgent version from file {} with error: {}",
-                            misc_helpers::path_to_string(&path),
-                            e
-                        );
-                        logger::write(error_message.clone());
-                        status.formattedMessage.message = error_message;
-                        status.code = constants::STATUS_CODE_NOT_OK;
-                        status.status = status_state_obj.update_state(false);
-                        common::report_status(
-                            status_folder_path.to_path_buf(),
-                            &current_seq_no,
-                            &status,
-                        );
-                        tokio::time::sleep(Duration::from_secs(15)).await;
-                        continue;
-                    }
-                };
+
+        // Step 1: Resolve the extension-bundled proxy agent version (retry each iteration until available)
+        match resolve_proxyagent_file_version_in_extension(
+            &proxyagent_file_version_in_extension,
+            &mut status,
+            &mut status_state_obj,
+        ) {
+            Some(version) => proxyagent_file_version_in_extension = version,
+            None => {
+                common::report_status(status_folder_path.to_path_buf(), &current_seq_no, &status);
+                tokio::time::sleep(loop_interval).await;
+                continue;
+            }
         }
+
+        // Step 2: On seq_no change, check whether the proxy agent service needs an update or
+        //         whether a previous update was interrupted and needs to be resumed.
         if cache_seq_no != current_seq_no {
             telemetry::event_logger::write_event(
                 LoggerLevel::Info,
@@ -133,68 +230,54 @@ async fn monitor_thread() {
                 logger_key,
             );
             cache_seq_no = current_seq_no.to_string();
-            let proxy_service_exe_file_path = common::get_proxy_agent_service_path();
-            let proxyagent_service_file_version =
-                match misc_helpers::get_proxy_agent_version(&proxy_service_exe_file_path) {
-                    Ok(version) => version,
-                    Err(e) => {
-                        logger::write(format!(
-                            "Failed to get GuestProxyAgent version from file {} with error: {}",
-                            misc_helpers::path_to_string(&proxy_service_exe_file_path),
-                            e
-                        ));
-                        // return empty string if failed to get version
-                        "".to_string()
-                    }
-                };
-            if proxyagent_file_version_in_extension != proxyagent_service_file_version {
-                // Call setup tool to install or update proxy agent service
-                telemetry::event_logger::write_event(
-                    LoggerLevel::Info,
-                    format!("Version mismatch between file versions. ProxyAgentService File Version: {proxyagent_service_file_version}, ProxyAgent in Extension File Version: {proxyagent_file_version_in_extension}"
-                        ),
-                    "monitor_thread",
-                    "service_main",
-                    logger_key,
-                );
-                let setup_tool = misc_helpers::path_to_string(&common::setup_tool_exe_path());
-                backup_proxyagent(&setup_tool);
-                let mut install_command = Command::new(&setup_tool);
-                // Set the current directory to the directory of the current executable for the setup tool to work properly
-                install_command.current_dir(misc_helpers::get_current_exe_dir());
-                let proxy_agent_update_command = telemetry::span::SimpleSpan::new();
+
+            if let Some(action) =
+                determine_update_action(&proxyagent_file_version_in_extension, logger_key)
+            {
+                if matches!(action, UpdateAction::VersionMismatch) {
+                    backup_proxyagent(
+                        &misc_helpers::path_to_string(&common::setup_tool_exe_path()),
+                    );
+
+                    // reset this flag in case the previous restore was done due to an error,
+                    // but now the version mismatch indicates a new update attempt rather than a resume of a previous interrupted update
+                    restored_in_error = false;
+                }
+                let update_span = telemetry::span::SimpleSpan::new();
                 proxy_agent_update_reported = Some(telemetry::span::SimpleSpan::new());
-                install_command.arg("install");
-                let output = install_command.output();
-                report_proxy_agent_service_status(
-                    output,
+                run_setup_tool_install(
                     exe_path.join("status"),
                     &cache_seq_no,
                     &mut status,
                     &mut status_state_obj,
                 );
-                // Time taken to update proxy agent service
-                proxy_agent_update_command.write_event(
-                    "Update Proxy Agent command completed",
-                    "monitor_thread",
-                    "service_main",
-                    logger_key,
-                );
+                let span_message = match &action {
+                    UpdateAction::VersionMismatch => "Update Proxy Agent command completed",
+                    UpdateAction::ResumeInterruptedUpdate => {
+                        "Retry install for interrupted update completed"
+                    }
+                };
+                update_span.write_event(span_message, "monitor_thread", "service_main", logger_key);
             }
         }
-        // Read proxy agent aggregate status file and get ProxyAgentAggregateStatus object
+
+        // Step 3: Read and evaluate the proxy agent aggregate status
         report_proxy_agent_aggregate_status(
             &proxyagent_file_version_in_extension,
             &mut status,
             &mut status_state_obj,
-            &mut restored_in_error,
             &mut service_state,
         );
 
-        // Time taken to report success for proxy agent service after update
+        // Step 4: Restore (on error) or purge (on success) the backed-up proxy agent, once
+        if !restored_in_error {
+            restored_in_error = restore_purge_proxyagent(&mut status);
+        }
+
+        // Step 5: Track time-to-success after an update
         if status.status == *constants::SUCCESS_STATUS {
-            if let Some(proxy_agent_update_reported) = proxy_agent_update_reported.as_ref() {
-                proxy_agent_update_reported.write_event(
+            if let Some(span) = proxy_agent_update_reported.as_ref() {
+                span.write_event(
                     "Proxy Agent Service is updated and reporting successful status",
                     "monitor_thread",
                     "service_main",
@@ -203,18 +286,21 @@ async fn monitor_thread() {
             }
             proxy_agent_update_reported = None;
         }
+
+        // Step 6: Report eBPF driver status (Windows only)
         #[cfg(windows)]
         {
             report_ebpf_status(&mut status);
         }
 
+        // Step 7: Write the final status file and sleep
         common::report_status(
             status_folder_path.to_path_buf(),
             &cache_seq_no.to_string(),
             &status,
         );
 
-        tokio::time::sleep(Duration::from_secs(15)).await;
+        tokio::time::sleep(loop_interval).await;
     }
 }
 
@@ -337,11 +423,42 @@ fn backup_proxyagent(setup_tool: &String) {
     }
 }
 
+/// Checks if the proxy agent service is running a different version than the files present in the extension,
+/// This can happen when a VM is force-restarted during a proxy agent service update, causing the new service to not start properly.
+/// Return true if the versions match, return false if the versions do not match or if not able to read the service status version at all.
+fn check_version_in_proxy_agent_status_file(proxyagent_file_version_in_extension: &str) -> bool {
+    let aggregate_status_file_path =
+        proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
+            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME);
+    match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
+        &aggregate_status_file_path,
+    ) {
+        Ok(aggregate_status) => {
+            let running_version = &aggregate_status.proxyAgentStatus.version;
+            if running_version != proxyagent_file_version_in_extension {
+                logger::write(format!(
+                    "Reported GPA service version {running_version} differs from installed file version {proxyagent_file_version_in_extension}."
+                ));
+                false
+            } else {
+                true
+            }
+        }
+        Err(e) => {
+            // Cannot read aggregate status — service may not be running at all.
+            // Treat this as an incomplete update so install is retried.
+            logger::write(format!(
+                "Cannot read aggregate status file to verify running version: {e}.",
+            ));
+            false
+        }
+    }
+}
+
 fn report_proxy_agent_aggregate_status(
     proxyagent_file_version_in_extension: &String,
     status: &mut StatusObj,
     status_state_obj: &mut common::StatusState,
-    restored_in_error: &mut bool,
     service_state: &mut ServiceState,
 ) {
     let aggregate_status_file_path =
@@ -416,9 +533,6 @@ fn report_proxy_agent_aggregate_status(
                 ]
             };
         }
-    }
-    if !(*restored_in_error) {
-        *restored_in_error = restore_purge_proxyagent(status);
     }
 }
 

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -257,7 +257,12 @@ async fn monitor_thread() {
                         "Retry install for interrupted update completed"
                     }
                 };
-                update_span.write_event(span_message, "install_proxy_agent", "service_main", logger_key);
+                update_span.write_event(
+                    span_message,
+                    "install_proxy_agent",
+                    "service_main",
+                    logger_key,
+                );
             }
         }
 

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -72,6 +72,7 @@ async fn heartbeat_thread() {
 }
 
 /// Describes the reason for running the setup tool install command.
+#[derive(Debug, PartialEq)]
 enum UpdateAction {
     /// Service file version differs from extension — a fresh update.
     VersionMismatch,
@@ -125,27 +126,33 @@ fn get_proxy_agent_service_file_version() -> String {
 }
 
 /// Determines what update action (if any) is needed for the proxy agent service.
-fn determine_update_action(extension_version: &str, logger_key: &str) -> Option<UpdateAction> {
-    let service_file_version = get_proxy_agent_service_file_version();
-
-    if extension_version != service_file_version {
+fn determine_update_action(
+    proxy_agent_in_extension_version: &str,
+    proxy_agent_service_version: &str,
+    status_file_path: Option<PathBuf>,
+    logger_key: &str,
+) -> Option<UpdateAction> {
+    if proxy_agent_in_extension_version != proxy_agent_service_version {
         telemetry::event_logger::write_event(
             LoggerLevel::Info,
             format!(
                 "Version mismatch between file versions. \
-                 ProxyAgentService File Version: {service_file_version}, \
-                 ProxyAgent in Extension File Version: {extension_version}"
+                 ProxyAgentService File Version: {proxy_agent_service_version}, \
+                 ProxyAgent in Extension File Version: {proxy_agent_in_extension_version}"
             ),
             "monitor_thread",
             "service_main",
             logger_key,
         );
         Some(UpdateAction::VersionMismatch)
-    } else if !check_version_in_proxy_agent_status_file(extension_version) {
+    } else if !check_version_in_proxy_agent_status_file(
+        proxy_agent_in_extension_version,
+        status_file_path,
+    ) {
         telemetry::event_logger::write_event(
             LoggerLevel::Info,
             format!(
-                "Service file version matches extension version {extension_version} but \
+                "Service file version matches extension version {proxy_agent_in_extension_version} but \
                  running service reports a different version. \
                  Re-running install to complete the interrupted update."
             ),
@@ -231,9 +238,13 @@ async fn monitor_thread() {
             );
             cache_seq_no = current_seq_no.to_string();
 
-            if let Some(action) =
-                determine_update_action(&proxyagent_file_version_in_extension, logger_key)
-            {
+            let proxy_agent_service_version = get_proxy_agent_service_file_version();
+            if let Some(action) = determine_update_action(
+                &proxyagent_file_version_in_extension,
+                &proxy_agent_service_version,
+                None,
+                logger_key,
+            ) {
                 if matches!(action, UpdateAction::VersionMismatch) {
                     backup_proxyagent(
                         &misc_helpers::path_to_string(&common::setup_tool_exe_path()),
@@ -431,10 +442,15 @@ fn backup_proxyagent(setup_tool: &String) {
 /// Checks if the proxy agent service is running a different version than the files present in the extension,
 /// This can happen when a VM is force-restarted during a proxy agent service update, causing the new service to not start properly.
 /// Return true if the versions match, return false if the versions do not match or if not able to read the service status version at all.
-fn check_version_in_proxy_agent_status_file(proxyagent_file_version_in_extension: &str) -> bool {
-    let aggregate_status_file_path =
-        proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
-            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME);
+fn check_version_in_proxy_agent_status_file(
+    proxyagent_file_version_in_extension: &str,
+    status_file_path: Option<PathBuf>,
+) -> bool {
+    let aggregate_status_file_path = match status_file_path {
+        Some(path) => path,
+        None => proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
+            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME),
+    };
     match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
         &aggregate_status_file_path,
     ) {
@@ -940,6 +956,70 @@ mod tests {
     use crate::structs::*;
     use proxy_agent_shared::misc_helpers;
     use proxy_agent_shared::proxy_agent_aggregate_status::*;
+    use std::path::PathBuf;
+
+    /// Build a StatusObj with default plugin name, enable operation, and current timestamp.
+    fn make_test_status_obj(status: &str, code: i32, message: &str) -> StatusObj {
+        StatusObj {
+            name: constants::PLUGIN_NAME.to_string(),
+            operation: constants::ENABLE_OPERATION.to_string(),
+            configurationAppliedTime: misc_helpers::get_date_time_string(),
+            code,
+            status: status.to_string(),
+            formattedMessage: FormattedMessage {
+                lang: constants::LANG_EN_US.to_string(),
+                message: message.to_string(),
+            },
+            substatus: Default::default(),
+        }
+    }
+
+    fn make_detail_status() -> ProxyAgentDetailStatus {
+        ProxyAgentDetailStatus {
+            status: ModuleState::RUNNING,
+            message: "test".to_string(),
+            states: None,
+        }
+    }
+
+    fn make_test_proxy_agent_status(version: &str) -> ProxyAgentStatus {
+        ProxyAgentStatus {
+            version: version.to_string(),
+            status: OverallState::SUCCESS,
+            monitorStatus: make_detail_status(),
+            keyLatchStatus: make_detail_status(),
+            ebpfProgramStatus: make_detail_status(),
+            proxyListenerStatus: make_detail_status(),
+            telemetryLoggerStatus: make_detail_status(),
+            proxyConnectionsCount: 1,
+        }
+    }
+
+    fn make_test_connection_summary() -> ProxyConnectionSummary {
+        ProxyConnectionSummary {
+            userName: "test".to_string(),
+            ip: "test".to_string(),
+            port: 1,
+            processCmdLine: "test".to_string(),
+            responseStatus: "test".to_string(),
+            count: 1,
+            processFullPath: Some("test".to_string()),
+            userGroups: Some(vec!["test".to_string()]),
+        }
+    }
+
+    fn make_test_aggregate_status(
+        timestamp: String,
+        version: &str,
+    ) -> GuestProxyAgentAggregateStatus {
+        let summary = make_test_connection_summary();
+        GuestProxyAgentAggregateStatus {
+            timestamp,
+            proxyAgentStatus: make_test_proxy_agent_status(version),
+            proxyConnectionSummary: vec![summary.clone()],
+            failedAuthenticateSummary: vec![summary],
+        }
+    }
 
     #[test]
     #[cfg(windows)]
@@ -970,18 +1050,11 @@ mod tests {
         let seq_no = "0";
         let expected_status_file: &PathBuf = &temp_test_path.join("status").join("0.status");
 
-        let mut status = StatusObj {
-            name: constants::PLUGIN_NAME.to_string(),
-            operation: constants::ENABLE_OPERATION.to_string(),
-            configurationAppliedTime: misc_helpers::get_date_time_string(),
-            code: constants::STATUS_CODE_OK,
-            status: constants::SUCCESS_STATUS.to_string(),
-            formattedMessage: FormattedMessage {
-                lang: constants::LANG_EN_US.to_string(),
-                message: "Update Proxy Agent command output successfully".to_string(),
-            },
-            substatus: Default::default(),
-        };
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "Update Proxy Agent command output successfully",
+        );
         let mut status_state_obj = super::common::StatusState::new();
 
         super::report_proxy_agent_service_status(
@@ -1026,65 +1099,8 @@ mod tests {
 
     #[test]
     fn test_proxyagent_service_success_status() {
-        let proxy_agent_status_obj = ProxyAgentStatus {
-            version: "1.0.0".to_string(),
-            status: OverallState::SUCCESS,
-            monitorStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            keyLatchStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            ebpfProgramStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyListenerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            telemetryLoggerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyConnectionsCount: 1,
-        };
-
-        let proxy_connection_summary_obj = ProxyConnectionSummary {
-            userName: "test".to_string(),
-            ip: "test".to_string(),
-            port: 1,
-            processCmdLine: "test".to_string(),
-            responseStatus: "test".to_string(),
-            count: 1,
-            processFullPath: Some("test".to_string()),
-            userGroups: Some(vec!["test".to_string()]),
-        };
-
-        let proxy_failedAuthenticateSummary_obj = ProxyConnectionSummary {
-            userName: "test".to_string(),
-            ip: "test".to_string(),
-            port: 1,
-            processCmdLine: "test".to_string(),
-            responseStatus: "test".to_string(),
-            count: 1,
-            processFullPath: Some("test".to_string()),
-            userGroups: Some(vec!["test".to_string()]),
-        };
-
-        let toplevel_status = GuestProxyAgentAggregateStatus {
-            timestamp: misc_helpers::get_date_time_string(),
-            proxyAgentStatus: proxy_agent_status_obj,
-            proxyConnectionSummary: vec![proxy_connection_summary_obj],
-            failedAuthenticateSummary: vec![proxy_failedAuthenticateSummary_obj],
-        };
+        let toplevel_status =
+            make_test_aggregate_status(misc_helpers::get_date_time_string(), "1.0.0");
         let result = toplevel_status.get_status_timestamp();
         assert!(
             result.is_ok(),
@@ -1092,18 +1108,11 @@ mod tests {
             result.err()
         );
 
-        let mut status = StatusObj {
-            name: constants::PLUGIN_NAME.to_string(),
-            operation: constants::ENABLE_OPERATION.to_string(),
-            configurationAppliedTime: misc_helpers::get_date_time_string(),
-            code: constants::STATUS_CODE_OK,
-            status: constants::SUCCESS_STATUS.to_string(),
-            formattedMessage: FormattedMessage {
-                lang: constants::LANG_EN_US.to_string(),
-                message: "Update Proxy Agent command output successfully".to_string(),
-            },
-            substatus: Default::default(),
-        };
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "Update Proxy Agent command output successfully",
+        );
 
         let mut status_state_obj = super::common::StatusState::new();
 
@@ -1123,48 +1132,40 @@ mod tests {
     #[tokio::test]
     #[cfg(windows)]
     async fn test_report_ebpf_status() {
-        let mut status = StatusObj {
-            name: constants::PLUGIN_NAME.to_string(),
-            operation: constants::ENABLE_OPERATION.to_string(),
-            configurationAppliedTime: misc_helpers::get_date_time_string(),
-            code: constants::STATUS_CODE_OK,
-            status: constants::SUCCESS_STATUS.to_string(),
-            formattedMessage: FormattedMessage {
-                lang: constants::LANG_EN_US.to_string(),
-                message: "Update Proxy Agent command output successfully".to_string(),
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "Update Proxy Agent command output successfully",
+        );
+        status.substatus = vec![
+            SubStatus {
+                name: constants::PLUGIN_CONNECTION_NAME.to_string(),
+                status: constants::SUCCESS_STATUS.to_string(),
+                code: constants::STATUS_CODE_OK,
+                formattedMessage: FormattedMessage {
+                    lang: constants::LANG_EN_US.to_string(),
+                    message: "test".to_string(),
+                },
             },
-            substatus: {
-                vec![
-                    SubStatus {
-                        name: constants::PLUGIN_CONNECTION_NAME.to_string(),
-                        status: constants::SUCCESS_STATUS.to_string(),
-                        code: constants::STATUS_CODE_OK,
-                        formattedMessage: FormattedMessage {
-                            lang: constants::LANG_EN_US.to_string(),
-                            message: "test".to_string(),
-                        },
-                    },
-                    SubStatus {
-                        name: constants::PLUGIN_STATUS_NAME.to_string(),
-                        status: constants::SUCCESS_STATUS.to_string(),
-                        code: constants::STATUS_CODE_OK,
-                        formattedMessage: FormattedMessage {
-                            lang: constants::LANG_EN_US.to_string(),
-                            message: "test".to_string(),
-                        },
-                    },
-                    SubStatus {
-                        name: constants::PLUGIN_FAILED_AUTH_NAME.to_string(),
-                        status: constants::SUCCESS_STATUS.to_string(),
-                        code: constants::STATUS_CODE_OK,
-                        formattedMessage: FormattedMessage {
-                            lang: constants::LANG_EN_US.to_string(),
-                            message: "test".to_string(),
-                        },
-                    },
-                ]
+            SubStatus {
+                name: constants::PLUGIN_STATUS_NAME.to_string(),
+                status: constants::SUCCESS_STATUS.to_string(),
+                code: constants::STATUS_CODE_OK,
+                formattedMessage: FormattedMessage {
+                    lang: constants::LANG_EN_US.to_string(),
+                    message: "test".to_string(),
+                },
             },
-        };
+            SubStatus {
+                name: constants::PLUGIN_FAILED_AUTH_NAME.to_string(),
+                status: constants::SUCCESS_STATUS.to_string(),
+                code: constants::STATUS_CODE_OK,
+                formattedMessage: FormattedMessage {
+                    lang: constants::LANG_EN_US.to_string(),
+                    message: "test".to_string(),
+                },
+            },
+        ];
 
         super::report_ebpf_status(&mut status);
         assert_eq!(
@@ -1188,16 +1189,7 @@ mod tests {
     #[tokio::test]
     async fn get_top_proxy_connection_summary_tests() {
         let mut summary = Vec::new();
-        let mut proxy_connection_summary_obj = ProxyConnectionSummary {
-            userName: "test".to_string(),
-            ip: "test".to_string(),
-            port: 1,
-            processCmdLine: "test".to_string(),
-            responseStatus: "test".to_string(),
-            count: 1,
-            processFullPath: Some("test".to_string()),
-            userGroups: Some(vec!["test".to_string()]),
-        };
+        let mut proxy_connection_summary_obj = make_test_connection_summary();
         summary.push(proxy_connection_summary_obj.clone());
         proxy_connection_summary_obj.count = 5;
         summary.push(proxy_connection_summary_obj.clone());
@@ -1272,71 +1264,16 @@ mod tests {
 
     #[test]
     fn test_stale_status_timestamp_greater_than_5_minutes() {
-        let proxy_agent_status_obj = ProxyAgentStatus {
-            version: "1.0.0".to_string(),
-            status: OverallState::SUCCESS,
-            monitorStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            keyLatchStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            ebpfProgramStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyListenerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            telemetryLoggerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyConnectionsCount: 1,
-        };
-
-        let proxy_connection_summary_obj = ProxyConnectionSummary {
-            userName: "test".to_string(),
-            ip: "test".to_string(),
-            port: 1,
-            processCmdLine: "test".to_string(),
-            responseStatus: "test".to_string(),
-            count: 1,
-            processFullPath: Some("test".to_string()),
-            userGroups: Some(vec!["test".to_string()]),
-        };
-
         // Create a timestamp that is 10 minutes old (greater than 5 minutes)
         // Use a fixed old timestamp format to simulate staleness
         let stale_timestamp = "2024-01-01T00:00:00Z".to_string();
+        let toplevel_status = make_test_aggregate_status(stale_timestamp, "1.0.0");
 
-        let toplevel_status = GuestProxyAgentAggregateStatus {
-            timestamp: stale_timestamp,
-            proxyAgentStatus: proxy_agent_status_obj,
-            proxyConnectionSummary: vec![proxy_connection_summary_obj.clone()],
-            failedAuthenticateSummary: vec![proxy_connection_summary_obj],
-        };
-
-        let mut status = StatusObj {
-            name: constants::PLUGIN_NAME.to_string(),
-            operation: constants::ENABLE_OPERATION.to_string(),
-            configurationAppliedTime: misc_helpers::get_date_time_string(),
-            code: constants::STATUS_CODE_OK,
-            status: constants::SUCCESS_STATUS.to_string(),
-            formattedMessage: FormattedMessage {
-                lang: constants::LANG_EN_US.to_string(),
-                message: "Update Proxy Agent command output successfully".to_string(),
-            },
-            substatus: Default::default(),
-        };
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "Update Proxy Agent command output successfully",
+        );
 
         let mut status_state_obj = super::common::StatusState::new();
         let proxyagent_file_version_in_extension: &String = &"1.0.0".to_string();
@@ -1366,70 +1303,15 @@ mod tests {
 
     #[test]
     fn test_fresh_status_timestamp_within_5_minutes() {
-        let proxy_agent_status_obj = ProxyAgentStatus {
-            version: "1.0.0".to_string(),
-            status: OverallState::SUCCESS,
-            monitorStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            keyLatchStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            ebpfProgramStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyListenerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            telemetryLoggerStatus: ProxyAgentDetailStatus {
-                status: ModuleState::RUNNING,
-                message: "test".to_string(),
-                states: None,
-            },
-            proxyConnectionsCount: 1,
-        };
-
-        let proxy_connection_summary_obj = ProxyConnectionSummary {
-            userName: "test".to_string(),
-            ip: "test".to_string(),
-            port: 1,
-            processCmdLine: "test".to_string(),
-            responseStatus: "test".to_string(),
-            count: 1,
-            processFullPath: Some("test".to_string()),
-            userGroups: Some(vec!["test".to_string()]),
-        };
-
         // Create a fresh timestamp (current time)
-        let fresh_timestamp = misc_helpers::get_date_time_string();
+        let toplevel_status =
+            make_test_aggregate_status(misc_helpers::get_date_time_string(), "1.0.0");
 
-        let toplevel_status = GuestProxyAgentAggregateStatus {
-            timestamp: fresh_timestamp,
-            proxyAgentStatus: proxy_agent_status_obj,
-            proxyConnectionSummary: vec![proxy_connection_summary_obj.clone()],
-            failedAuthenticateSummary: vec![proxy_connection_summary_obj],
-        };
-
-        let mut status = StatusObj {
-            name: constants::PLUGIN_NAME.to_string(),
-            operation: constants::ENABLE_OPERATION.to_string(),
-            configurationAppliedTime: misc_helpers::get_date_time_string(),
-            code: constants::STATUS_CODE_OK,
-            status: constants::SUCCESS_STATUS.to_string(),
-            formattedMessage: FormattedMessage {
-                lang: constants::LANG_EN_US.to_string(),
-                message: "Update Proxy Agent command output successfully".to_string(),
-            },
-            substatus: Default::default(),
-        };
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "Update Proxy Agent command output successfully",
+        );
 
         let mut status_state_obj = super::common::StatusState::new();
         let proxyagent_file_version_in_extension: &String = &"1.0.0".to_string();
@@ -1451,5 +1333,160 @@ mod tests {
             constants::SUCCESS_STATUS.to_string()
         );
         assert_eq!(status.substatus[0].code, constants::STATUS_CODE_OK);
+    }
+
+    #[test]
+    fn test_resolve_version_returns_cached_when_non_empty() {
+        let mut status =
+            make_test_status_obj(constants::SUCCESS_STATUS, constants::STATUS_CODE_OK, "test");
+        let mut status_state_obj = super::common::StatusState::new();
+
+        let result = super::resolve_proxyagent_file_version_in_extension(
+            "1.0.39",
+            &mut status,
+            &mut status_state_obj,
+        );
+
+        assert_eq!(result, Some("1.0.39".to_string()));
+        // Status should remain unchanged when cached version is returned
+        assert_eq!(status.status, constants::SUCCESS_STATUS.to_string());
+        assert_eq!(status.code, constants::STATUS_CODE_OK);
+        assert_eq!(status.formattedMessage.message, "test");
+    }
+
+    #[test]
+    fn test_resolve_version_returns_none_when_file_not_found() {
+        let mut status =
+            make_test_status_obj(constants::SUCCESS_STATUS, constants::STATUS_CODE_OK, "test");
+        let mut status_state_obj = super::common::StatusState::new();
+
+        // Empty cache forces file read; the proxy agent exe doesn't exist in test env
+        let result = super::resolve_proxyagent_file_version_in_extension(
+            "",
+            &mut status,
+            &mut status_state_obj,
+        );
+
+        assert_eq!(result, None);
+        assert_eq!(status.code, constants::STATUS_CODE_NOT_OK);
+        assert!(status
+            .formattedMessage
+            .message
+            .contains("Failed to get GuestProxyAgent version"));
+        // StatusState starts at Transitioning; one failure keeps it there
+        assert_eq!(status.status, constants::TRANSITIONING_STATUS.to_string());
+    }
+
+    #[test]
+    fn test_determine_update_action() {
+        use std::env;
+        use std::fs;
+
+        let temp_dir = env::temp_dir().join("test_check_version_status");
+        _ = fs::remove_dir_all(&temp_dir);
+        _ = misc_helpers::try_create_folder(&temp_dir);
+        let status_file = temp_dir.join("status.json");
+
+        let version_39 = "1.0.39";
+        let version_30 = "1.0.30";
+
+        // Matching versions should return VersionMismatch
+        let result =
+            super::determine_update_action(version_39, version_30, None, "test_logger_key");
+        assert_eq!(
+            result,
+            Some(super::UpdateAction::VersionMismatch),
+            "Expected VersionMismatch when versions differ"
+        );
+
+        // Matching versions should return ResumeInterruptedUpdate when the aggregate status file doesn't exist
+        let result = super::determine_update_action(
+            version_39,
+            version_39,
+            Some(PathBuf::from("nonexistent_path")),
+            "test_logger_key",
+        );
+        assert_eq!(
+            result,
+            Some(super::UpdateAction::ResumeInterruptedUpdate),
+            "Expected ResumeInterruptedUpdate when status file does not exist"
+        );
+
+        // Matching versions should return ResumeInterruptedUpdate when the aggregate status file does exist but with different version
+        // Write a valid aggregate status file with version "1.0.30"
+        let aggregate_status =
+            make_test_aggregate_status(misc_helpers::get_date_time_string(), version_30);
+        misc_helpers::json_write_to_file(&aggregate_status, &status_file).unwrap();
+        let result = super::determine_update_action(
+            version_39,
+            version_39,
+            Some(status_file.clone()),
+            "test_logger_key",
+        );
+        assert_eq!(
+            result,
+            Some(super::UpdateAction::ResumeInterruptedUpdate),
+            "Expected ResumeInterruptedUpdate when status file exists but version differs"
+        );
+
+        // Matching versions should return None when the aggregate status file does exist and version matches
+        // Write a valid aggregate status file with version "1.0.39"
+        let aggregate_status =
+            make_test_aggregate_status(misc_helpers::get_date_time_string(), version_39);
+        misc_helpers::json_write_to_file(&aggregate_status, &status_file).unwrap();
+        let result = super::determine_update_action(
+            version_39,
+            version_39,
+            Some(status_file.clone()),
+            "test_logger_key",
+        );
+        assert_eq!(
+            result, None,
+            "Expected None when status file exists and version matches"
+        );
+
+        // Clean up
+        _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_restore_purge_returns_true_for_error_status() {
+        let mut status = make_test_status_obj(
+            constants::ERROR_STATUS,
+            constants::STATUS_CODE_NOT_OK,
+            "test error",
+        );
+
+        // restore_purge_proxyagent should return true when status is ERROR
+        // (the restore command will fail since setup tool doesn't exist, but that's OK in unit test)
+        let result = super::restore_purge_proxyagent(&mut status);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_restore_purge_returns_true_for_success_status() {
+        let mut status = make_test_status_obj(
+            constants::SUCCESS_STATUS,
+            constants::STATUS_CODE_OK,
+            "test success",
+        );
+
+        // restore_purge_proxyagent should return true when status is SUCCESS
+        // (the purge command will fail since setup tool doesn't exist, but that's OK in unit test)
+        let result = super::restore_purge_proxyagent(&mut status);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_restore_purge_returns_false_for_transitioning_status() {
+        let mut status = make_test_status_obj(
+            constants::TRANSITIONING_STATUS,
+            constants::STATUS_CODE_OK,
+            "test transitioning",
+        );
+
+        // restore_purge_proxyagent should return false when status is TRANSITIONING
+        let result = super::restore_purge_proxyagent(&mut status);
+        assert!(!result);
     }
 }


### PR DESCRIPTION
- Fix VM Extension service main could ably resume from previous interrupted update
- Refactoring the main loop code to multiple sub functions.
- Added Unit Tests for the refactored functions.