### PR TITLE
Report eBPF service statuses instead of checking installation

### DIFF
--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -376,18 +376,13 @@ fn build_ebpf_substatus(
         (None, None) => (
             constants::ERROR_STATUS.to_string(),
             constants::STATUS_CODE_NOT_OK,
-            format!(
-                "Ebpf Driver: {} unsuccessfully queried, Ebpf Driver: {} unsuccessfully queried.",
-                constants::EBPF_CORE,
-                constants::EBPF_EXT
-            ),
+            "EbpfCore: unsuccessfully queried, NetEbpfExt: unsuccessfully queried.".to_string(),
         ),
         (None, _) => (
             constants::ERROR_STATUS.to_string(),
             constants::STATUS_CODE_NOT_OK,
             format!(
-                "Ebpf Driver: {} unsuccessfully queried, NetEbpfExt: {}",
-                constants::EBPF_CORE,
+                "EbpfCore: unsuccessfully queried, NetEbpfExt: {}",
                 ext.summary()
             ),
         ),
@@ -395,9 +390,8 @@ fn build_ebpf_substatus(
             constants::ERROR_STATUS.to_string(),
             constants::STATUS_CODE_NOT_OK,
             format!(
-                "EbpfCore: {}, Ebpf Driver: {} unsuccessfully queried.",
-                core.summary(),
-                constants::EBPF_EXT
+                "EbpfCore: {}, NetEbpfExt: unsuccessfully queried.",
+                core.summary()
             ),
         ),
     };

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -341,68 +341,89 @@ fn write_state_event(
 }
 
 #[cfg(windows)]
-fn report_ebpf_status(status_obj: &mut StatusObj) {
-    match service::check_service_installed(constants::EBPF_CORE) {
-        (true, message) => {
-            logger::write(message.to_string());
-            match service::check_service_installed(constants::EBPF_EXT) {
-                (true, message) => {
-                    logger::write(message.to_string());
-                    status_obj.substatus = {
-                        let mut substatus = status_obj.substatus.clone();
-                        substatus.push(SubStatus {
-                            name: constants::EBPF_SUBSTATUS_NAME.to_string(),
-                            status: constants::SUCCESS_STATUS.to_string(),
-                            code: constants::STATUS_CODE_OK,
-                            formattedMessage: FormattedMessage {
-                                lang: constants::LANG_EN_US.to_string(),
-                                message: "Ebpf Drivers successfully queried.".to_string(),
-                            },
-                        });
-                        substatus
-                    };
-                }
-                (false, message) => {
-                    logger::write(message.to_string());
-                    status_obj.substatus = {
-                        let mut substatus = status_obj.substatus.clone();
-                        substatus.push(SubStatus {
-                            name: constants::EBPF_SUBSTATUS_NAME.to_string(),
-                            status: constants::ERROR_STATUS.to_string(),
-                            code: constants::STATUS_CODE_NOT_OK,
-                            formattedMessage: FormattedMessage {
-                                lang: constants::LANG_EN_US.to_string(),
-                                message: format!(
-                                    "Ebpf Driver: {} unsuccessfully queried.",
-                                    constants::EBPF_EXT
-                                ),
-                            },
-                        });
-                        substatus
-                    };
-                }
+fn build_ebpf_substatus(
+    core: &proxy_agent_shared::service::ServiceStatusInfo,
+    ext: &proxy_agent_shared::service::ServiceStatusInfo,
+) -> SubStatus {
+    use proxy_agent_shared::service::ServiceState;
+
+    let (status, code, message) = match (&core.state, &ext.state) {
+        (Some(core_state), Some(ext_state)) => {
+            let both_running =
+                *core_state == ServiceState::Running && *ext_state == ServiceState::Running;
+            if both_running {
+                (
+                    constants::SUCCESS_STATUS.to_string(),
+                    constants::STATUS_CODE_OK,
+                    format!(
+                        "EbpfCore: {}, NetEbpfExt: {}",
+                        core.summary(),
+                        ext.summary()
+                    ),
+                )
+            } else {
+                (
+                    constants::ERROR_STATUS.to_string(),
+                    constants::STATUS_CODE_NOT_OK,
+                    format!(
+                        "EbpfCore: {}, NetEbpfExt: {}",
+                        core.summary(),
+                        ext.summary()
+                    ),
+                )
             }
         }
-        (false, message) => {
-            logger::write(message.to_string());
-            status_obj.substatus = {
-                let mut substatus = status_obj.substatus.clone();
-                substatus.push(SubStatus {
-                    name: constants::EBPF_SUBSTATUS_NAME.to_string(),
-                    status: constants::ERROR_STATUS.to_string(),
-                    code: constants::STATUS_CODE_NOT_OK,
-                    formattedMessage: FormattedMessage {
-                        lang: constants::LANG_EN_US.to_string(),
-                        message: format!(
-                            "Ebpf Driver: {} unsuccessfully queried.",
-                            constants::EBPF_CORE
-                        ),
-                    },
-                });
-                substatus
-            };
-        }
+        (None, None) => (
+            constants::ERROR_STATUS.to_string(),
+            constants::STATUS_CODE_NOT_OK,
+            format!(
+                "Ebpf Driver: {} unsuccessfully queried, Ebpf Driver: {} unsuccessfully queried.",
+                constants::EBPF_CORE,
+                constants::EBPF_EXT
+            ),
+        ),
+        (None, _) => (
+            constants::ERROR_STATUS.to_string(),
+            constants::STATUS_CODE_NOT_OK,
+            format!(
+                "Ebpf Driver: {} unsuccessfully queried, NetEbpfExt: {}",
+                constants::EBPF_CORE,
+                ext.summary()
+            ),
+        ),
+        (_, None) => (
+            constants::ERROR_STATUS.to_string(),
+            constants::STATUS_CODE_NOT_OK,
+            format!(
+                "EbpfCore: {}, Ebpf Driver: {} unsuccessfully queried.",
+                core.summary(),
+                constants::EBPF_EXT
+            ),
+        ),
+    };
+
+    SubStatus {
+        name: constants::EBPF_SUBSTATUS_NAME.to_string(),
+        status,
+        code,
+        formattedMessage: FormattedMessage {
+            lang: constants::LANG_EN_US.to_string(),
+            message,
+        },
     }
+}
+
+#[cfg(windows)]
+fn report_ebpf_status(status_obj: &mut StatusObj) {
+    let core_status = service::check_service_status(constants::EBPF_CORE);
+    logger::write(format!("check_service_status: {}", core_status.message()));
+
+    let ext_status = service::check_service_status(constants::EBPF_EXT);
+    logger::write(format!("check_service_status: {}", ext_status.message()));
+
+    let mut substatus = status_obj.substatus.clone();
+    substatus.push(build_ebpf_substatus(&core_status, &ext_status));
+    status_obj.substatus = substatus;
 }
 
 fn backup_proxy_agent(setup_tool: &String) {
@@ -1184,6 +1205,155 @@ mod tests {
             status.substatus[3].name,
             constants::EBPF_SUBSTATUS_NAME.to_string()
         );
+
+        // Verify the eBPF substatus message includes service status info
+        let ebpf_substatus = &status.substatus[3];
+        let ebpf_message = &ebpf_substatus.formattedMessage.message;
+        if ebpf_message.contains("unsuccessfully queried") {
+            // At least one service not installed — status should be Error
+            assert_eq!(
+                ebpf_substatus.status,
+                constants::ERROR_STATUS,
+                "Expected Error status when a service is not installed"
+            );
+        } else {
+            // Both services found — message should contain status details for each driver
+            assert!(
+                ebpf_message.contains("EbpfCore:"),
+                "Expected message to contain 'EbpfCore:', got: {ebpf_message}"
+            );
+            assert!(
+                ebpf_message.contains("NetEbpfExt:"),
+                "Expected message to contain 'NetEbpfExt:', got: {ebpf_message}"
+            );
+            // Status depends on whether both services are running
+            if ebpf_message.contains("Running") && !ebpf_message.contains("Stopped") {
+                assert_eq!(
+                    ebpf_substatus.status,
+                    constants::SUCCESS_STATUS,
+                    "Expected Success when both services are running"
+                );
+                assert_eq!(ebpf_substatus.code, constants::STATUS_CODE_OK);
+            } else {
+                assert_eq!(
+                    ebpf_substatus.status,
+                    constants::ERROR_STATUS,
+                    "Expected Error when at least one service is not running"
+                );
+                assert_eq!(ebpf_substatus.code, constants::STATUS_CODE_NOT_OK);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_build_ebpf_substatus() {
+        use proxy_agent_shared::service::{ServiceState, ServiceStatusInfo};
+
+        fn make_info(name: &str, state: Option<ServiceState>) -> ServiceStatusInfo {
+            let start_type = if state.is_some() {
+                "AutoStart".to_string()
+            } else {
+                "NotInstalled".to_string()
+            };
+            ServiceStatusInfo {
+                service_name: name.to_string(),
+                state,
+                start_type,
+            }
+        }
+
+        // 1. Both not installed
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, None),
+            &make_info(constants::EBPF_EXT, None),
+        );
+        assert_eq!(sub.status, constants::ERROR_STATUS, "Both not installed");
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
+        let msg = &sub.formattedMessage.message;
+        assert!(
+            msg.contains(constants::EBPF_CORE) && msg.contains(constants::EBPF_EXT),
+            "Expected both driver names in message, got: {msg}"
+        );
+
+        // 2. Core not installed, Ext running
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, None),
+            &make_info(constants::EBPF_EXT, Some(ServiceState::Running)),
+        );
+        assert_eq!(sub.status, constants::ERROR_STATUS, "Core not installed");
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
+        let msg = &sub.formattedMessage.message;
+        assert!(
+            msg.contains(constants::EBPF_CORE),
+            "Expected EbpfCore in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("Running"),
+            "Expected Ext summary (Running) in message, got: {msg}"
+        );
+
+        // 3. Core running, Ext not installed
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, Some(ServiceState::Running)),
+            &make_info(constants::EBPF_EXT, None),
+        );
+        assert_eq!(sub.status, constants::ERROR_STATUS, "Ext not installed");
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
+        let msg = &sub.formattedMessage.message;
+        assert!(
+            msg.contains("Running"),
+            "Expected Core summary (Running) in message, got: {msg}"
+        );
+        assert!(
+            msg.contains(constants::EBPF_EXT),
+            "Expected NetEbpfExt in message, got: {msg}"
+        );
+
+        // 4. Both running → success
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, Some(ServiceState::Running)),
+            &make_info(constants::EBPF_EXT, Some(ServiceState::Running)),
+        );
+        assert_eq!(sub.status, constants::SUCCESS_STATUS, "Both running");
+        assert_eq!(sub.code, constants::STATUS_CODE_OK);
+        let msg = &sub.formattedMessage.message;
+        assert!(
+            msg.contains("EbpfCore:") && msg.contains("NetEbpfExt:"),
+            "Expected both driver labels in message, got: {msg}"
+        );
+
+        // 5. Core stopped, Ext running → error
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, Some(ServiceState::Stopped)),
+            &make_info(constants::EBPF_EXT, Some(ServiceState::Running)),
+        );
+        assert_eq!(
+            sub.status,
+            constants::ERROR_STATUS,
+            "Core stopped, Ext running"
+        );
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
+
+        // 6. Core running, Ext stopped → error
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, Some(ServiceState::Running)),
+            &make_info(constants::EBPF_EXT, Some(ServiceState::Stopped)),
+        );
+        assert_eq!(
+            sub.status,
+            constants::ERROR_STATUS,
+            "Core running, Ext stopped"
+        );
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
+
+        // 7. Both stopped → error
+        let sub = super::build_ebpf_substatus(
+            &make_info(constants::EBPF_CORE, Some(ServiceState::Stopped)),
+            &make_info(constants::EBPF_EXT, Some(ServiceState::Stopped)),
+        );
+        assert_eq!(sub.status, constants::ERROR_STATUS, "Both stopped");
+        assert_eq!(sub.code, constants::STATUS_CODE_NOT_OK);
     }
 
     #[tokio::test]

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -145,8 +145,37 @@ pub fn check_service_installed(service_name: &str) -> (bool, String) {
     }
 }
 
+/// Checks whether a Windows service is installed and queries its runtime state and start type.
+/// Returns a `ServiceStatusInfo` whose `state` is `Some(ServiceState)` when the service exists,
+/// or `None` when the service is not installed.
+#[cfg(windows)]
+pub fn check_service_status(service_name: &str) -> windows_service::ServiceStatusInfo {
+    let state = match windows_service::query_service_status(service_name) {
+        Ok(status) => Some(status.current_state),
+        Err(_) => None,
+    };
+
+    let start_type = match &state {
+        Some(_) => match windows_service::query_service_config(service_name) {
+            Ok(config) => format!("{:?}", config.start_type),
+            Err(_) => "Unknown".to_string(),
+        },
+        None => "NotInstalled".to_string(),
+    };
+
+    windows_service::ServiceStatusInfo {
+        service_name: service_name.to_string(),
+        state,
+        start_type,
+    }
+}
+
 #[cfg(windows)]
 pub use windows_service::set_default_failure_actions;
+#[cfg(windows)]
+pub use windows_service::ServiceState;
+#[cfg(windows)]
+pub use windows_service::ServiceStatusInfo;
 
 #[cfg(test)]
 mod tests {
@@ -186,6 +215,47 @@ mod tests {
             let (is_installed, message) = super::check_service_installed(service_name);
             assert!(is_installed);
             assert!(message.contains("successfully queried"));
+
+            // clean up
+            _ = super::stop_and_delete_service(service_name).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_service_status() {
+        #[cfg(windows)]
+        {
+            let service_name = "test_check_service_status";
+            // try delete the service if it exists
+            _ = super::stop_and_delete_service(service_name).await;
+
+            // Verify non-existent service returns not installed
+            let status = super::check_service_status(service_name);
+            assert_eq!(status.state, None, "Expected None for non-existent service");
+            assert!(status.message().contains("query failed"));
+            assert_eq!(status.summary(), "NotInstalled");
+
+            // Install a test service and verify status is reported
+            let exe_path = std::env::current_exe().unwrap();
+            let result = super::install_service(service_name, service_name, vec![], exe_path);
+            assert!(result.is_ok());
+
+            let status = super::check_service_status(service_name);
+            assert!(status.state.is_some(), "Expected service to be installed");
+            assert!(status.message().contains("status:"));
+            // Service should be stopped (test exe can't actually run as a service)
+            assert_eq!(
+                status.state,
+                Some(super::ServiceState::Stopped),
+                "Expected Some(ServiceState::Stopped), got: {:?}",
+                status.state
+            );
+            // Summary should also contain start type info
+            let summary = status.summary();
+            assert!(
+                summary.contains("AutoStart"),
+                "Expected summary to contain 'AutoStart', got: {summary}"
+            );
 
             // clean up
             _ = super::stop_and_delete_service(service_name).await.unwrap();

--- a/proxy_agent_shared/src/service.rs
+++ b/proxy_agent_shared/src/service.rs
@@ -150,17 +150,29 @@ pub fn check_service_installed(service_name: &str) -> (bool, String) {
 /// or `None` when the service is not installed.
 #[cfg(windows)]
 pub fn check_service_status(service_name: &str) -> windows_service::ServiceStatusInfo {
-    let state = match windows_service::query_service_status(service_name) {
-        Ok(status) => Some(status.current_state),
-        Err(_) => None,
-    };
-
-    let start_type = match &state {
-        Some(_) => match windows_service::query_service_config(service_name) {
-            Ok(config) => format!("{:?}", config.start_type),
-            Err(_) => "Unknown".to_string(),
-        },
-        None => "NotInstalled".to_string(),
+    let (state, start_type) = match windows_service::query_service_status(service_name) {
+        Ok(status) => {
+            let start_type = match windows_service::query_service_config(service_name) {
+                Ok(config) => format!("{:?}", config.start_type),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to query config for service '{}': {}",
+                        service_name,
+                        e
+                    );
+                    "Unknown".to_string()
+                }
+            };
+            (Some(status.current_state), start_type)
+        }
+        Err(e) => {
+            log::debug!(
+                "Failed to query status for service '{}': {}. Treating as not installed.",
+                service_name,
+                e
+            );
+            (None, "NotInstalled".to_string())
+        }
     };
 
     windows_service::ServiceStatusInfo {

--- a/proxy_agent_shared/src/service/windows_service.rs
+++ b/proxy_agent_shared/src/service/windows_service.rs
@@ -7,13 +7,42 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::str;
 use std::time::Duration;
+pub use windows_service::service::ServiceState;
 use windows_service::service::{
     ServiceAccess, ServiceAction, ServiceActionType, ServiceConfig, ServiceErrorControl,
-    ServiceFailureResetPeriod, ServiceInfo, ServiceStartType, ServiceState, ServiceStatus,
-    ServiceType,
+    ServiceFailureResetPeriod, ServiceInfo, ServiceStartType, ServiceStatus, ServiceType,
 };
 use windows_service::service::{ServiceDependency, ServiceFailureActions};
 use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+
+/// Holds the runtime status of a Windows service.
+#[derive(Debug)]
+pub struct ServiceStatusInfo {
+    pub service_name: String,
+    pub state: Option<ServiceState>,
+    pub start_type: String,
+}
+
+impl ServiceStatusInfo {
+    /// Human-readable summary, e.g. "Running, AutoStart" or "NotInstalled".
+    pub fn summary(&self) -> String {
+        match self.state {
+            Some(ref state) => format!("{:?}, {}", state, self.start_type),
+            None => "NotInstalled".to_string(),
+        }
+    }
+
+    /// Log-friendly message including the service name and summary.
+    pub fn message(&self) -> String {
+        match self.state {
+            Some(_) => format!("service: {} status: {}", self.service_name, self.summary()),
+            None => format!(
+                "service: {} status query failed, service may not be installed",
+                self.service_name
+            ),
+        }
+    }
+}
 
 pub async fn start_service_with_retry(
     service_name: &str,
@@ -167,7 +196,7 @@ pub fn install_or_update_service(
     }
 }
 
-fn query_service_status(service_name: &str) -> Result<ServiceStatus> {
+pub fn query_service_status(service_name: &str) -> Result<ServiceStatus> {
     let service_manager =
         ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
             .map_err(|e| Error::WindowsService(e, std::io::Error::last_os_error()))?;
@@ -305,6 +334,7 @@ pub fn set_default_failure_actions(service_name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::{path::PathBuf, process::Command};
+    use windows_service::service::ServiceState;
 
     #[tokio::test]
     async fn test_install_service() {
@@ -412,5 +442,72 @@ mod tests {
         assert!(output_str.contains("STOPPED"));
         //Clean up - delete service
         super::stop_and_delete_service(service_name).await.unwrap();
+    }
+
+    #[test]
+    fn test_service_status_info_summary() {
+        // Not installed
+        let info = super::ServiceStatusInfo {
+            service_name: "TestSvc".to_string(),
+            state: None,
+            start_type: "NotInstalled".to_string(),
+        };
+        assert_eq!(info.summary(), "NotInstalled");
+
+        // Running, AutoStart
+        let info = super::ServiceStatusInfo {
+            service_name: "TestSvc".to_string(),
+            state: Some(ServiceState::Running),
+            start_type: "AutoStart".to_string(),
+        };
+        assert_eq!(info.summary(), "Running, AutoStart");
+
+        // Stopped, Disabled
+        let info = super::ServiceStatusInfo {
+            service_name: "TestSvc".to_string(),
+            state: Some(ServiceState::Stopped),
+            start_type: "Disabled".to_string(),
+        };
+        assert_eq!(info.summary(), "Stopped, Disabled");
+    }
+
+    #[test]
+    fn test_service_status_info_message() {
+        // Not installed — message must mention the service name and "query failed"
+        let info = super::ServiceStatusInfo {
+            service_name: "TestSvc".to_string(),
+            state: None,
+            start_type: "NotInstalled".to_string(),
+        };
+        let msg = info.message();
+        assert!(
+            msg.contains("TestSvc"),
+            "Expected service name in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("query failed"),
+            "Expected 'query failed' in message, got: {msg}"
+        );
+
+        // Installed and running — message must contain "status:" and the summary
+        let info = super::ServiceStatusInfo {
+            service_name: "TestSvc".to_string(),
+            state: Some(ServiceState::Running),
+            start_type: "AutoStart".to_string(),
+        };
+        let msg = info.message();
+        assert!(
+            msg.contains("TestSvc"),
+            "Expected service name in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("status:"),
+            "Expected 'status:' in message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&info.summary()),
+            "Expected summary '{}' in message, got: {msg}",
+            info.summary()
+        );
     }
 }


### PR DESCRIPTION
## Overview

This PR improves the eBPF service status reporting in the GuestProxy Agent VM Extension. Previously, the eBPF substatus only reported whether the EbpfCore and NetEbpfExt driver services were **installed**. This meant the status could show `Success` even when one or both services were stopped or in a degraded state.

The change updates eBPF status reporting to query the **runtime state** (e.g., Running, Stopped) and **start type** (e.g., AutoStart, Disabled) of each eBPF driver service. The substatus now reports `Success` only when both services are confirmed running, and `Error` otherwise — providing more accurate and actionable health information. Each error case also includes the state of the other service in the message for full context.

The implementation is also refactored to use a dedicated `ServiceStatusInfo` struct (replacing a raw tuple return) and a pure `build_ebpf_substatus` helper function that isolates the substatus decision logic from I/O, enabling deterministic unit testing without mocking.

---

## High Level Code Changes

#### `proxy_agent_shared/src/service/windows_service.rs`
- Added a `ServiceStatusInfo` struct to hold the runtime status of a Windows service, with fields for `service_name`, `state: Option<ServiceState>`, and `start_type`.
- Added `summary()` and `message()` methods on `ServiceStatusInfo`. `summary()` produces a human-readable string (e.g., `"Running, AutoStart"` or `"NotInstalled"`); `message()` produces a log-friendly string using the service name and summary — the `check_service_status:` prefix is prepended by callers when logging.
- Made `query_service_status` public so it can be consumed by the new status-check logic.
- Re-exported `ServiceState` as a public type for callers to pattern-match on.
- Added unit tests for `ServiceStatusInfo::summary()` and `ServiceStatusInfo::message()` covering not-installed, running, and stopped states.

#### `proxy_agent_shared/src/service.rs`
- Added `check_service_status()` which returns a `ServiceStatusInfo` struct. Callers determine whether a service is installed by checking `state.is_some()` — the previous redundant `is_installed` boolean and prebuilt message string have been removed.
- Re-exported `ServiceStatusInfo` and `ServiceState` from the module for use by callers.
- Added a unit test (`test_check_service_status`) that validates the function against both a non-existent service and a freshly installed test service.

#### `proxy_agent_extension/src/service_main.rs`
- Extracted a pure `build_ebpf_substatus(core, ext)` helper function that takes two `ServiceStatusInfo` values and returns the `SubStatus` to report. This isolates all substatus decision logic from the I/O in `report_ebpf_status`.
- Updated `report_ebpf_status()` to call `check_service_status` for both services as two independent (non-nested) calls, so both services are always queried and logged regardless of the other's state.
- The substatus now reports `Success`/`STATUS_CODE_OK` only when both EbpfCore and NetEbpfExt are `Running`; otherwise reports `Error`/`STATUS_CODE_NOT_OK`.
- All four cases (both missing, core missing, ext missing, both present) include the state of both services in the formatted message.
- Added `test_build_ebpf_substatus` unit test covering all 7 meaningful state combinations: both not installed, one missing with the other running, both running (success), and partial/both-stopped error cases.

---

## Testing

Manually replaced the built ProxyAgentExt.exe in a VM and tested the following cases:

1. Both stopped and one disabled:

```
[{"version":"1.0","timestampUTC":"2026-04-01T15:01:33.746","status":{"name":"ProxyAgentVMExtension","operation":"Enable","configurationAppliedTime":"2026-04-01T15:01:33Z","status":"Transitioning","code":0,"formattedMessage":{"lang":"en-US","message":"Started ProxyAgent Extension Monitoring thread."},"substatus":[{"name":"ProxyAgentConnectionSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:01:33.7065978 +00:00:00"}},{"name":"ProxyAgentStatus","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:01:33.7065978 +00:00:00"}},{"name":"ProxyAgentFailedAuthenticationSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:01:33.7065978 +00:00:00"}},{"name":"EbpfStatus","status":"Error","code":4,"formattedMessage":{"lang":"en-US","message":"EbpfCore: Stopped, Disabled, NetEbpfExt: Stopped, AutoStart"}}]}}]
```

2. One service running and one stopped and disabled:


```
[{"version":"1.0","timestampUTC":"2026-04-01T15:02:34.124","status":{"name":"ProxyAgentVMExtension","operation":"Enable","configurationAppliedTime":"2026-04-01T15:02:34Z","status":"Transitioning","code":0,"formattedMessage":{"lang":"en-US","message":"Started ProxyAgent Extension Monitoring thread."},"substatus":[{"name":"ProxyAgentConnectionSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:02:34.0880885 +00:00:00"}},{"name":"ProxyAgentStatus","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:02:34.0880885 +00:00:00"}},{"name":"ProxyAgentFailedAuthenticationSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:02:34.0880885 +00:00:00"}},{"name":"EbpfStatus","status":"Error","code":4,"formattedMessage":{"lang":"en-US","message":"EbpfCore: Stopped, Disabled, NetEbpfExt: Running, AutoStart"}}]}}]
```

3. Both services running:


```
[{"version":"1.0","timestampUTC":"2026-04-01T15:05:20.171","status":{"name":"ProxyAgentVMExtension","operation":"Enable","configurationAppliedTime":"2026-04-01T15:05:20Z","status":"Error","code":0,"formattedMessage":{"lang":"en-US","message":"Started ProxyAgent Extension Monitoring thread."},"substatus":[{"name":"ProxyAgentConnectionSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:05:20.134109 +00:00:00"}},{"name":"ProxyAgentStatus","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:05:20.134109 +00:00:00"}},{"name":"ProxyAgentFailedAuthenticationSummary","status":"Transitioning","code":4,"formattedMessage":{"lang":"en-US","message":"Proxy agent aggregate status file is stale. Status timestamp: 2026-04-01 14:54:02.802 +00:00:00, Current time: 2026-04-01 15:05:20.134109 +00:00:00"}},{"name":"EbpfStatus","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"EbpfCore: Running, AutoStart, NetEbpfExt: Running, AutoStart"}}]}}]
```

4. After re-running GuestProxyAgent service:


```
[{"version":"1.0","timestampUTC":"2026-04-01T15:07:35.883","status":{"name":"ProxyAgentVMExtension","operation":"Enable","configurationAppliedTime":"2026-04-01T15:07:35Z","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"Started ProxyAgent Extension Monitoring thread."},"substatus":[{"name":"ProxyAgentConnectionSummary","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"proxy connection summary is empty"}},{"name":"ProxyAgentStatus","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"{\"version\":\"1.0.41.0\",\"status\":\"SUCCESS\",\"monitorStatus\":{\"status\":\"RUNNING\",\"message\":\"Proxy agent status is running.\"},\"keyLatchStatus\":{\"status\":\"RUNNING\",\"message\":\"Found key details from local and ready to use. - 141\",\"states\":{\"imdsRuleId\":\"0de+3s0TY/ikVyv5nylfT5I8KqA=\",\"wireServerRuleId\":\"AfxJN89/TGr+9Bq112Jpk+FT2C0=\",\"hostGARuleId\":\"AfxJN89/TGr+9Bq112Jpk+FT2C0=\",\"keyGuid\":\"1938a0d4-adbd-4276-8b12-fccd7574f375\",\"secureChannelState\":\"WireServer Enforce -  IMDS Disabled - HostGA Enforce\"}},\"ebpfProgramStatus\":{\"status\":\"RUNNING\",\"message\":\"Started Redirector with eBPF maps - 120\"},\"proxyListenerStatus\":{\"status\":\"RUNNING\",\"message\":\"Started proxy listener, ready to accept request - 120\"},\"telemetryLoggerStatus\":{\"status\":\"UNKNOWN\",\"message\":\"Status unknown.\"},\"proxyConnectionsCount\":0}"}},{"name":"ProxyAgentFailedAuthenticationSummary","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"proxy failed auth summary is empty"}},{"name":"EbpfStatus","status":"Success","code":0,"formattedMessage":{"lang":"en-US","message":"EbpfCore: Running, AutoStart, NetEbpfExt: Running, AutoStart"}}]}}]
```