### PR TITLE
Code refactoring: Move init logger and GPA service name to shared crate

### DIFF
--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -8,7 +8,7 @@ pub const IMDS_IP: &str = "169.254.169.254";
 pub const IMDS_PORT: u16 = 80u16;
 
 pub const WINDOWS_AZURE: &str = "Windows Azure";
-pub const PROXY_AGENT_SERVICE_NAME: &str = "GuestProxyAgent";
+pub use proxy_agent_shared::constants::PROXY_AGENT_SERVICE_NAME;
 pub const PROXY_AGENT_IP: &str = "127.0.0.1";
 pub const PROXY_AGENT_PORT: u16 = 3080;
 

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -11,11 +11,9 @@ use crate::redirector::{self, Redirector};
 use crate::shared_state::SharedState;
 use proxy_agent_shared::current_info;
 use proxy_agent_shared::hyper_client::HostEndpoint;
-use proxy_agent_shared::logger::rolling_logger::RollingLogger;
-use proxy_agent_shared::logger::{logger_manager, LoggerLevel};
+use proxy_agent_shared::logger::logger_manager;
 use proxy_agent_shared::proxy_agent_aggregate_status;
 use proxy_agent_shared::telemetry::event_logger;
-use std::path::PathBuf;
 
 #[cfg(not(windows))]
 use std::time::Duration;
@@ -42,7 +40,20 @@ pub async fn start_service(shared_state: SharedState) {
     if log_folder == proxy_agent_shared::misc_helpers::empty_path() {
         println!("The log folder is not set, skip write to GPA managed file log.");
     } else {
-        setup_loggers(log_folder, config::get_file_log_level());
+        proxy_agent_shared::logger::init_loggers(
+            log_folder,
+            &[
+                (logger::AGENT_LOGGER_KEY, "ProxyAgent.log"),
+                (
+                    ConnectionLogger::CONNECTION_LOGGER_KEY,
+                    "ProxyAgent.Connection.log",
+                ),
+            ],
+            logger::AGENT_LOGGER_KEY,
+            constants::MAX_LOG_FILE_SIZE,
+            constants::MAX_LOG_FILE_COUNT as u16,
+            config::get_file_log_level(),
+        );
     }
 
     let start_message = format!(
@@ -83,32 +94,6 @@ pub async fn start_service(shared_state: SharedState) {
             proxy_server.start().await;
         }
     });
-}
-
-fn setup_loggers(log_folder: PathBuf, max_logger_level: LoggerLevel) {
-    let agent_logger = RollingLogger::create_new(
-        log_folder.clone(),
-        "ProxyAgent.log".to_string(),
-        constants::MAX_LOG_FILE_SIZE,
-        constants::MAX_LOG_FILE_COUNT as u16,
-    );
-    let connection_logger = RollingLogger::create_new(
-        log_folder.clone(),
-        "ProxyAgent.Connection.log".to_string(),
-        constants::MAX_LOG_FILE_SIZE,
-        constants::MAX_LOG_FILE_COUNT as u16,
-    );
-    let mut loggers = std::collections::HashMap::new();
-    loggers.insert(logger::AGENT_LOGGER_KEY.to_string(), agent_logger);
-    loggers.insert(
-        ConnectionLogger::CONNECTION_LOGGER_KEY.to_string(),
-        connection_logger,
-    );
-    logger_manager::set_loggers(
-        loggers,
-        logger::AGENT_LOGGER_KEY.to_string(),
-        max_logger_level,
-    );
 }
 
 /// Start the service and wait until the service is stopped.

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -13,10 +13,7 @@ pub const EXTENSION_PROCESS_NAME: &str = "ProxyAgentExt";
 #[cfg(windows)]
 pub const EXTENSION_PROCESS_NAME: &str = "ProxyAgentExt.exe";
 pub const EXTENSION_SERVICE_DISPLAY_NAME: &str = "Microsoft Azure GuestProxyAgent VMExtension";
-#[cfg(windows)]
-pub const PROXY_AGENT_SERVICE_NAME: &str = "GuestProxyAgent";
-#[cfg(not(windows))]
-pub const PROXY_AGENT_SERVICE_NAME: &str = "azure-proxy-agent";
+pub use proxy_agent_shared::constants::PROXY_AGENT_SERVICE_NAME;
 pub const UPDATE_TAG_FILE: &str = "update.tag";
 pub const ENABLE_OPERATION: &str = "Enable";
 pub const LANG_EN_US: &str = "en-US";

--- a/proxy_agent_extension/src/logger.rs
+++ b/proxy_agent_extension/src/logger.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use proxy_agent_shared::logger::{logger_manager, rolling_logger::RollingLogger, LoggerLevel};
+use proxy_agent_shared::logger::{self, logger_manager, LoggerLevel};
 use std::path::PathBuf;
+
 static LOGGER_KEY: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
+
 pub fn get_logger_key() -> String {
     LOGGER_KEY
         .get()
@@ -11,15 +13,14 @@ pub fn get_logger_key() -> String {
 }
 
 pub fn init_logger(log_folder: String, log_name: &str) {
-    let logger = RollingLogger::create_new(
+    logger::init_loggers(
         PathBuf::from(log_folder),
-        log_name.to_string(),
+        &[(log_name, log_name)],
+        log_name,
         20 * 1024 * 1024,
         30,
+        LoggerLevel::Trace,
     );
-    let mut loggers = std::collections::HashMap::new();
-    loggers.insert(log_name.to_string(), logger);
-    logger_manager::set_loggers(loggers, log_name.to_string(), LoggerLevel::Trace);
 
     if !LOGGER_KEY.initialized() {
         if let Err(e) = LOGGER_KEY.set(log_name.to_string()) {

--- a/proxy_agent_setup/src/logger.rs
+++ b/proxy_agent_setup/src/logger.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 use proxy_agent_shared::{
-    logger::{logger_manager, rolling_logger::RollingLogger, LoggerLevel},
+    logger::{self, logger_manager, LoggerLevel},
     misc_helpers,
 };
 use std::path::PathBuf;
@@ -12,10 +12,14 @@ pub fn init_logger() {
 }
 
 fn force_init_logger(log_folder: PathBuf, log_name: &str) {
-    let logger = RollingLogger::create_new(log_folder, log_name.to_string(), 20 * 1024 * 1024, 30);
-    let mut loggers = std::collections::HashMap::new();
-    loggers.insert(log_name.to_string(), logger);
-    logger_manager::set_loggers(loggers, log_name.to_string(), LoggerLevel::Trace);
+    logger::init_loggers(
+        log_folder,
+        &[(log_name, log_name)],
+        log_name,
+        20 * 1024 * 1024,
+        30,
+        LoggerLevel::Trace,
+    );
 }
 
 pub fn write(message: String) {

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -13,6 +13,7 @@ pub mod setup;
 mod linux;
 
 use clap::Parser;
+use proxy_agent_shared::constants::{PROXY_AGENT_SERVICE_DISPLAY_NAME, PROXY_AGENT_SERVICE_NAME};
 use proxy_agent_shared::current_info;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::service;
@@ -20,12 +21,8 @@ use std::process;
 use std::time::Duration;
 use std::{fs, path::PathBuf};
 
-#[cfg(windows)]
-const SERVICE_NAME: &str = "GuestProxyAgent";
-const SERVICE_DISPLAY_NAME: &str = "Microsoft Azure Guest Proxy Agent";
-
-#[cfg(not(windows))]
-const SERVICE_NAME: &str = "azure-proxy-agent";
+const SERVICE_NAME: &str = PROXY_AGENT_SERVICE_NAME;
+const SERVICE_DISPLAY_NAME: &str = PROXY_AGENT_SERVICE_DISPLAY_NAME;
 
 #[tokio::main]
 async fn main() {

--- a/proxy_agent_shared/src/constants.rs
+++ b/proxy_agent_shared/src/constants.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+//! Workspace-wide constants shared across the agent, extension, and setup crates.
+//!
+//! This module consolidates values that previously lived in three
+//! separate `constants` modules and had silently drifted apart.
+
+/// The OS service name under which the proxy agent runs.
+///
+/// - Windows: registered Service Control Manager name.
+/// - Linux: `systemd` unit name (matches the binary installed at
+///   `/usr/sbin/azure-proxy-agent` and packaged in the .deb / .rpm).
+#[cfg(windows)]
+pub const PROXY_AGENT_SERVICE_NAME: &str = "GuestProxyAgent";
+#[cfg(not(windows))]
+pub const PROXY_AGENT_SERVICE_NAME: &str = "azure-proxy-agent";
+
+/// Human-readable display name for the proxy agent service.
+pub const PROXY_AGENT_SERVICE_DISPLAY_NAME: &str = "Microsoft Azure Guest Proxy Agent";

--- a/proxy_agent_shared/src/lib.rs
+++ b/proxy_agent_shared/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 pub mod common_state;
+pub mod constants;
 pub mod current_info;
 pub mod error;
 #[cfg(windows)]

--- a/proxy_agent_shared/src/logger.rs
+++ b/proxy_agent_shared/src/logger.rs
@@ -2,11 +2,49 @@
 // SPDX-License-Identifier: MIT
 
 use crate::misc_helpers;
+use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub mod logger_manager;
 pub mod rolling_logger;
 
 pub type LoggerLevel = log::Level;
+
+/// This function is a convenience wrapper that sets up the logging infrastructure for a given role.
+///
+/// # Arguments
+/// * `log_folder` — directory the rolling logs are written to.
+/// * `files` — `(logger_key, file_name)` pairs; each pair becomes one
+///   `RollingLogger`. The keys are what call sites use later via
+///   `logger_manager::log(key, …)`.
+/// * `primary_key` — the default logger key (must appear in `files`).
+/// * `max_file_size` — per-file size budget passed to `RollingLogger`.
+/// * `max_file_count` — number of rolled files retained.
+/// * `max_level` — maximum file-log level.
+///
+/// # Panics
+/// `logger_manager::set_loggers` panics if `primary_key` is not present in `files`.
+///      this function preserves that contract.
+pub fn init_loggers(
+    log_folder: PathBuf,
+    files: &[(&str, &str)],
+    primary_key: &str,
+    max_file_size: u64,
+    max_file_count: u16,
+    max_level: LoggerLevel,
+) {
+    let mut loggers = HashMap::with_capacity(files.len());
+    for (key, file_name) in files {
+        let logger = rolling_logger::RollingLogger::create_new(
+            log_folder.clone(),
+            (*file_name).to_string(),
+            max_file_size,
+            max_file_count,
+        );
+        loggers.insert((*key).to_string(), logger);
+    }
+    logger_manager::set_loggers(loggers, primary_key.to_string(), max_level);
+}
 
 const HEADER_LENGTH: usize = 34;
 pub fn get_log_header(level: LoggerLevel) -> String {

--- a/proxy_agent_shared/src/logger/logger_manager.rs
+++ b/proxy_agent_shared/src/logger/logger_manager.rs
@@ -210,18 +210,13 @@ mod tests {
 
     fn setup() {
         TEST_INIT.call_once(|| {
-            // Setup logger_manager for unit tests
-            let logger = crate::logger::rolling_logger::RollingLogger::create_new(
+            // Setup logger_manager for unit tests via the shared one-shot helper.
+            crate::logger::init_loggers(
                 get_temp_test_dir(),
-                "test.log".to_string(),
+                &[(TEST_LOGGER_KEY, "test.log")],
+                TEST_LOGGER_KEY,
                 200,
                 6,
-            );
-            let mut loggers = std::collections::HashMap::new();
-            loggers.insert(TEST_LOGGER_KEY.to_string(), logger);
-            crate::logger::logger_manager::set_loggers(
-                loggers,
-                TEST_LOGGER_KEY.to_string(),
                 LoggerLevel::Trace,
             );
 


### PR DESCRIPTION
- Add a convenience wrapper that sets up the logging infrastructure
- Move GPA service name to shared crate