### PR TITLE
Add get_proxy_agent_aggregate_status to remove the disk write-permission dependency

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -48,7 +48,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             runs_on: ubuntu-latest
             crate: ProxyAgentExt
-            max_binary_bytes: "9000000"   # ~9 MB
+            max_binary_bytes: "10000000"   # ~10 MB
             crate_share_overrides: "clap_builder=0.15 regex_automata=0.15"
             apt_packages: musl-tools
           - target: x86_64-unknown-linux-musl
@@ -70,7 +70,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             runs_on: ubuntu-24.04-arm
             crate: ProxyAgentExt
-            max_binary_bytes: "16000000"
+            max_binary_bytes: "10000000"
             crate_share_overrides: "clap_builder=0.15 regex_automata=0.15"
             apt_packages: musl-tools
           - target: aarch64-unknown-linux-musl

--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -8,9 +8,9 @@ pub const IMDS_IP: &str = "169.254.169.254";
 pub const IMDS_PORT: u16 = 80u16;
 
 pub const WINDOWS_AZURE: &str = "Windows Azure";
+pub use proxy_agent_shared::constants::PROXY_AGENT_IP;
+pub use proxy_agent_shared::constants::PROXY_AGENT_PORT;
 pub use proxy_agent_shared::constants::PROXY_AGENT_SERVICE_NAME;
-pub const PROXY_AGENT_IP: &str = "127.0.0.1";
-pub const PROXY_AGENT_PORT: u16 = 3080;
 
 pub const WIRE_SERVER_IP_NETWORK_BYTE_ORDER: u32 = 0x10813FA8; // 168.63.129.16
 pub const GA_PLUGIN_IP_NETWORK_BYTE_ORDER: u32 = 0x10813FA8; // 168.63.129.16

--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-pub const WIRE_SERVER_IP: &str = "168.63.129.16";
-pub const WIRE_SERVER_PORT: u16 = 80u16;
-pub const GA_PLUGIN_IP: &str = "168.63.129.16";
-pub const GA_PLUGIN_PORT: u16 = 32526u16;
-pub const IMDS_IP: &str = "169.254.169.254";
-pub const IMDS_PORT: u16 = 80u16;
-
-pub const WINDOWS_AZURE: &str = "Windows Azure";
+pub use proxy_agent_shared::constants::GA_PLUGIN_IP;
+pub use proxy_agent_shared::constants::GA_PLUGIN_PORT;
+pub use proxy_agent_shared::constants::IMDS_IP;
+pub use proxy_agent_shared::constants::IMDS_PORT;
 pub use proxy_agent_shared::constants::PROXY_AGENT_IP;
 pub use proxy_agent_shared::constants::PROXY_AGENT_PORT;
 pub use proxy_agent_shared::constants::PROXY_AGENT_SERVICE_NAME;
+pub use proxy_agent_shared::constants::WIRE_SERVER_IP;
+pub use proxy_agent_shared::constants::WIRE_SERVER_PORT;
+
+pub const WINDOWS_AZURE: &str = "Windows Azure";
 
 pub const WIRE_SERVER_IP_NETWORK_BYTE_ORDER: u32 = 0x10813FA8; // 168.63.129.16
 pub const GA_PLUGIN_IP_NETWORK_BYTE_ORDER: u32 = 0x10813FA8; // 168.63.129.16

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -23,7 +23,6 @@
 use super::proxy_authorizer::AuthorizeResult;
 use super::proxy_connection::{ConnectionLogger, HttpConnectionContext, TcpConnectionContext};
 use crate::common::{constants, error::Error, helpers, logger, result::Result};
-use crate::provision;
 use crate::proxy::{proxy_authorizer, proxy_summary::ProxySummary, Claims};
 use crate::shared_state::access_control_wrapper::AccessControlSharedState;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
@@ -33,6 +32,7 @@ use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::proxy_server_wrapper::ProxyServerSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
 use crate::shared_state::{EventThreadsSharedState, SharedState};
+use crate::{provision, proxy_agent_status};
 use http_body_util::Full;
 use http_body_util::{combinators::BoxBody, BodyExt};
 use hyper::body::{Bytes, Incoming};
@@ -424,6 +424,14 @@ impl ProxyServer {
                 .await;
         }
 
+        if http_connection_context.url
+            == proxy_agent_shared::proxy_agent_aggregate_status::STATUS_URL_PATH
+        {
+            return self
+                .handle_status_request(http_connection_context.get_logger_mut_ref(), request)
+                .await;
+        }
+
         http_connection_context.log(
             LoggerLevel::Trace,
             "Getting destination IP and port.".to_string(),
@@ -703,6 +711,47 @@ impl ProxyServer {
                 Ok(response)
             }
         }
+    }
+
+    /// Handle a status request.
+    /// This function handles a status request by fetching the current status of the proxy agent service and returning it as a JSON response.
+    async fn handle_status_request(
+        &self,
+        logger: &mut ConnectionLogger,
+        request: Request<Limited<hyper::body::Incoming>>,
+    ) -> Result<Response<BoxBody<Bytes, hyper::Error>>> {
+        // check MetaData header exists or not
+        if request
+            .headers()
+            .get(hyper_client::METADATA_HEADER)
+            .is_none()
+        {
+            logger.write(
+                LoggerLevel::Warn,
+                "No MetaData header found in the request.".to_string(),
+            );
+            return Ok(Self::closed_response(StatusCode::BAD_REQUEST));
+        }
+
+        let status = proxy_agent_status::ProxyAgentStatusTask::get_proxy_agent_aggregate_status(
+            &self.agent_status_shared_state,
+            &self.key_keeper_shared_state,
+            &self.connection_summary_shared_state,
+        )
+        .await;
+        let json = serde_json::to_string(&status).unwrap_or_else(|e| {
+            logger.write(
+                LoggerLevel::Warn,
+                format!("Failed to serialize status: {e}"),
+            );
+            String::new()
+        });
+        let mut response = Response::new(hyper_client::full_body(json.as_bytes().to_vec()));
+        response.headers_mut().insert(
+            hyper::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json; charset=utf-8"),
+        );
+        Ok(response)
     }
 
     async fn forward_response(
@@ -1091,7 +1140,7 @@ mod tests {
     use crate::proxy::proxy_server;
     use crate::shared_state;
     use http::Method;
-    use proxy_agent_shared::hyper_client;
+    use proxy_agent_shared::{current_info, hyper_client, proxy_agent_aggregate_status};
     use std::collections::HashMap;
     use std::time::Duration;
 
@@ -1115,6 +1164,17 @@ mod tests {
         // give some time to let the listener started
         let sleep_duration = Duration::from_millis(100);
         tokio::time::sleep(sleep_duration).await;
+
+        // test /status endpoint
+        let status =
+            proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_from_server(host, port)
+                .await
+                .unwrap();
+        assert!(!status.proxyAgentStatus.version.is_empty());
+        assert_eq!(
+            status.proxyAgentStatus.version,
+            current_info::get_current_exe_version()
+        );
 
         let endpoint = hyper_client::HostEndpoint::new(host, port, "/");
         let request = hyper_client::build_request(

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -758,7 +758,10 @@ impl ProxyServer {
                 // If claims is None or runAsElevated is false
                 logger.write(
                     LoggerLevel::Warn,
-                    "Rejected /status request from unauthenticated caller.".to_string(),
+                    format!(
+                        "Rejected {} request from unauthenticated caller.",
+                        proxy_agent_shared::proxy_agent_aggregate_status::STATUS_URL_PATH
+                    ),
                 );
                 return Ok(Self::closed_response(StatusCode::FORBIDDEN));
             }
@@ -1225,7 +1228,7 @@ mod tests {
             Ok(_) => {
                 assert!(
                     false,
-                    "Expected error when calling /status endpoint without authentication"
+                    "Expected error when calling /gpa-aggregated-status endpoint without authentication"
                 );
             }
             Err(e) => {

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -428,7 +428,11 @@ impl ProxyServer {
             == proxy_agent_shared::proxy_agent_aggregate_status::STATUS_URL_PATH
         {
             return self
-                .handle_status_request(http_connection_context.get_logger_mut_ref(), request)
+                .handle_status_request(
+                    http_connection_context.get_logger_mut_ref(),
+                    request,
+                    tcp_connection_context.claims.as_ref(),
+                )
                 .await;
         }
 
@@ -705,10 +709,12 @@ impl ProxyServer {
             Err(e) => {
                 let error = format!("Failed to get provision state: {e}");
                 logger.write(LoggerLevel::Warn, error.to_string());
-                let mut response =
-                    Response::new(hyper_client::full_body(error.as_bytes().to_vec()));
-                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                Ok(response)
+
+                // return an error response and close the connection
+                Ok(Self::closed_response_with_body(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    error,
+                ))
             }
         }
     }
@@ -719,6 +725,7 @@ impl ProxyServer {
         &self,
         logger: &mut ConnectionLogger,
         request: Request<Limited<hyper::body::Incoming>>,
+        claims: Option<&Claims>,
     ) -> Result<Response<BoxBody<Bytes, hyper::Error>>> {
         // check MetaData header exists or not
         if request
@@ -733,25 +740,57 @@ impl ProxyServer {
             return Ok(Self::closed_response(StatusCode::BAD_REQUEST));
         }
 
+        // Restrict status access to elevated callers only. The Metadata header is
+        // user-controlled and cannot be used as an authorization signal.
+
+        match claims {
+            Some(claims) if claims.runAsElevated => {
+                logger.write(
+                    LoggerLevel::Trace,
+                    format!(
+                        "Allowing {} request from elevated caller: {}",
+                        proxy_agent_shared::proxy_agent_aggregate_status::STATUS_URL_PATH,
+                        misc_helpers::path_to_string(&claims.processFullPath)
+                    ),
+                );
+            }
+            _ => {
+                // If claims is None or runAsElevated is false
+                logger.write(
+                    LoggerLevel::Warn,
+                    "Rejected /status request from unauthenticated caller.".to_string(),
+                );
+                return Ok(Self::closed_response(StatusCode::FORBIDDEN));
+            }
+        }
+
         let status = proxy_agent_status::ProxyAgentStatusTask::get_proxy_agent_aggregate_status(
             &self.agent_status_shared_state,
             &self.key_keeper_shared_state,
             &self.connection_summary_shared_state,
         )
         .await;
-        let json = serde_json::to_string(&status).unwrap_or_else(|e| {
-            logger.write(
-                LoggerLevel::Warn,
-                format!("Failed to serialize status: {e}"),
-            );
-            String::new()
-        });
-        let mut response = Response::new(hyper_client::full_body(json.as_bytes().to_vec()));
-        response.headers_mut().insert(
-            hyper::header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json; charset=utf-8"),
-        );
-        Ok(response)
+        match serde_json::to_string(&status) {
+            Ok(json) => {
+                let mut response = Response::new(hyper_client::full_body(json.as_bytes().to_vec()));
+                response.headers_mut().insert(
+                    hyper::header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json; charset=utf-8"),
+                );
+
+                Ok(response)
+            }
+            Err(e) => {
+                let error = format!("Failed to serialize status: {e}");
+                logger.write(LoggerLevel::Warn, error.to_string());
+
+                // return an error response and close the connection
+                Ok(Self::closed_response_with_body(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    error,
+                ))
+            }
+        }
     }
 
     async fn forward_response(
@@ -956,6 +995,20 @@ impl ProxyServer {
         response
     }
 
+    fn closed_response_with_body(
+        status_code: StatusCode,
+        body: String,
+    ) -> Response<BoxBody<Bytes, hyper::Error>> {
+        let mut response = Response::new(hyper_client::full_body(body.as_bytes().to_vec()));
+        *response.status_mut() = status_code;
+        // Add the Connection: close header to close the tcp connection
+        response
+            .headers_mut()
+            .insert(hyper::header::CONNECTION, HeaderValue::from_static("close"));
+
+        response
+    }
+
     /// Methods that GPA's HTTP/1.1 forward-proxy will accept and try to route
     /// to a fabric endpoint. Anything else (CONNECT, TRACE, made-up verbs)
     /// is rejected with 405 by `handle_new_http_request` BEFORE any
@@ -1140,7 +1193,7 @@ mod tests {
     use crate::proxy::proxy_server;
     use crate::shared_state;
     use http::Method;
-    use proxy_agent_shared::{current_info, hyper_client, proxy_agent_aggregate_status};
+    use proxy_agent_shared::{hyper_client, proxy_agent_aggregate_status};
     use std::collections::HashMap;
     use std::time::Duration;
 
@@ -1165,16 +1218,20 @@ mod tests {
         let sleep_duration = Duration::from_millis(100);
         tokio::time::sleep(sleep_duration).await;
 
-        // test /status endpoint
-        let status =
-            proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_from_server(host, port)
-                .await
-                .unwrap();
-        assert!(!status.proxyAgentStatus.version.is_empty());
-        assert_eq!(
-            status.proxyAgentStatus.version,
-            current_info::get_current_exe_version()
-        );
+        // test /gpa-aggregated-status endpoint is forbidden for unauthenticated direct callers
+        match proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_from_server(host, port)
+            .await
+        {
+            Ok(_) => {
+                assert!(
+                    false,
+                    "Expected error when calling /status endpoint without authentication"
+                );
+            }
+            Err(e) => {
+                assert!(e.to_string().to_ascii_lowercase().contains("forbidden"));
+            }
+        }
 
         let endpoint = hyper_client::HostEndpoint::new(host, port, "/");
         let request = hyper_client::build_request(

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -99,9 +99,10 @@ impl ProxyAgentStatusTask {
         }
     }
 
-    async fn get_agent_status_message(&self) -> String {
-        match self
-            .agent_status_shared_state
+    async fn get_agent_status_message(
+        agent_status_shared_state: &AgentStatusSharedState,
+    ) -> String {
+        match agent_status_shared_state
             .get_module_status_message(AgentStatusModule::ProxyAgentStatus)
             .await
         {
@@ -165,48 +166,46 @@ impl ProxyAgentStatusTask {
         }
     }
 
-    async fn get_key_keeper_status(&self) -> ProxyAgentDetailStatus {
-        let mut key_latch_status = self
-            .agent_status_shared_state
+    async fn get_key_keeper_status(
+        agent_status_shared_state: &AgentStatusSharedState,
+        key_keeper_shared_state: &KeyKeeperSharedState,
+    ) -> ProxyAgentDetailStatus {
+        let mut key_latch_status = agent_status_shared_state
             .get_module_status(AgentStatusModule::KeyKeeper)
             .await;
         let mut states = HashMap::new();
         states.insert(
             "secureChannelState".to_string(),
-            self.key_keeper_shared_state
+            key_keeper_shared_state
                 .get_current_secure_channel_state()
                 .await
                 .unwrap_or(UNKNOWN_STATE.to_string()),
         );
-        if let Ok(Some(key_guid)) = self.key_keeper_shared_state.get_current_key_guid().await {
+        if let Ok(Some(key_guid)) = key_keeper_shared_state.get_current_key_guid().await {
             states.insert("keyGuid".to_string(), key_guid);
         }
         states.insert(
             "wireServerRuleId".to_string(),
-            self.key_keeper_shared_state
+            key_keeper_shared_state
                 .get_wireserver_rule_id()
                 .await
                 .unwrap_or(UNKNOWN_STATE.to_string()),
         );
         states.insert(
             "imdsRuleId".to_string(),
-            self.key_keeper_shared_state
+            key_keeper_shared_state
                 .get_imds_rule_id()
                 .await
                 .unwrap_or(UNKNOWN_STATE.to_string()),
         );
         states.insert(
             "hostGARuleId".to_string(),
-            self.key_keeper_shared_state
+            key_keeper_shared_state
                 .get_hostga_rule_id()
                 .await
                 .unwrap_or(UNKNOWN_STATE.to_string()),
         );
-        if let Ok(Some(incarnation)) = self
-            .key_keeper_shared_state
-            .get_current_key_incarnation()
-            .await
-        {
+        if let Ok(Some(incarnation)) = key_keeper_shared_state.get_current_key_incarnation().await {
             states.insert("keyIncarnationId".to_string(), incarnation.to_string());
         }
         key_latch_status.states = Some(states);
@@ -214,14 +213,16 @@ impl ProxyAgentStatusTask {
         key_latch_status
     }
 
-    async fn proxy_agent_status_new(&self) -> ProxyAgentStatus {
-        let key_latch_status = self.get_key_keeper_status().await;
-        let ebpf_status = self
-            .agent_status_shared_state
+    async fn proxy_agent_status_new(
+        agent_status_shared_state: &AgentStatusSharedState,
+        key_keeper_shared_state: &KeyKeeperSharedState,
+    ) -> ProxyAgentStatus {
+        let key_latch_status =
+            Self::get_key_keeper_status(agent_status_shared_state, key_keeper_shared_state).await;
+        let ebpf_status = agent_status_shared_state
             .get_module_status(AgentStatusModule::Redirector)
             .await;
-        let proxy_status = self
-            .agent_status_shared_state
+        let proxy_status = agent_status_shared_state
             .get_module_status(AgentStatusModule::ProxyServer)
             .await;
         let status = if key_latch_status.status != ModuleState::RUNNING
@@ -239,18 +240,16 @@ impl ProxyAgentStatusTask {
             // monitorStatus is proxy_agent_status itself status
             monitorStatus: ProxyAgentDetailStatus {
                 status: ModuleState::RUNNING,
-                message: self.get_agent_status_message().await,
+                message: Self::get_agent_status_message(agent_status_shared_state).await,
                 states: None,
             },
             keyLatchStatus: key_latch_status,
             ebpfProgramStatus: ebpf_status,
             proxyListenerStatus: proxy_status,
-            telemetryLoggerStatus: self
-                .agent_status_shared_state
+            telemetryLoggerStatus: agent_status_shared_state
                 .get_module_status(AgentStatusModule::TelemetryLogger)
                 .await,
-            proxyConnectionsCount: match self.agent_status_shared_state.get_connection_count().await
-            {
+            proxyConnectionsCount: match agent_status_shared_state.get_connection_count().await {
                 Ok(count) => count,
                 Err(e) => {
                     logger::write_error(format!("Error getting connection count: {e}"));
@@ -261,11 +260,28 @@ impl ProxyAgentStatusTask {
     }
 
     async fn guest_proxy_agent_aggregate_status_new(&self) -> GuestProxyAgentAggregateStatus {
+        Self::get_proxy_agent_aggregate_status(
+            &self.agent_status_shared_state,
+            &self.key_keeper_shared_state,
+            &self.connection_summary_shared_state,
+        )
+        .await
+    }
+
+    /// Get the aggregate status of the proxy agent service.
+    pub async fn get_proxy_agent_aggregate_status(
+        agent_status_shared_state: &AgentStatusSharedState,
+        key_keeper_shared_state: &KeyKeeperSharedState,
+        connection_summary_shared_state: &ConnectionSummarySharedState,
+    ) -> GuestProxyAgentAggregateStatus {
         GuestProxyAgentAggregateStatus {
             timestamp: misc_helpers::get_date_time_string_with_milliseconds(),
-            proxyAgentStatus: self.proxy_agent_status_new().await,
-            proxyConnectionSummary: match self
-                .connection_summary_shared_state
+            proxyAgentStatus: Self::proxy_agent_status_new(
+                agent_status_shared_state,
+                key_keeper_shared_state,
+            )
+            .await,
+            proxyConnectionSummary: match connection_summary_shared_state
                 .get_all_connection_summary()
                 .await
             {
@@ -275,8 +291,7 @@ impl ProxyAgentStatusTask {
                     vec![]
                 }
             },
-            failedAuthenticateSummary: match self
-                .connection_summary_shared_state
+            failedAuthenticateSummary: match connection_summary_shared_state
                 .get_all_failed_connection_summary()
                 .await
             {

--- a/proxy_agent_extension/src/constants.rs
+++ b/proxy_agent_extension/src/constants.rs
@@ -62,7 +62,7 @@ pub const EXIT_CODE_WRITE_CURRENT_SEQ_NO_ERROR: i32 = 10;
 
 pub const MIN_SUPPORTED_OS_BUILD: u32 = 17763;
 
-pub const STATE_KEY_READ_PROXY_AGENT_STATUS_FILE: &str = "ReadProxyAgentStatusFile";
+pub const STATE_KEY_READ_PROXY_AGENT_AGGREGATE_STATUS: &str = "ReadProxyAgentAggregateStatus";
 pub const STATE_KEY_FILE_VERSION: &str = "FileVersion";
 pub const STATE_KEY_STALE_PROXY_AGENT_STATUS: &str = "StaleProxyAgentStatus";
 pub const STATE_KEY_PARSE_TIMESTAMP_ERROR: &str = "ParseTimestampError";

--- a/proxy_agent_extension/src/error.rs
+++ b/proxy_agent_extension/src/error.rs
@@ -9,4 +9,7 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    ProxyAgentShared(#[from] proxy_agent_shared::error::Error),
 }

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -130,7 +130,8 @@ fn get_proxy_agent_service_file_version() -> String {
 async fn determine_update_action(
     proxy_agent_in_extension_version: &str,
     proxy_agent_service_version: &str,
-    proxy_agent_port: Option<u16>,
+    http_ip: Option<String>,
+    http_port: Option<u16>,
     status_file_path: Option<PathBuf>,
     logger_key: &str,
 ) -> Option<UpdateAction> {
@@ -149,7 +150,8 @@ async fn determine_update_action(
         Some(UpdateAction::VersionMismatch)
     } else if !check_version_in_proxy_agent_aggregate_status(
         proxy_agent_in_extension_version,
-        proxy_agent_port,
+        http_ip,
+        http_port,
         status_file_path,
     )
     .await
@@ -247,7 +249,8 @@ async fn monitor_thread() {
             if let Some(action) = determine_update_action(
                 &proxy_agent_file_version_in_extension,
                 &proxy_agent_service_version,
-                Some(proxy_agent_shared::constants::PROXY_AGENT_PORT), // Proxy Agent port
+                Some(proxy_agent_shared::constants::WIRE_SERVER_IP.to_string()), // HTTP IP
+                Some(proxy_agent_shared::constants::WIRE_SERVER_PORT),           // HTTP port
                 None,
                 logger_key,
             )
@@ -468,10 +471,11 @@ fn backup_proxy_agent(setup_tool: &String) {
 /// Return true if the versions match, return false if the versions do not match or if not able to read the service status version at all.
 async fn check_version_in_proxy_agent_aggregate_status(
     proxy_agent_file_version_in_extension: &str,
-    proxy_agent_port: Option<u16>,
+    http_ip: Option<String>,
+    http_port: Option<u16>,
     status_file_path: Option<PathBuf>,
 ) -> bool {
-    match get_proxy_agent_aggregate_status(proxy_agent_port, status_file_path).await {
+    match get_proxy_agent_aggregate_status(http_ip, http_port, status_file_path).await {
         Ok((aggregate_status, _)) => {
             let running_version = &aggregate_status.proxyAgentStatus.version;
             if running_version != proxy_agent_file_version_in_extension {
@@ -495,10 +499,11 @@ async fn check_version_in_proxy_agent_aggregate_status(
 }
 
 /// Get the proxy agent aggregate status from a specific port or file.
-/// If a port is provided, it will attempt to fetch the status from that port first and then specified status file.
-/// If no port is provided, it will attempt to read the status from the specified file directly.
+/// If ip and port are provided, it will attempt to fetch the status from that port first and then specified status file.
+/// or, it will attempt to read the status from the specified file directly.
 async fn get_proxy_agent_aggregate_status(
-    proxy_agent_port: Option<u16>,
+    http_ip: Option<String>,
+    http_port: Option<u16>,
     status_file_path: Option<PathBuf>,
 ) -> Result<
     (
@@ -513,21 +518,20 @@ async fn get_proxy_agent_aggregate_status(
             .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME),
     };
 
-    match proxy_agent_port {
-        Some(port) => {
-            proxy_agent_aggregate_status::get_proxy_agent_aggregate_status(
-                proxy_agent_shared::constants::PROXY_AGENT_IP,
-                port,
-                &aggregate_status_file_path,
-            )
-            .await
-        }
-        None => Ok((
+    if let (Some(http_ip), Some(http_port)) = (http_ip, http_port) {
+        proxy_agent_aggregate_status::get_proxy_agent_aggregate_status(
+            &http_ip,
+            http_port,
+            &aggregate_status_file_path,
+        )
+        .await
+    } else {
+        Ok((
             misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
                 &aggregate_status_file_path,
             )?,
             GuestProxyAgentAggregateStatusSource::FILE,
-        )),
+        ))
     }
 }
 
@@ -538,8 +542,13 @@ async fn report_proxy_agent_aggregate_status(
     service_state: &mut ServiceState,
 ) {
     let proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus;
+    // Attempt to get the proxy agent aggregate status from the GPA Proxy Server.
+    // If the GPA Proxy Server is not available, fall back to reading the status from the file.
+    // We used the WS IP and Port to let this http reqeust go through eBPF and redirectd to GPA proxy server,
+    // It utilizes the existing GPA claims as authorization signal
     match get_proxy_agent_aggregate_status(
-        Some(proxy_agent_shared::constants::PROXY_AGENT_PORT),
+        Some(proxy_agent_shared::constants::WIRE_SERVER_IP.to_string()),
+        Some(proxy_agent_shared::constants::WIRE_SERVER_PORT),
         None,
     )
     .await
@@ -1598,9 +1607,15 @@ mod tests {
         let version_30 = "1.0.30";
 
         // Matching versions should return VersionMismatch
-        let result =
-            super::determine_update_action(version_39, version_30, None, None, "test_logger_key")
-                .await;
+        let result = super::determine_update_action(
+            version_39,
+            version_30,
+            None,
+            None,
+            None,
+            "test_logger_key",
+        )
+        .await;
         assert_eq!(
             result,
             Some(super::UpdateAction::VersionMismatch),
@@ -1611,6 +1626,7 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None,
             None, // do not query from gpa server
             Some(PathBuf::from("nonexistent_path")),
             "test_logger_key",
@@ -1630,6 +1646,7 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None,
             None, // do not query from gpa server
             Some(status_file.clone()),
             "test_logger_key",
@@ -1649,6 +1666,7 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None,
             None, // do not query from gpa server
             Some(status_file.clone()),
             "test_logger_key",

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -544,7 +544,7 @@ async fn report_proxy_agent_aggregate_status(
     let proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus;
     // Attempt to get the proxy agent aggregate status from the GPA Proxy Server.
     // If the GPA Proxy Server is not available, fall back to reading the status from the file.
-    // We used the WS IP and Port to let this http reqeust go through eBPF and redirectd to GPA proxy server,
+    // We used the WS IP and Port to let this http request go through eBPF and redirect to GPA proxy server,
     // It utilizes the existing GPA claims as authorization signal
     match get_proxy_agent_aggregate_status(
         Some(proxy_agent_shared::constants::WIRE_SERVER_IP.to_string()),

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -7,7 +7,8 @@ use crate::structs::*;
 use proxy_agent_shared::current_info;
 use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::proxy_agent_aggregate_status::{
-    self, GuestProxyAgentAggregateStatus, ProxyConnectionSummary,
+    self, GuestProxyAgentAggregateStatus, GuestProxyAgentAggregateStatusSource,
+    ProxyConnectionSummary,
 };
 use proxy_agent_shared::telemetry::event_logger;
 use proxy_agent_shared::{misc_helpers, telemetry};
@@ -126,9 +127,10 @@ fn get_proxy_agent_service_file_version() -> String {
 }
 
 /// Determines what update action (if any) is needed for the proxy agent service.
-fn determine_update_action(
+async fn determine_update_action(
     proxy_agent_in_extension_version: &str,
     proxy_agent_service_version: &str,
+    proxy_agent_port: Option<u16>,
     status_file_path: Option<PathBuf>,
     logger_key: &str,
 ) -> Option<UpdateAction> {
@@ -145,10 +147,13 @@ fn determine_update_action(
             logger_key,
         );
         Some(UpdateAction::VersionMismatch)
-    } else if !check_version_in_proxy_agent_status_file(
+    } else if !check_version_in_proxy_agent_aggregate_status(
         proxy_agent_in_extension_version,
+        proxy_agent_port,
         status_file_path,
-    ) {
+    )
+    .await
+    {
         telemetry::event_logger::write_event(
             LoggerLevel::Info,
             format!(
@@ -242,9 +247,12 @@ async fn monitor_thread() {
             if let Some(action) = determine_update_action(
                 &proxy_agent_file_version_in_extension,
                 &proxy_agent_service_version,
+                Some(proxy_agent_shared::constants::PROXY_AGENT_PORT), // Proxy Agent port
                 None,
                 logger_key,
-            ) {
+            )
+            .await
+            {
                 if matches!(action, UpdateAction::VersionMismatch) {
                     backup_proxy_agent(&misc_helpers::path_to_string(
                         &common::setup_tool_exe_path(),
@@ -283,7 +291,8 @@ async fn monitor_thread() {
             &mut status,
             &mut status_state_obj,
             &mut service_state,
-        );
+        )
+        .await;
 
         // Step 4: Restore (on error) or purge (on success) the backed-up proxy agent, once
         if !restored_in_error {
@@ -457,19 +466,13 @@ fn backup_proxy_agent(setup_tool: &String) {
 /// Checks if the proxy agent service is running a different version than the files present in the extension,
 /// This can happen when a VM is force-restarted during a proxy agent service update, causing the new service to not start properly.
 /// Return true if the versions match, return false if the versions do not match or if not able to read the service status version at all.
-fn check_version_in_proxy_agent_status_file(
+async fn check_version_in_proxy_agent_aggregate_status(
     proxy_agent_file_version_in_extension: &str,
+    proxy_agent_port: Option<u16>,
     status_file_path: Option<PathBuf>,
 ) -> bool {
-    let aggregate_status_file_path = match status_file_path {
-        Some(path) => path,
-        None => proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
-            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME),
-    };
-    match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
-        &aggregate_status_file_path,
-    ) {
-        Ok(aggregate_status) => {
+    match get_proxy_agent_aggregate_status(proxy_agent_port, status_file_path).await {
+        Ok((aggregate_status, _)) => {
             let running_version = &aggregate_status.proxyAgentStatus.version;
             if running_version != proxy_agent_file_version_in_extension {
                 logger::write(format!(
@@ -481,41 +484,81 @@ fn check_version_in_proxy_agent_status_file(
             }
         }
         Err(e) => {
-            // Cannot read aggregate status — service may not be running at all.
+            // Cannot get aggregate status — service may not be running at all.
             // Treat this as an incomplete update so install is retried.
             logger::write(format!(
-                "Cannot read aggregate status file to verify running version: {e}.",
+                "Cannot get aggregate status to verify running version: {e}.",
             ));
             false
         }
     }
 }
 
-fn report_proxy_agent_aggregate_status(
+/// Get the proxy agent aggregate status from a specific port or file.
+/// If a port is provided, it will attempt to fetch the status from that port first and then specified status file.
+/// If no port is provided, it will attempt to read the status from the specified file directly.
+async fn get_proxy_agent_aggregate_status(
+    proxy_agent_port: Option<u16>,
+    status_file_path: Option<PathBuf>,
+) -> Result<
+    (
+        GuestProxyAgentAggregateStatus,
+        GuestProxyAgentAggregateStatusSource,
+    ),
+    proxy_agent_shared::error::Error,
+> {
+    let aggregate_status_file_path = match status_file_path {
+        Some(path) => path,
+        None => proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
+            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME),
+    };
+
+    match proxy_agent_port {
+        Some(port) => {
+            proxy_agent_aggregate_status::get_proxy_agent_aggregate_status(
+                proxy_agent_shared::constants::PROXY_AGENT_IP,
+                port,
+                &aggregate_status_file_path,
+            )
+            .await
+        }
+        None => Ok((
+            misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
+                &aggregate_status_file_path,
+            )?,
+            GuestProxyAgentAggregateStatusSource::FILE,
+        )),
+    }
+}
+
+async fn report_proxy_agent_aggregate_status(
     proxy_agent_file_version_in_extension: &String,
     status: &mut StatusObj,
     status_state_obj: &mut common::StatusState,
     service_state: &mut ServiceState,
 ) {
-    let aggregate_status_file_path =
-        proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder()
-            .join(proxy_agent_aggregate_status::PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME);
-
     let proxy_agent_aggregate_status_top_level: GuestProxyAgentAggregateStatus;
-    match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(
-        &aggregate_status_file_path,
-    ) {
-        Ok(ok) => {
+    match get_proxy_agent_aggregate_status(
+        Some(proxy_agent_shared::constants::PROXY_AGENT_PORT),
+        None,
+    )
+    .await
+    {
+        Ok((proxy_agent_aggregate_status, source)) => {
             write_state_event(
-                constants::STATE_KEY_READ_PROXY_AGENT_STATUS_FILE,
-                constants::SUCCESS_STATUS,
-                "Successfully read proxy agent aggregate status file".to_string(),
+                constants::STATE_KEY_READ_PROXY_AGENT_AGGREGATE_STATUS,
+                &format!(
+                    "{success}|{source:?}",
+                    success = constants::SUCCESS_STATUS,
+                    source = source
+                ),
+                format!("Successfully get proxy agent aggregate status from {source:?}"),
                 "report_proxy_agent_aggregate_status",
                 "service_main",
                 &logger::get_logger_key(),
                 service_state,
             );
-            proxy_agent_aggregate_status_top_level = ok;
+            proxy_agent_aggregate_status_top_level = proxy_agent_aggregate_status;
             extension_substatus(
                 proxy_agent_aggregate_status_top_level,
                 proxy_agent_file_version_in_extension,
@@ -525,9 +568,9 @@ fn report_proxy_agent_aggregate_status(
             );
         }
         Err(e) => {
-            let error_message = format!("Error in reading proxy agent aggregate status file: {e}");
+            let error_message = format!("{e}");
             write_state_event(
-                constants::STATE_KEY_READ_PROXY_AGENT_STATUS_FILE,
+                constants::STATE_KEY_READ_PROXY_AGENT_AGGREGATE_STATUS,
                 constants::ERROR_STATUS,
                 error_message.to_string(),
                 "report_proxy_agent_aggregate_status",
@@ -1541,8 +1584,8 @@ mod tests {
         assert_eq!(status.status, constants::TRANSITIONING_STATUS.to_string());
     }
 
-    #[test]
-    fn test_determine_update_action() {
+    #[tokio::test]
+    async fn test_determine_update_action() {
         use std::env;
         use std::fs;
 
@@ -1556,7 +1599,8 @@ mod tests {
 
         // Matching versions should return VersionMismatch
         let result =
-            super::determine_update_action(version_39, version_30, None, "test_logger_key");
+            super::determine_update_action(version_39, version_30, None, None, "test_logger_key")
+                .await;
         assert_eq!(
             result,
             Some(super::UpdateAction::VersionMismatch),
@@ -1567,9 +1611,11 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None, // do not query from gpa server
             Some(PathBuf::from("nonexistent_path")),
             "test_logger_key",
-        );
+        )
+        .await;
         assert_eq!(
             result,
             Some(super::UpdateAction::ResumeInterruptedUpdate),
@@ -1584,9 +1630,11 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None, // do not query from gpa server
             Some(status_file.clone()),
             "test_logger_key",
-        );
+        )
+        .await;
         assert_eq!(
             result,
             Some(super::UpdateAction::ResumeInterruptedUpdate),
@@ -1601,9 +1649,11 @@ mod tests {
         let result = super::determine_update_action(
             version_39,
             version_39,
+            None, // do not query from gpa server
             Some(status_file.clone()),
             "test_logger_key",
-        );
+        )
+        .await;
         assert_eq!(
             result, None,
             "Expected None when status file exists and version matches"

--- a/proxy_agent_shared/src/constants.rs
+++ b/proxy_agent_shared/src/constants.rs
@@ -21,3 +21,9 @@ pub const PROXY_AGENT_SERVICE_DISPLAY_NAME: &str = "Microsoft Azure Guest Proxy 
 
 pub const PROXY_AGENT_IP: &str = "127.0.0.1";
 pub const PROXY_AGENT_PORT: u16 = 3080;
+pub const WIRE_SERVER_IP: &str = "168.63.129.16";
+pub const WIRE_SERVER_PORT: u16 = 80u16;
+pub const GA_PLUGIN_IP: &str = "168.63.129.16";
+pub const GA_PLUGIN_PORT: u16 = 32526u16;
+pub const IMDS_IP: &str = "169.254.169.254";
+pub const IMDS_PORT: u16 = 80u16;

--- a/proxy_agent_shared/src/constants.rs
+++ b/proxy_agent_shared/src/constants.rs
@@ -18,3 +18,6 @@ pub const PROXY_AGENT_SERVICE_NAME: &str = "azure-proxy-agent";
 
 /// Human-readable display name for the proxy agent service.
 pub const PROXY_AGENT_SERVICE_DISPLAY_NAME: &str = "Microsoft Azure Guest Proxy Agent";
+
+pub const PROXY_AGENT_IP: &str = "127.0.0.1";
+pub const PROXY_AGENT_PORT: u16 = 3080;

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -57,7 +57,9 @@ pub enum Error {
     #[error("Parse datetime string error: {0}")]
     ParseDateTimeStringError(String),
 
-    #[error("Failed to get proxy agent aggregate status:\r\n Server error: {0}\r\n Status file error: {1}")]
+    #[error(
+        "Failed to get proxy agent aggregate status:\n Server error: {0}\n Status file error: {1}"
+    )]
     GetProxyAgentAggregateStatus(String, String),
 }
 

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     ParseDateTimeStringError(String),
 
     #[error(
-        "Failed to get proxy agent aggregate status:\n Server error: {0}\n Status file error: {1}"
+        "Failed to get proxy agent aggregate status (server error: {0}; status file error: {1})"
     )]
     GetProxyAgentAggregateStatus(String, String),
 }

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -56,6 +56,9 @@ pub enum Error {
 
     #[error("Parse datetime string error: {0}")]
     ParseDateTimeStringError(String),
+
+    #[error("Failed to get proxy agent aggregate status:\r\n Server error: {0}\r\n Status file error: {1}")]
+    GetProxyAgentAggregateStatus(String, String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
-use crate::{misc_helpers, time_buckets::Countable};
+use crate::{logger::logger_manager, misc_helpers, time_buckets::Countable};
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 use time::OffsetDateTime;
 
 #[cfg(windows)]
@@ -10,6 +13,9 @@ const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "%SYSTEMDRIVE%\\WindowsAzure\\
 #[cfg(not(windows))]
 const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "/var/log/azure-proxy-agent/";
 pub const PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME: &str = "status.json";
+
+/// The URL path for the proxy agent status endpoint.
+pub const STATUS_URL_PATH: &str = "/status";
 
 pub fn get_proxy_agent_aggregate_status_folder() -> std::path::PathBuf {
     let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER);
@@ -98,5 +104,98 @@ pub struct GuestProxyAgentAggregateStatus {
 impl GuestProxyAgentAggregateStatus {
     pub fn get_status_timestamp(&self) -> crate::result::Result<OffsetDateTime> {
         misc_helpers::parse_date_time_string(&self.timestamp)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum GuestProxyAgentAggregateStatusSource {
+    SERVER,
+    FILE,
+}
+
+pub use crate::result::Result;
+
+/// Get the proxy agent aggregate status from a specific port or file.
+/// It attempts to fetch the status from proxy agent server first and then specified status file.
+///
+/// This helps remove the local disk write-permission dependency
+/// when communicating the aggregate status between Proxy Agent service and the extension.
+pub async fn get_proxy_agent_aggregate_status(
+    proxy_agent_server_ip: &str,
+    proxy_agent_server_port: u16,
+    status_file_path: &Path,
+) -> Result<(
+    GuestProxyAgentAggregateStatus,
+    GuestProxyAgentAggregateStatusSource,
+)> {
+    let server_error = match get_proxy_agent_aggregate_status_from_server(
+        proxy_agent_server_ip,
+        proxy_agent_server_port,
+    )
+    .await
+    {
+        Ok(status) => return Ok((status, GuestProxyAgentAggregateStatusSource::SERVER)),
+        Err(e) => e,
+    };
+
+    // If the HTTP request fails, fall back to reading the status from the file.
+    match misc_helpers::json_read_from_file::<GuestProxyAgentAggregateStatus>(status_file_path) {
+        Ok(status) => Ok((status, GuestProxyAgentAggregateStatusSource::FILE)),
+        Err(e) => Err(crate::error::Error::GetProxyAgentAggregateStatus(
+            server_error.to_string(),
+            e.to_string(),
+        )),
+    }
+}
+
+/// Get the proxy agent aggregate status from the proxy agent server.
+pub async fn get_proxy_agent_aggregate_status_from_server(
+    proxy_agent_server_ip: &str,
+    proxy_agent_server_port: u16,
+) -> Result<GuestProxyAgentAggregateStatus> {
+    use crate::hyper_client;
+
+    let endpoint = hyper_client::HostEndpoint::new(
+        proxy_agent_server_ip,
+        proxy_agent_server_port,
+        STATUS_URL_PATH,
+    );
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        hyper_client::METADATA_HEADER.to_string(),
+        "true".to_string(),
+    );
+    hyper_client::get(&endpoint, &headers, None, None, logger_manager::write_warn).await
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[tokio::test]
+    async fn test_get_proxy_agent_aggregate_status_from_server_with_mock_server() {
+        use crate::server_mock;
+        use tokio_util::sync::CancellationToken;
+
+        let ip = "127.0.0.1";
+        let port = 9074u16;
+        let cancellation_token = CancellationToken::new();
+
+        let port = server_mock::start(ip.to_string(), port, cancellation_token.clone())
+            .await
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let status = super::get_proxy_agent_aggregate_status_from_server(&ip, port)
+            .await
+            .unwrap();
+        assert!(!status.proxyAgentStatus.version.is_empty());
+        assert!(status.proxyConnectionSummary.is_empty());
+        assert!(status.failedAuthenticateSummary.is_empty());
+        assert!(status.proxyAgentStatus.proxyConnectionsCount == 0);
+        assert!(status.proxyAgentStatus.status == super::OverallState::SUCCESS);
+        assert!(status.proxyAgentStatus.version == "1.0");
+
+        cancellation_token.cancel();
     }
 }

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -14,8 +14,8 @@ const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "%SYSTEMDRIVE%\\WindowsAzure\\
 const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "/var/log/azure-proxy-agent/";
 pub const PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME: &str = "status.json";
 
-/// The URL path for the proxy agent status endpoint.
-pub const STATUS_URL_PATH: &str = "/status";
+/// The URL path for the proxy agent aggregated status endpoint.
+pub const STATUS_URL_PATH: &str = "/gpa-aggregated-status";
 
 pub fn get_proxy_agent_aggregate_status_folder() -> std::path::PathBuf {
     let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER);

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+use crate::result::Result;
 use crate::{logger::logger_manager, misc_helpers, time_buckets::Countable};
 use serde_derive::{Deserialize, Serialize};
 use std::{
@@ -113,26 +114,20 @@ pub enum GuestProxyAgentAggregateStatusSource {
     FILE,
 }
 
-pub use crate::result::Result;
-
 /// Get the proxy agent aggregate status from a specific port or file.
 /// It attempts to fetch the status from proxy agent server first and then specified status file.
 ///
 /// This helps remove the local disk write-permission dependency
 /// when communicating the aggregate status between Proxy Agent service and the extension.
 pub async fn get_proxy_agent_aggregate_status(
-    proxy_agent_server_ip: &str,
-    proxy_agent_server_port: u16,
+    http_ip: &str,
+    http_port: u16,
     status_file_path: &Path,
 ) -> Result<(
     GuestProxyAgentAggregateStatus,
     GuestProxyAgentAggregateStatusSource,
 )> {
-    let server_error = match get_proxy_agent_aggregate_status_from_server(
-        proxy_agent_server_ip,
-        proxy_agent_server_port,
-    )
-    .await
+    let server_error = match get_proxy_agent_aggregate_status_from_server(http_ip, http_port).await
     {
         Ok(status) => return Ok((status, GuestProxyAgentAggregateStatusSource::SERVER)),
         Err(e) => e,

--- a/proxy_agent_shared/src/server_mock.rs
+++ b/proxy_agent_shared/src/server_mock.rs
@@ -3,6 +3,7 @@
 
 use crate::hyper_client;
 use crate::logger::logger_manager;
+use crate::proxy_agent_aggregate_status;
 use crate::result::Result;
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
@@ -110,6 +111,41 @@ async fn handle_request(
                 let state = unsafe { (*CURRENT_STATE).to_string() };
                 body_string = status_response.replace("$$secureChannelState$$", &state);
             }
+        } else if !segments.is_empty()
+            && segments[0] == proxy_agent_aggregate_status::STATUS_URL_PATH.trim_start_matches('/')
+        {
+            // get proxy agent aggregate status
+            let status_response = r#"{
+                "timestamp": "2023-01-01T00:00:00Z",
+                "proxyAgentStatus": {
+                    "version": "1.0",
+                    "status": "SUCCESS",
+                    "monitorStatus": {
+                        "status": "RUNNING",
+                        "message": "Monitor is running"
+                    },
+                    "keyLatchStatus": {
+                        "status": "RUNNING",
+                        "message": "Key latch is running"
+                    },
+                    "ebpfProgramStatus": {
+                        "status": "RUNNING",
+                        "message": "eBPF program is running"
+                    },
+                    "proxyListenerStatus": {
+                        "status": "RUNNING",
+                        "message": "Proxy listener is running"
+                    },
+                    "telemetryLoggerStatus": {
+                        "status": "RUNNING",
+                        "message": "Telemetry logger is running"
+                    },
+                    "proxyConnectionsCount": 0
+                },
+                "proxyConnectionSummary": [],
+                "failedAuthenticateSummary": []
+            }"#;
+            body_string = status_response.to_string();
         } else if !segments.is_empty() && segments[0] == "machine?comp=goalstate" {
             let goal_state_str = r#"<?xml version="1.0" encoding="utf-8"?>
             <GoalState xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="goalstate10.xsd">


### PR DESCRIPTION
- Currently GPA service passes its aggregated status to GPA VM Extension via status.json file, if the status folder is ready-only for whatever reason, GPA VM Extension will not be able to get the latest aggregated status.
- GPA http server starts to accept `/gpa-aggregated-status` and return current aggregated status in json as response.
- GPA VM Extension first try query the GPA server for aggregated status, if not available, fallback to read the status.json file. 
- Update max_binary_bytes for ProxyAgentExt as it starts to static link hyper client.