### PR TITLE
Optimize telemetry event flow to by-pass local disk dependency

### DIFF
--- a/doc/TelemetryEventFlow.md
+++ b/doc/TelemetryEventFlow.md
@@ -32,14 +32,19 @@ File: `proxy_agent_shared/src/telemetry/event_logger.rs`
 - `write_event` / `write_event_only` **always** push the event into a bounded
   in-memory `EVENT_QUEUE` (capacity 1000). Messages are truncated to 4 KB
   (`MAX_MESSAGE_LENGTH`).
-- A background loop in `event_logger::start` wakes **every 60 seconds** and
-  drains `EVENT_QUEUE`. When a `DirectSendConfig` is provided, each event is
-  first attempted on the **direct in-memory send path**
-  (`event_sender::try_enqueue_generic_event`), which converts it and pushes it
-  straight into the `EventSender`'s `TELEMETRY_EVENT_QUEUE`. If at least one
-  event was enqueued directly, the loop calls
-  `common_state.notify_telemetry_event()` to wake the sender. Only events that
-  cannot be enqueued directly fall back to disk.
+- A background loop in `event_logger::run_event_loop` wakes **every 60 seconds**
+  and drains `EVENT_QUEUE`. The loop is started through one of two entry points:
+  - `event_logger::start_with_direct_send` (proxy agent service): each event is
+    first attempted on the **direct in-memory send path**
+    (`event_sender::try_enqueue_generic_event`), which converts it and pushes it
+    straight into the `EventSender`'s `TELEMETRY_EVENT_QUEUE`. If at least one
+    event was enqueued directly, the loop calls
+    `common_state.notify_telemetry_event()` to wake the sender. Only events that
+    cannot be enqueued directly fall back to disk.
+  - `event_logger::start` (disk-only, e.g. the extension): the loop buffers
+    every event on disk and never references the direct send path. Keeping the
+    direct-send code out of this entry point lets dead-code elimination drop the
+    `event_sender` machinery from binaries that only buffer to disk.
 - `report_extension_status_event` (async) tries the direct path first via
   `event_sender::try_enqueue_extension_event` and, on success, notifies the
   sender and returns; otherwise it falls back to disk.
@@ -49,9 +54,9 @@ File: `proxy_agent_shared/src/telemetry/event_logger.rs`
 - `DirectSendConfig` is defined in `event_logger.rs` and carries the
   `execution_mode`, `event_name`, optional `version`, and a `CommonState`
   handle (used to notify the sender).
-- It is passed into `event_logger::start(..., direct_send_config, ...)` by the
-  proxy agent service (see [provision.rs](../proxy_agent/src/provision.rs)) and
-  also cached in a static `DIRECT_SEND_CONFIG` so
+- It is passed into `event_logger::start_with_direct_send(..., direct_send_config, ...)`
+  by the proxy agent service (see [provision.rs](../proxy_agent/src/provision.rs))
+  and also cached in a static `DIRECT_SEND_CONFIG` so
   `report_extension_status_event` can use it.
 - The `execution_mode` / `event_name` / `version` match the `EventReader`
   configuration so events are shaped identically regardless of which path they
@@ -59,13 +64,14 @@ File: `proxy_agent_shared/src/telemetry/event_logger.rs`
 
 ## Stage 2 — Disk buffer (fallback only)
 
-- The on-disk buffer is now a **fallback**, used only when no `DirectSendConfig`
-  is set or the in-memory send queue (`TELEMETRY_EVENT_QUEUE`) is full/closed.
-  This lets VMs without disk write permission still report telemetry over the
-  direct path.
-- Processes that pass a `DirectSendConfig` (the proxy agent service) send most
-  events directly. Processes that do not (e.g. the extension, which calls
-  `event_logger::start` with `None`) keep the original disk-only behavior.
+- The on-disk buffer is now a **fallback**, used only when the logger is started
+  without a `DirectSendConfig` (via `event_logger::start`) or the in-memory send
+  queue (`TELEMETRY_EVENT_QUEUE`) is full/closed. This lets VMs without disk
+  write permission still report telemetry over the direct path.
+- Processes that pass a `DirectSendConfig` (the proxy agent service, via
+  `event_logger::start_with_direct_send`) send most events directly. Processes
+  that do not (e.g. the extension, which calls the disk-only `event_logger::start`)
+  keep the original disk-only behavior.
 - Two file types act as the durable fallback buffer:
   - Generic logs: `^[0-9]+\.json$` → `TelemetryGenericLogsEvent`
   - Extension status: `^extension_[0-9]+\.json$` → `TelemetryExtensionEventsEvent`

--- a/doc/TelemetryEventFlow.md
+++ b/doc/TelemetryEventFlow.md
@@ -1,0 +1,150 @@
+# Telemetry Event Flow
+
+This document describes how telemetry events are produced, buffered, read, and
+sent out of the VM by the GuestProxyAgent.
+
+The telemetry system lives in `proxy_agent_shared/src/telemetry/` and is a
+**producer → disk buffer → reader → queue → wire-server** pipeline composed of
+four cooperating async tasks. All four are spawned in
+[provision.rs](../proxy_agent/src/provision.rs).
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    A["Code calls write_event / report_extension_status_event"] --> B["event_logger<br/>in-memory EVENT_QUEUE"]
+    B -->|"60s loop / async: try_enqueue (direct)"| D["TELEMETRY_EVENT_QUEUE"]
+    B -.->|"fallback when direct send fails / no config"| C["Events dir<br/>N.json / extension_N.json"]
+    C -->|"EventReader.process_once (300s)"| D
+    C -->|"EventReader.process_extension_status_events (60s)"| D
+    B -->|"common_state.notify_telemetry_event()"| E["EventSender"]
+    D --> E
+    E -->|"batch to XML, <64KB"| F["WireServerClient<br/>POST 168.63.129.16:80<br/>/machine/?comp=telemetrydata"]
+    F --> G["Azure Host / Kusto"]
+```
+
+## Stage 1 — Production (in-memory)
+
+File: `proxy_agent_shared/src/telemetry/event_logger.rs`
+
+- Application code calls `write_event` / `write_event_only` (generic logs) or
+  `report_extension_status_event` (extension status).
+- `write_event` / `write_event_only` **always** push the event into a bounded
+  in-memory `EVENT_QUEUE` (capacity 1000). Messages are truncated to 4 KB
+  (`MAX_MESSAGE_LENGTH`).
+- A background loop in `event_logger::start` wakes **every 60 seconds** and
+  drains `EVENT_QUEUE`. When a `DirectSendConfig` is provided, each event is
+  first attempted on the **direct in-memory send path**
+  (`event_sender::try_enqueue_generic_event`), which converts it and pushes it
+  straight into the `EventSender`'s `TELEMETRY_EVENT_QUEUE`. If at least one
+  event was enqueued directly, the loop calls
+  `common_state.notify_telemetry_event()` to wake the sender. Only events that
+  cannot be enqueued directly fall back to disk.
+- `report_extension_status_event` (async) tries the direct path first via
+  `event_sender::try_enqueue_extension_event` and, on success, notifies the
+  sender and returns; otherwise it falls back to disk.
+
+### DirectSendConfig
+
+- `DirectSendConfig` is defined in `event_logger.rs` and carries the
+  `execution_mode`, `event_name`, optional `version`, and a `CommonState`
+  handle (used to notify the sender).
+- It is passed into `event_logger::start(..., direct_send_config, ...)` by the
+  proxy agent service (see [provision.rs](../proxy_agent/src/provision.rs)) and
+  also cached in a static `DIRECT_SEND_CONFIG` so
+  `report_extension_status_event` can use it.
+- The `execution_mode` / `event_name` / `version` match the `EventReader`
+  configuration so events are shaped identically regardless of which path they
+  take.
+
+## Stage 2 — Disk buffer (fallback only)
+
+- The on-disk buffer is now a **fallback**, used only when no `DirectSendConfig`
+  is set or the in-memory send queue (`TELEMETRY_EVENT_QUEUE`) is full/closed.
+  This lets VMs without disk write permission still report telemetry over the
+  direct path.
+- Processes that pass a `DirectSendConfig` (the proxy agent service) send most
+  events directly. Processes that do not (e.g. the extension, which calls
+  `event_logger::start` with `None`) keep the original disk-only behavior.
+- Two file types act as the durable fallback buffer:
+  - Generic logs: `^[0-9]+\.json$` → `TelemetryGenericLogsEvent`
+  - Extension status: `^extension_[0-9]+\.json$` → `TelemetryExtensionEventsEvent`
+- If the direct send succeeds, the disk is never touched. If it falls back, the
+  file-count cap (`max_event_file_count` for generic,
+  `MAX_EXTENSION_EVENT_FILE_COUNT` for extension) still applies as backpressure.
+
+## Stage 3 — Reading & enqueueing
+
+File: `proxy_agent_shared/src/telemetry/event_reader.rs`
+
+Two independent reader loops:
+
+- `start` → `process_once` runs **every 300s**: reads generic `*.json` files,
+  converts each to a `TelemetryEvent::GenericLogsEvent`, enqueues into
+  `TELEMETRY_EVENT_QUEUE`, then **deletes the file**.
+- `start_extension_status_event_processor` → `process_extension_status_events`
+  runs **every 60s**: same for `extension_*.json` →
+  `TelemetryEvent::ExtensionEvent`.
+- Optional `EventReaderLimits` enforce max events/round and max file size;
+  oversized files are deleted to avoid blocking.
+- After enqueueing, each calls `common_state.notify_telemetry_event()` to wake
+  the sender.
+
+## Stage 4 — Sending out of the VM
+
+File: `proxy_agent_shared/src/telemetry/event_sender.rs`
+
+- `EventSender::start` waits on a `notify` (or cancellation). The notify is
+  signaled both by `event_logger` (direct path) and by the `EventReader` (disk
+  path) via `common_state.notify_telemetry_event()`. On notify it calls
+  `process_event_queue`:
+  1. Refreshes VM metadata via `WireServerClient` + `ImdsClient`.
+  2. Builds `TelemetryEventVMData` (tenant, role, subscription, VM id, OS, RAM,
+     CPU…).
+  3. `send_events` batches queued events into `TelemetryData`, capping each
+     payload at **64 KB** (`MAX_MESSAGE_SIZE`); oversized single events are
+     dropped, otherwise re-enqueued.
+  4. Serializes to the Azure telemetry XML format
+     (`telemetry_event.rs`) with provider IDs:
+     - Generic logs: `FFF0196F-EE4C-4EAF-9AA5-776F622DEB4F`
+     - Extension status: `69B669B9-4AF8-4C50-BDC4-6006FA76E975`
+
+## The actual exit point
+
+File: `proxy_agent_shared/src/host_clients/wire_server_client.rs`
+
+- `send_telemetry_data` POSTs the XML to the **Azure WireServer at
+  `168.63.129.16:80`**, path `/machine/?comp=telemetrydata`, headers
+  `x-ms-version: 2012-11-30` and `Content-Type: text/xml`.
+- The sender retries up to **5 times with 15s backoff** on failure. This is the
+  single egress path; from there the Azure host platform forwards events to its
+  telemetry backend.
+
+## Key design points
+
+- **Durability:** events survive on disk between produce and send; only deleted
+  after being enqueued for sending.
+- **Backpressure at every stage:** bounded in-memory queues (1000), file-count
+  caps, message-size caps (4 KB per message, 64 KB per payload).
+- **Cancellation-aware:** all tasks listen to the shared `CancellationToken`;
+  the sender closes `TELEMETRY_EVENT_QUEUE` on shutdown.
+- **No signing required** for the telemetry POST (unlike other wire-server
+  calls).
+
+## Latency note
+
+With the direct in-memory path enabled (proxy agent service):
+
+- **Generic events** typically leave the VM within ~60 seconds (the
+  `event_logger` loop interval), since they are enqueued straight into the send
+  queue and the sender is notified.
+- **Extension status events** are enqueued and notified as soon as
+  `report_extension_status_event` runs.
+
+On the disk **fallback** path (or in processes without a `DirectSendConfig`,
+such as the extension):
+
+- **Generic events** take up to ~6 minutes worst-case to leave the VM
+  (60s flush + 300s read interval).
+- **Extension status events** take up to ~2 minutes (60s flush + 60s read
+  interval).

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -335,14 +335,22 @@ pub async fn start_event_threads(event_threads_shared_state: EventThreadsSharedS
     // those tasks starts to run after provision finished or provision timedout
     set_resource_limits();
 
-    let cloned_agent_status_shared_state =
-        event_threads_shared_state.agent_status_shared_state.clone();
     tokio::spawn({
-        async {
+        let cloned_agent_status_shared_state =
+            event_threads_shared_state.agent_status_shared_state.clone();
+        let direct_send_config = event_logger::DirectSendConfig::new(
+            "ProxyAgent".to_string(),
+            "MicrosoftAzureGuestProxyAgent".to_string(),
+            None,
+            event_threads_shared_state.common_state.clone(),
+        );
+
+        async move {
             event_logger::start(
                 config::get_events_dir(),
                 Duration::default(),
                 config::get_max_event_file_count(),
+                Some(direct_send_config),
                 move |status: String| {
                     let cloned_agent_status_shared_state = cloned_agent_status_shared_state.clone();
                     async move {

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -346,11 +346,11 @@ pub async fn start_event_threads(event_threads_shared_state: EventThreadsSharedS
         );
 
         async move {
-            event_logger::start(
+            event_logger::start_with_direct_send(
                 config::get_events_dir(),
                 Duration::default(),
                 config::get_max_event_file_count(),
-                Some(direct_send_config),
+                direct_send_config,
                 move |status: String| {
                     let cloned_agent_status_shared_state = cloned_agent_status_shared_state.clone();
                     async move {

--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -234,11 +234,17 @@ pub async fn start_event_logger() {
                 return;
             }
 
-            telemetry::event_logger::start(event_folder, interval, max_event_file_count, |_| {
-                async {
-                    // do nothing
-                }
-            })
+            telemetry::event_logger::start(
+                event_folder,
+                interval,
+                max_event_file_count,
+                None, // always write to extension telemetry events folder
+                |_| {
+                    async {
+                        // do nothing
+                    }
+                },
+            )
             .await;
         }
     });

--- a/proxy_agent_extension/src/common.rs
+++ b/proxy_agent_extension/src/common.rs
@@ -234,17 +234,11 @@ pub async fn start_event_logger() {
                 return;
             }
 
-            telemetry::event_logger::start(
-                event_folder,
-                interval,
-                max_event_file_count,
-                None, // always write to extension telemetry events folder
-                |_| {
-                    async {
-                        // do nothing
-                    }
-                },
-            )
+            telemetry::event_logger::start(event_folder, interval, max_event_file_count, |_| {
+                async {
+                    // do nothing
+                }
+            })
             .await;
         }
     });

--- a/proxy_agent_shared/src/common_state.rs
+++ b/proxy_agent_shared/src/common_state.rs
@@ -46,6 +46,7 @@ pub struct CommonState {
 impl CommonState {
     pub fn start_new(cancellation_token: CancellationToken) -> Self {
         let (sender, mut receiver) = mpsc::channel(100);
+        let cloned_cancellation_token = cancellation_token.clone();
         tokio::spawn(async move {
             let mut vm_meta_data: Option<VmMetaData> = None;
             let mut states: std::collections::HashMap<String, String> =
@@ -53,54 +54,62 @@ impl CommonState {
             let telemetry_event_notify = Arc::new(Notify::new());
 
             loop {
-                match receiver.recv().await {
-                    Some(CommonStateAction::SetVmMetaData {
-                        vm_meta_data: meta_data,
-                        response,
-                    }) => {
-                        vm_meta_data = meta_data.clone();
-                        if response.send(()).is_err() {
-                            logger_manager::write_warn(format!(
-                                "Failed to send response to CommonStateAction::SetVmMetaData '{meta_data:?}'"
-                            ));
-                        }
-                    }
-                    Some(CommonStateAction::GetVmMetaData { response }) => {
-                        if let Err(meta_data) = response.send(vm_meta_data.clone()) {
-                            logger_manager::write_warn(format!(
-                                "Failed to send response to CommonStateAction::GetVmMetaData '{meta_data:?}'"
-                            ));
-                        }
-                    }
-                    Some(CommonStateAction::SetState {
-                        key,
-                        value,
-                        response,
-                    }) => {
-                        states.insert(key.clone(), value.clone());
-                        if response.send(()).is_err() {
-                            logger_manager::write_warn(format!(
-                                "Failed to send response to CommonStateAction::SetState '{key}':'{value}'"
-                            ));
-                        }
-                    }
-                    Some(CommonStateAction::GetState { key, response }) => {
-                        let value = states.get(&key).cloned();
-                        if let Err(v) = response.send(value) {
-                            logger_manager::write_warn(format!(
-                                "Failed to send response to CommonStateAction::GetState '{key}':'{v:?}'"
-                            ));
-                        }
-                    }
-                    Some(CommonStateAction::GetTelemetryEventNotify { response }) => {
-                        if let Err(notify) = response.send(telemetry_event_notify.clone()) {
-                            logger_manager::write_warn(format!(
-                                "Failed to send response to CommonStateAction::GetTelemetryEventNotify '{notify:?}'"
-                            ));
-                        }
-                    }
-                    None => {
+                tokio::select! {
+                    // Cancel the task if the cancellation token is cancelled
+                    _ = cloned_cancellation_token.cancelled() => {
                         break;
+                    }
+                    msg = receiver.recv() => {
+                        match msg {
+                            Some(CommonStateAction::SetVmMetaData {
+                                vm_meta_data: meta_data,
+                                response,
+                            }) => {
+                                vm_meta_data = meta_data.clone();
+                                if response.send(()).is_err() {
+                                    logger_manager::write_warn(format!(
+                                        "Failed to send response to CommonStateAction::SetVmMetaData '{meta_data:?}'"
+                                    ));
+                                }
+                            }
+                            Some(CommonStateAction::GetVmMetaData { response }) => {
+                                if let Err(meta_data) = response.send(vm_meta_data.clone()) {
+                                    logger_manager::write_warn(format!(
+                                        "Failed to send response to CommonStateAction::GetVmMetaData '{meta_data:?}'"
+                                    ));
+                                }
+                            }
+                            Some(CommonStateAction::SetState {
+                                key,
+                                value,
+                                response,
+                            }) => {
+                                states.insert(key.clone(), value.clone());
+                                if response.send(()).is_err() {
+                                    logger_manager::write_warn(format!(
+                                        "Failed to send response to CommonStateAction::SetState '{key}':'{value}'"
+                                    ));
+                                }
+                            }
+                            Some(CommonStateAction::GetState { key, response }) => {
+                                let value = states.get(&key).cloned();
+                                if let Err(v) = response.send(value) {
+                                    logger_manager::write_warn(format!(
+                                        "Failed to send response to CommonStateAction::GetState '{key}':'{v:?}'"
+                                    ));
+                                }
+                            }
+                            Some(CommonStateAction::GetTelemetryEventNotify { response }) => {
+                                if let Err(notify) = response.send(telemetry_event_notify.clone()) {
+                                    logger_manager::write_warn(format!(
+                                        "Failed to send response to CommonStateAction::GetTelemetryEventNotify '{notify:?}'"
+                                    ));
+                                }
+                            }
+                            None => {
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/proxy_agent_shared/src/error.rs
+++ b/proxy_agent_shared/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
         "Failed to get proxy agent aggregate status (server error: {0}; status file error: {1})"
     )]
     GetProxyAgentAggregateStatus(String, String),
+
+    #[error("Failed to enqueue telemetry event with error: {0}")]
+    EnqueueEvent(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -47,37 +47,148 @@ impl DirectSendConfig {
     }
 }
 
+/// Start the telemetry event logger loop in disk-only mode.
+///
+/// Events are buffered to disk and later picked up by the event reader. This is
+/// used by callers (such as the extension) that do not have a direct in-memory
+/// telemetry path. It deliberately does not reference the `event_sender` direct
+/// path so that the direct-send machinery is not linked into binaries that only
+/// use this entry point.
 pub async fn start<F, Fut>(
     event_dir: PathBuf,
-    mut interval: Duration,
+    interval: Duration,
     max_event_file_count: usize,
-    direct_send_config: Option<DirectSendConfig>,
     set_status_fn: F,
 ) where
     F: Fn(String) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    // Disk-only mode: no events are sent directly, so every event falls through
+    // to be buffered on disk.
+    run_event_loop(
+        event_dir,
+        interval,
+        max_event_file_count,
+        set_status_fn,
+        |events| async move { events },
+    )
+    .await;
+}
+
+/// Start the telemetry event logger loop with a direct in-memory send path.
+///
+/// Events are first attempted to be sent directly via the in-memory telemetry
+/// queue (so VMs without disk write permission can still report telemetry).
+/// Any events that cannot be enqueued directly fall back to being buffered on
+/// disk.
+pub async fn start_with_direct_send<F, Fut>(
+    event_dir: PathBuf,
+    interval: Duration,
+    max_event_file_count: usize,
+    direct_send_config: DirectSendConfig,
+    set_status_fn: F,
+) where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    if DIRECT_SEND_CONFIG.set(direct_send_config.clone()).is_err() {
+        let message = "DirectSendConfig is already set, cannot set it again.";
+        logger_manager::write_warn(message.to_string());
+    }
+
+    run_event_loop(
+        event_dir,
+        interval,
+        max_event_file_count,
+        set_status_fn,
+        move |events| {
+            let config = direct_send_config.clone();
+            async move { try_direct_send_events(events, &config).await }
+        },
+    )
+    .await;
+}
+
+/// Try to send the drained events directly via the in-memory telemetry queue,
+/// returning the events that could not be enqueued directly (and therefore need
+/// to be buffered on disk).
+async fn try_direct_send_events(events: Vec<Event>, config: &DirectSendConfig) -> Vec<Event> {
+    try_direct_send_events_with(
+        events,
+        config,
+        crate::telemetry::event_sender::try_enqueue_generic_event,
+    )
+    .await
+}
+
+/// Implementation of [`try_direct_send_events`] with the enqueue operation
+/// injected, so the filtering / notify logic can be unit-tested without the
+/// global `event_sender` queue. `try_enqueue` returns `Ok` when the event was
+/// accepted by the direct path and `Err` when it must fall back to disk.
+async fn try_direct_send_events_with<E>(
+    events: Vec<Event>,
+    config: &DirectSendConfig,
+    try_enqueue: E,
+) -> Vec<Event>
+where
+    E: Fn(&Event, String, String, Option<String>) -> crate::result::Result<()>,
+{
+    let event_count = events.len();
+    let remaining_events: Vec<Event> = events
+        .into_iter()
+        .filter(|event| {
+            try_enqueue(
+                event,
+                config.execution_mode.clone(),
+                config.event_name.clone(),
+                config.version.clone(),
+            )
+            .is_err()
+        })
+        .collect();
+    if remaining_events.len() < event_count {
+        // some events were queued directly, notify the event_sender
+        if let Err(e) = config.common_state.notify_telemetry_event().await {
+            logger_manager::write_warn(format!(
+                "event_logger::try_direct_send_events: failed to notify telemetry event with error: {e}"
+            ));
+        };
+    }
+
+    // return the possible remaining events
+    remaining_events
+}
+
+/// Core event logger loop shared by the disk-only and direct-send entry points.
+///
+/// `direct_send` is given the events drained from the in-memory queue and
+/// returns the events that still need to be buffered on disk. For disk-only
+/// mode this is the identity function.
+async fn run_event_loop<F, Fut, S, SFut>(
+    event_dir: PathBuf,
+    mut interval: Duration,
+    max_event_file_count: usize,
+    set_status_fn: F,
+    direct_send: S,
+) where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+    S: Fn(Vec<Event>) -> SFut,
+    SFut: std::future::Future<Output = Vec<Event>>,
+{
     let message = "Telemetry event logger thread started.";
-    set_status_fn(message.to_string());
+    set_status_fn(message.to_string()).await;
 
     logger_manager::write_log(Level::Info, message.to_string());
 
     if let Err(e) = misc_helpers::try_create_folder(&event_dir) {
         let message = format!("Failed to create event folder with error: {e}");
-        set_status_fn(message.to_string());
+        logger_manager::write_warn(message.to_string());
     }
 
     if EVENTS_DIR.set(event_dir.clone()).is_err() {
         let message = "Event directory is already set, cannot set it again.";
-        set_status_fn(message.to_string());
-        logger_manager::write_log(Level::Warn, message.to_string());
-    }
-    if let Some(config) = direct_send_config.clone() {
-        if DIRECT_SEND_CONFIG.set(config).is_err() {
-            let message = "DirectSendConfig is already set, cannot set it again.";
-            set_status_fn(message.to_string());
-            logger_manager::write_log(Level::Warn, message.to_string());
-        }
+        logger_manager::write_warn(message.to_string());
     }
 
     let shutdown = SHUT_DOWN.clone();
@@ -87,7 +198,6 @@ pub async fn start<F, Fut>(
     loop {
         if EVENT_QUEUE.is_closed() {
             let message = "Event queue already closed, stop processing events.";
-            set_status_fn(message.to_string());
             logger_manager::write_log(Level::Info, message.to_string());
             break;
         }
@@ -95,7 +205,7 @@ pub async fn start<F, Fut>(
 
         if shutdown.load(Ordering::Relaxed) {
             let message = "Stop signal received, exiting the event logger thread.";
-            set_status_fn(message.to_string());
+            set_status_fn(message.to_string()).await;
 
             logger_manager::write_log(Level::Info, message.to_string());
             EVENT_QUEUE.close();
@@ -112,40 +222,9 @@ pub async fn start<F, Fut>(
             events.push(event);
         }
 
-        // Try to send the events directly via the in-memory telemetry queue
-        // first, so VMs without disk write permission can still report
-        // telemetry. Any events that cannot be enqueued directly (the direct
-        // path is None or the queue is full/closed) fall back to being
-        // buffered on disk below.
-        let events: Vec<Event> = match &direct_send_config {
-            Some(config) => {
-                let event_count = events.len();
-                let remaining_events: Vec<Event> = events
-                    .into_iter()
-                    .filter(|event| {
-                        crate::telemetry::event_sender::try_enqueue_generic_event(
-                            event,
-                            config.execution_mode.clone(),
-                            config.event_name.clone(),
-                            config.version.clone(),
-                        )
-                        .is_err()
-                    })
-                    .collect();
-                if remaining_events.len() < event_count {
-                    // some events were queued directly, notify the event_sender
-                    if let Err(e) = config.common_state.notify_telemetry_event().await {
-                        logger_manager::write_warn(format!(
-                        "report_generic_event: failed to notify telemetry event with error: {e}"
-                    ));
-                    };
-                }
-
-                // return the possible remaining events
-                remaining_events
-            }
-            None => events,
-        };
+        // Try to send the events directly first; any events that cannot be sent
+        // directly fall back to being buffered on disk below.
+        let events: Vec<Event> = direct_send(events).await;
         if events.is_empty() {
             // all events were queued directly, skip the rest
             continue;
@@ -359,17 +438,11 @@ mod tests {
         // Start the event logger loop and set the EVENTS_DIR
         let cloned_events_dir = events_dir.to_path_buf();
         tokio::spawn(async {
-            super::start(
-                cloned_events_dir,
-                Duration::from_millis(100),
-                3,
-                None,
-                |_| {
-                    async {
-                        // do nothing
-                    }
-                },
-            )
+            super::start(cloned_events_dir, Duration::from_millis(100), 3, |_| {
+                async {
+                    // do nothing
+                }
+            })
             .await;
         });
 
@@ -472,5 +545,108 @@ mod tests {
         }
         // wait for the queue write to event folder
         tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    fn create_direct_send_config() -> super::DirectSendConfig {
+        let common_state =
+            crate::common_state::CommonState::start_new(tokio_util::sync::CancellationToken::new());
+        super::DirectSendConfig::new(
+            "ProxyAgent".to_string(),
+            "MicrosoftAzureGuestProxyAgent".to_string(),
+            Some("1.0.0".to_string()),
+            common_state,
+        )
+    }
+
+    fn create_event(message: &str) -> crate::telemetry::Event {
+        crate::telemetry::Event::new(
+            "Informational".to_string(),
+            message.to_string(),
+            "test_task".to_string(),
+            "test_module".to_string(),
+        )
+    }
+
+    #[tokio::test]
+    async fn try_direct_send_events_empty_input() {
+        let config = create_direct_send_config();
+
+        // Empty input must return empty without touching the enqueue path.
+        let remaining = super::try_direct_send_events_with(Vec::new(), &config, |_, _, _, _| {
+            panic!("enqueue should not be called for empty input");
+        })
+        .await;
+
+        assert!(
+            remaining.is_empty(),
+            "Empty input should produce no remaining events"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_direct_send_events_all_enqueued() {
+        let config = create_direct_send_config();
+        let events = vec![
+            create_event("event 1"),
+            create_event("event 2"),
+            create_event("event 3"),
+        ];
+
+        // Every event is accepted by the direct path, so nothing falls back to disk.
+        let remaining =
+            super::try_direct_send_events_with(events, &config, |_, _, _, _| Ok(())).await;
+
+        assert!(
+            remaining.is_empty(),
+            "All events were enqueued, none should remain for disk fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_direct_send_events_all_fail_back_to_disk() {
+        let config = create_direct_send_config();
+        let events = vec![create_event("event 1"), create_event("event 2")];
+        let expected_messages: Vec<String> = events.iter().map(|e| e.Message.clone()).collect();
+
+        // Every enqueue fails, so all events must be returned for disk fallback,
+        // preserving order.
+        let remaining = super::try_direct_send_events_with(events, &config, |_, _, _, _| {
+            Err(crate::error::Error::EnqueueEvent("queue full".to_string()))
+        })
+        .await;
+
+        let remaining_messages: Vec<String> = remaining.iter().map(|e| e.Message.clone()).collect();
+        assert_eq!(
+            remaining_messages, expected_messages,
+            "All events should fall back to disk (in order) when enqueue fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn try_direct_send_events_partial_fallback() {
+        let config = create_direct_send_config();
+        let events = vec![
+            create_event("send-ok"),
+            create_event("force-fail"),
+            create_event("send-ok"),
+        ];
+
+        // Only the event whose message is "force-fail" cannot be enqueued and
+        // therefore must be returned for disk fallback.
+        let remaining = super::try_direct_send_events_with(events, &config, |event, _, _, _| {
+            if event.Message == "force-fail" {
+                Err(crate::error::Error::EnqueueEvent("queue full".to_string()))
+            } else {
+                Ok(())
+            }
+        })
+        .await;
+
+        assert_eq!(
+            remaining.len(),
+            1,
+            "Only the event that failed to enqueue should remain"
+        );
+        assert_eq!(remaining[0].Message, "force-fail");
     }
 }

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -649,4 +649,32 @@ mod tests {
         );
         assert_eq!(remaining[0].Message, "force-fail");
     }
+
+    #[tokio::test]
+    async fn try_direct_send_events_notify_failed() {
+        let config = create_direct_send_config();
+        let events = vec![
+            create_event("event 1"),
+            create_event("event 2"),
+            create_event("event 3"),
+        ];
+
+        config.common_state.cancel_cancellation_token();
+        // Wait for the cancellation to take effect
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // check that the cancellation is effective
+        assert!(
+            config.common_state.notify_telemetry_event().await.is_err(),
+            "Expected error when notifying telemetry event after cancellation"
+        );
+
+        // Every event is accepted by the direct path, even failed to notify the event_sender.
+        let remaining =
+            super::try_direct_send_events_with(events, &config, |_, _, _, _| Ok(())).await;
+        assert!(
+            remaining.is_empty(),
+            "All events were enqueued, none should remain for disk fallback"
+        );
+    }
 }

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+use crate::common_state::CommonState;
 use crate::logger::logger_manager;
 use crate::misc_helpers;
 use crate::telemetry::Event;
@@ -18,12 +19,39 @@ static EVENT_QUEUE: Lazy<ConcurrentQueue<Event>> =
 static SHUT_DOWN: Lazy<Arc<AtomicBool>> = Lazy::new(|| Arc::new(AtomicBool::new(false)));
 /// Store the event directory path, so that other modules can access it if needed.
 static EVENTS_DIR: tokio::sync::OnceCell<PathBuf> = tokio::sync::OnceCell::const_new();
+static DIRECT_SEND_CONFIG: tokio::sync::OnceCell<DirectSendConfig> =
+    tokio::sync::OnceCell::const_new();
 const MAX_EXTENSION_EVENT_FILE_COUNT: usize = 1000;
+
+#[derive(Clone, Debug)]
+pub struct DirectSendConfig {
+    execution_mode: String,
+    event_name: String,
+    version: Option<String>,
+    common_state: CommonState,
+}
+
+impl DirectSendConfig {
+    pub fn new(
+        execution_mode: String,
+        event_name: String,
+        version: Option<String>,
+        common_state: CommonState,
+    ) -> Self {
+        Self {
+            execution_mode,
+            event_name,
+            version,
+            common_state,
+        }
+    }
+}
 
 pub async fn start<F, Fut>(
     event_dir: PathBuf,
     mut interval: Duration,
     max_event_file_count: usize,
+    direct_send_config: Option<DirectSendConfig>,
     set_status_fn: F,
 ) where
     F: Fn(String) -> Fut,
@@ -43,6 +71,13 @@ pub async fn start<F, Fut>(
         let message = "Event directory is already set, cannot set it again.";
         set_status_fn(message.to_string());
         logger_manager::write_log(Level::Warn, message.to_string());
+    }
+    if let Some(config) = direct_send_config.clone() {
+        if DIRECT_SEND_CONFIG.set(config).is_err() {
+            let message = "DirectSendConfig is already set, cannot set it again.";
+            set_status_fn(message.to_string());
+            logger_manager::write_log(Level::Warn, message.to_string());
+        }
     }
 
     let shutdown = SHUT_DOWN.clone();
@@ -73,9 +108,47 @@ pub async fn start<F, Fut>(
 
         let mut events: Vec<Event> = Vec::new();
         events.reserve_exact(EVENT_QUEUE.len());
-
         for event in EVENT_QUEUE.try_iter() {
             events.push(event);
+        }
+
+        // Try to send the events directly via the in-memory telemetry queue
+        // first, so VMs without disk write permission can still report
+        // telemetry. Any events that cannot be enqueued directly (the direct
+        // path is None or the queue is full/closed) fall back to being
+        // buffered on disk below.
+        let events: Vec<Event> = match &direct_send_config {
+            Some(config) => {
+                let event_count = events.len();
+                let remaining_events: Vec<Event> = events
+                    .into_iter()
+                    .filter(|event| {
+                        crate::telemetry::event_sender::try_enqueue_generic_event(
+                            event,
+                            config.execution_mode.clone(),
+                            config.event_name.clone(),
+                            config.version.clone(),
+                        )
+                        .is_err()
+                    })
+                    .collect();
+                if remaining_events.len() < event_count {
+                    // some events were queued directly, notify the event_sender
+                    if let Err(e) = config.common_state.notify_telemetry_event().await {
+                        logger_manager::write_warn(format!(
+                        "report_generic_event: failed to notify telemetry event with error: {e}"
+                    ));
+                    };
+                }
+
+                // return the possible remaining events
+                remaining_events
+            }
+            None => events,
+        };
+        if events.is_empty() {
+            // all events were queued directly, skip the rest
+            continue;
         }
 
         // Check the event file counts,
@@ -173,6 +246,27 @@ pub async fn report_extension_status_event(
     extension: crate::telemetry::Extension,
     operation_status: crate::telemetry::OperationStatus,
 ) {
+    let event = crate::telemetry::ExtensionStatusEvent::new(extension, operation_status);
+
+    if let Some(config) = DIRECT_SEND_CONFIG.get() {
+        // Try to send the event directly via the in-memory telemetry queue first,
+        // so VMs without disk write permission can still report telemetry.
+        // If the queue is full/closed, fall back to buffering the event on disk.
+        if crate::telemetry::event_sender::try_enqueue_extension_event(
+            &event,
+            config.execution_mode.clone(),
+        )
+        .is_ok()
+        {
+            if let Err(e) = config.common_state.notify_telemetry_event().await {
+                logger_manager::write_warn(format!(
+                        "report_extension_status_event: failed to notify telemetry event with error: {e}"
+                    ));
+            }
+            return;
+        }
+    }
+
     let event_dir = match EVENTS_DIR.get() {
         Some(dir) => dir.clone(),
         None => {
@@ -207,7 +301,6 @@ pub async fn report_extension_status_event(
         }
     }
 
-    let event = crate::telemetry::ExtensionStatusEvent::new(extension, operation_status);
     let mut file_path = event_dir.to_path_buf();
     file_path.push(crate::telemetry::new_extension_event_file_name());
     if let Err(e) = misc_helpers::json_write_to_file_async(&event, &file_path).await {
@@ -266,11 +359,17 @@ mod tests {
         // Start the event logger loop and set the EVENTS_DIR
         let cloned_events_dir = events_dir.to_path_buf();
         tokio::spawn(async {
-            super::start(cloned_events_dir, Duration::from_millis(100), 3, |_| {
-                async {
-                    // do nothing
-                }
-            })
+            super::start(
+                cloned_events_dir,
+                Duration::from_millis(100),
+                3,
+                None,
+                |_| {
+                    async {
+                        // do nothing
+                    }
+                },
+            )
             .await;
         });
 

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -5,13 +5,9 @@
 //! //! The telemetry event files are written by the event_logger module.
 
 use crate::common_state::CommonState;
-use crate::current_info;
 use crate::logger::logger_manager;
 use crate::misc_helpers;
 use crate::telemetry::event_sender;
-use crate::telemetry::telemetry_event::TelemetryEvent;
-use crate::telemetry::telemetry_event::TelemetryExtensionEventsEvent;
-use crate::telemetry::telemetry_event::TelemetryGenericLogsEvent;
 use crate::telemetry::Event;
 use std::fs::remove_file;
 use std::path::PathBuf;
@@ -207,15 +203,19 @@ impl EventReader {
         while !events.is_empty() {
             match events.pop() {
                 Some(event) => {
-                    let telemetry_event = TelemetryGenericLogsEvent::from_event_log(
+                    if let Err(e) = event_sender::try_enqueue_generic_event(
                         &event,
                         self.execution_mode.clone(),
                         self.event_name.clone(),
                         self.limits.version.clone(),
-                    );
-                    let telemetry_event = TelemetryEvent::GenericLogsEvent(telemetry_event);
-                    event_sender::enqueue_event(telemetry_event);
-                    queued_event = true;
+                    ) {
+                        logger_manager::write_warn(format!(
+                            "Failed to enqueue generic event: {}",
+                            e
+                        ));
+                    } else {
+                        queued_event = true;
+                    }
                 }
                 None => {
                     break;
@@ -292,6 +292,14 @@ impl EventReader {
                 logger_manager::write_info( format!(
                     "Telemetry event reader sent {event_count} extension status events from {file_count} files"
                 ));
+
+                if event_count > 0 {
+                    if let Err(e) = self.common_state.notify_telemetry_event().await {
+                        logger_manager::write_warn(format!(
+                            "Failed to notify telemetry event with error: {e}"
+                        ));
+                    }
+                }
             }
             Err(e) => {
                 logger_manager::write_warn(format!(
@@ -305,22 +313,16 @@ impl EventReader {
     }
 
     async fn process_one_extension_status_event_file(&self, file: PathBuf) -> usize {
-        let mut num_events_logged = 0;
+        let mut num_events_processed = 0;
 
         match misc_helpers::json_read_from_file::<crate::telemetry::ExtensionStatusEvent>(&file) {
             Ok(event) => {
-                num_events_logged += 1;
-                let telemetry_event = TelemetryExtensionEventsEvent::from_extension_status_event(
-                    &event,
-                    self.execution_mode.clone(),
-                    current_info::get_current_exe_version(),
-                );
-                let telemetry_event = TelemetryEvent::ExtensionEvent(telemetry_event);
-                event_sender::enqueue_event(telemetry_event);
-                if let Err(e) = self.common_state.notify_telemetry_event().await {
-                    logger_manager::write_warn(format!(
-                        "Failed to notify telemetry event with error: {e}"
-                    ));
+                if let Err(e) =
+                    event_sender::try_enqueue_extension_event(&event, self.execution_mode.clone())
+                {
+                    logger_manager::write_warn(format!("Failed to enqueue extension event: {}", e));
+                } else {
+                    num_events_processed += 1;
                 }
             }
             Err(e) => {
@@ -333,7 +335,7 @@ impl EventReader {
         }
 
         Self::clean_file(file);
-        num_events_logged
+        num_events_processed
     }
 }
 

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -172,10 +172,10 @@ impl EventSender {
     }
 }
 
-/// Try to enqueue a generic log event directly into the in-memory telemetry queue.
+/// Try to enqueue a generic log event into the in-memory telemetry queue.
 ///
 /// Returns `Err` if the queue is full/closed.
-pub fn try_enqueue_generic_event(
+pub(crate) fn try_enqueue_generic_event(
     event: &Event,
     execution_mode: String,
     event_name: String,
@@ -189,11 +189,9 @@ pub fn try_enqueue_generic_event(
         .map_err(|e| crate::error::Error::EnqueueEvent(format!("{e}")))
 }
 
-/// Try to enqueue an extension status event directly into the in-memory
-/// telemetry queue, bypassing the on-disk buffer.
+/// Try to enqueue an extension status event into the in-memory telemetry queue.
 ///
-/// Returns `Err` if the direct path is disabled (config not set) or the queue
-/// is full/closed, so the caller can fall back to buffering on disk.
+/// Returns `Err` if the queue is full/closed.
 pub(crate) fn try_enqueue_extension_event(
     event: &ExtensionStatusEvent,
     execution_mode: String,

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -2,15 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 //! This module contains the logic to send the telemetry event to the wire server.
-use std::time::Duration;
-
 use crate::common_state::CommonState;
+use crate::current_info;
 use crate::host_clients::imds_client::ImdsClient;
 use crate::host_clients::wire_server_client::WireServerClient;
 use crate::logger::{logger_manager, LoggerLevel};
-use crate::telemetry::telemetry_event::{TelemetryData, TelemetryEvent, TelemetryEventVMData};
+use crate::result::Result;
+use crate::telemetry::telemetry_event::{
+    TelemetryData, TelemetryEvent, TelemetryEventVMData, TelemetryExtensionEventsEvent,
+    TelemetryGenericLogsEvent,
+};
+use crate::telemetry::{Event, ExtensionStatusEvent};
 use concurrent_queue::ConcurrentQueue;
 use once_cell::sync::Lazy;
+use std::time::Duration;
 
 static TELEMETRY_EVENT_QUEUE: Lazy<ConcurrentQueue<TelemetryEvent>> =
     Lazy::new(|| ConcurrentQueue::<TelemetryEvent>::bounded(1000));
@@ -167,10 +172,41 @@ impl EventSender {
     }
 }
 
-pub(crate) fn enqueue_event(event: TelemetryEvent) {
-    if let Err(e) = TELEMETRY_EVENT_QUEUE.push(event) {
-        logger_manager::write_warn(format!("Failed to enqueue telemetry event with error: {e}"));
-    }
+/// Try to enqueue a generic log event directly into the in-memory telemetry queue.
+///
+/// Returns `Err` if the queue is full/closed.
+pub fn try_enqueue_generic_event(
+    event: &Event,
+    execution_mode: String,
+    event_name: String,
+    version: Option<String>,
+) -> Result<()> {
+    let telemetry_event =
+        TelemetryGenericLogsEvent::from_event_log(event, execution_mode, event_name, version);
+    let telemetry_event = TelemetryEvent::GenericLogsEvent(telemetry_event);
+    TELEMETRY_EVENT_QUEUE
+        .push(telemetry_event)
+        .map_err(|e| crate::error::Error::EnqueueEvent(format!("{e}")))
+}
+
+/// Try to enqueue an extension status event directly into the in-memory
+/// telemetry queue, bypassing the on-disk buffer.
+///
+/// Returns `Err` if the direct path is disabled (config not set) or the queue
+/// is full/closed, so the caller can fall back to buffering on disk.
+pub(crate) fn try_enqueue_extension_event(
+    event: &ExtensionStatusEvent,
+    execution_mode: String,
+) -> Result<()> {
+    let telemetry_event = TelemetryExtensionEventsEvent::from_extension_status_event(
+        event,
+        execution_mode,
+        current_info::get_current_exe_version(),
+    );
+    let telemetry_event = TelemetryEvent::ExtensionEvent(telemetry_event);
+    TELEMETRY_EVENT_QUEUE
+        .push(telemetry_event)
+        .map_err(|e| crate::error::Error::EnqueueEvent(format!("{e}")))
 }
 
 #[cfg(test)]
@@ -194,6 +230,14 @@ mod tests {
             resource_group_name: "test-resource-group".to_string(),
             vm_id: "test-vm-id".to_string(),
             image_origin: 1,
+        }
+    }
+
+    fn enqueue_event(event: TelemetryEvent) {
+        if let Err(e) = TELEMETRY_EVENT_QUEUE.push(event) {
+            logger_manager::write_warn(format!(
+                "Failed to enqueue telemetry event with error: {e}"
+            ));
         }
     }
 


### PR DESCRIPTION
- `DirectSendConfig` defined in event_logger.rs and carries the execution_mode, event_name, optional version, and a CommonState handle (used to notify the sender).
- A background loop in `event_logger::start_with_direct_send`, with `DirectSendConfig`, wakes every 60 seconds and drains EVENT_QUEUE, each event is first attempted on the direct in-memory send path `event_sender::try_enqueue_generic_event`, which converts it and pushes it straight into the EventSender's TELEMETRY_EVENT_QUEUE. If at least one event was enqueued directly, the loop calls `common_state.notify_telemetry_event()` to wake the sender. Only events that cannot be enqueued directly fall back to disk.
- `report_extension_status_event` tries the direct path first via `event_sender::try_enqueue_extension_event` and, on success, notifies the sender and returns; otherwise it falls back to disk.
- Added TelemetryEventFlow.md file under doc folder for more design details.