### PR TITLE
Add azure-proxy-agent manpage.

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -198,6 +198,7 @@ fi
 echo "======= copy to package folder"
 cp -f $out_dir/proxy_agent_setup $out_package_dir/
 cp -f $out_dir/azure-proxy-agent.service $out_package_dir/
+cp -f $out_dir/azure-proxy-agent.8 $out_package_dir/
 
 out_package_proxyagent_dir=$out_package_dir/ProxyAgent
 if [ ! -d $out_package_proxyagent_dir ]; then
@@ -251,6 +252,7 @@ pushd debbuild
     cp -f $out_package_proxyagent_dir/azure-proxy-agent ./
     cp -f $out_package_proxyagent_dir/proxy-agent.json ./
     cp -f $out_package_proxyagent_dir/ebpf_cgroup.o ./
+    cp -f $out_package_dir/azure-proxy-agent.8 ./
     cp -f $out_package_dir/azure-proxy-agent.service ./DEBIAN/
     sed -i "s/pkgversion/${pkgversion}/g" DEBIAN/control  # replace pkgversion with actual version
     sed -i "s/pkgversion/${pkgversion}/g" DEBIAN/postinst  # replace pkgversion with actual version

--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -114,4 +114,5 @@ assets = [
     ["azure-proxy-agent", "usr/sbin/azure-proxy-agent", "755"],  # Binary
     ["proxy-agent.json", "etc/azure/proxy-agent.json", "644"],
     ["ebpf_cgroup.o", "usr/lib/azure-proxy-agent/ebpf_cgroup.o", "644"],
+    ["azure-proxy-agent.8", "usr/share/man/man8/azure-proxy-agent.8", "644"],  # Man page (cargo-deb gzips it)
 ]

--- a/proxy_agent_setup/src/linux.rs
+++ b/proxy_agent_setup/src/linux.rs
@@ -9,11 +9,33 @@ use std::{fs, path::PathBuf};
 const SERVICE_CONFIG_FILE_NAME: &str = "azure-proxy-agent.service";
 const CONFIG_FILE: &str = "proxy-agent.json";
 const EBPF_FILE: &str = "ebpf_cgroup.o";
+const MAN_FILE: &str = "azure-proxy-agent.8";
 const CONFIG_PATH: &str = "/etc/azure/proxy-agent.json";
 const EBPF_PATH: &str = "/usr/lib/azure-proxy-agent/ebpf_cgroup.o";
+const MAN_PATH: &str = "/usr/share/man/man8/azure-proxy-agent.8";
 
 pub fn setup_service(service_name: &str, service_file_dir: PathBuf) -> Result<()> {
-    copy_service_config_file(service_name, service_file_dir)
+    copy_service_config_file(service_name, service_file_dir.clone())?;
+    copy_man_page(service_file_dir);
+    Ok(())
+}
+
+// Install the man page (staged next to the service config file) so that
+// `man azure-proxy-agent` works on extension-based installs, matching the
+// distro (.deb/.rpm) packages. Older packages may not ship the man page, in
+// which case this is a no-op.
+fn copy_man_page(src_folder: PathBuf) {
+    let man_src = src_folder.join(MAN_FILE);
+    if !man_src.exists() {
+        return;
+    }
+    copy_file(man_src, PathBuf::from(MAN_PATH));
+    if let Err(e) = proxy_agent_shared::linux::set_file_permissions(&PathBuf::from(MAN_PATH), 0o644)
+    {
+        logger::write_error(format!(
+            "Failed to set man page file permission to 644 with error: {e}"
+        ));
+    }
 }
 
 fn copy_service_config_file(service_name: &str, service_file_dir: PathBuf) -> Result<()> {
@@ -99,6 +121,12 @@ pub fn backup_files() {
         running::proxy_agent_running_folder("").join("azure-proxy-agent"),
         backup_folder.join("azure-proxy-agent"),
     );
+    // back up the man page next to the service config file so restore can
+    // reinstall it from the same folder.
+    copy_file(
+        PathBuf::from(MAN_PATH),
+        backup::proxy_agent_backup_folder().join(MAN_FILE),
+    );
     backup_service_config_file(backup::proxy_agent_backup_folder());
 }
 
@@ -134,4 +162,5 @@ pub fn delete_files() {
     delete_file(proxy_agent_running_folder.join("azure-proxy-agent"));
     delete_file(PathBuf::from(crate::linux::CONFIG_PATH));
     delete_file(PathBuf::from(crate::linux::EBPF_PATH));
+    delete_file(PathBuf::from(crate::linux::MAN_PATH));
 }

--- a/proxy_agent_setup/src/linux/azure-proxy-agent.8
+++ b/proxy_agent_setup/src/linux/azure-proxy-agent.8
@@ -1,0 +1,103 @@
+.\" Copyright (c) Microsoft Corporation
+.\" SPDX-License-Identifier: MIT
+.\"
+.\" Manual page for the Azure Guest Proxy Agent (GPA).
+.TH AZURE-PROXY-AGENT 8 "2026-06-25" "Azure Guest Proxy Agent" "System Administration Utilities"
+.SH NAME
+azure\-proxy\-agent \- Azure Guest Proxy Agent daemon
+.SH SYNOPSIS
+.B azure\-proxy\-agent
+.RB [ \-\-status " [" \-\-wait
+.IR seconds ]]
+.br
+.B azure\-proxy\-agent
+.B \-\-version
+.br
+.B azure\-proxy\-agent
+.B console
+.SH DESCRIPTION
+.B azure\-proxy\-agent
+is the Azure Guest Proxy Agent (GPA), a daemon that runs inside an Azure
+guest virtual machine. It transparently secures and authorizes the
+communication between the guest operating system and the Azure host
+endpoints (such as the Wire Server and the Instance Metadata Service),
+enforcing access policy on that traffic.
+.PP
+The agent is normally managed as a systemd service
+.RB ( azure\-proxy\-agent.service )
+and started automatically at boot. When invoked with no arguments it runs
+as a long\-lived background service. The options below are intended for
+manual inspection and troubleshooting.
+.SH OPTIONS
+.TP
+.BR \-s ", " \-\-status
+Print the provisioning status of the running GPA service and exit.
+.TP
+.BR \-w ", " \-\-wait " " \fIseconds\fR
+Wait up to
+.I seconds
+for provisioning to reach a terminal state before printing the status.
+Must be used together with
+.BR \-\-status .
+.TP
+.BR \-v ", " \-\-version
+Print the version of the GPA and exit.
+.TP
+.BR \-h ", " \-\-help
+Print a short usage message and exit.
+.SH COMMANDS
+.TP
+.B console
+Run the GPA in the foreground (console mode) instead of as a background
+service. Logs are written to standard output. This is primarily useful for
+debugging.
+.SH FILES
+.TP
+.I /usr/sbin/azure-proxy-agent
+The GPA daemon executable.
+.TP
+.I /etc/azure/proxy-agent.json
+Runtime configuration file for the GPA.
+.TP
+.I /usr/lib/systemd/system/azure-proxy-agent.service
+The systemd service unit for the GPA.
+.TP
+.I /usr/lib/azure-proxy-agent/ebpf_cgroup.o
+Compiled eBPF program loaded by the GPA on Linux.
+.TP
+.I /var/log/azure-proxy-agent/
+Log directory, including the provisioning status file
+.RI ( status.json ).
+.TP
+.I /var/lib/azure-proxy-agent/
+Runtime state directory.
+.SH EXIT STATUS
+.TP
+.B 0
+Success.
+.TP
+.B non-zero
+An error occurred.
+.SH EXAMPLES
+.TP
+Show the agent version:
+.B azure\-proxy\-agent \-\-version
+.TP
+Query provisioning status, waiting up to 30 seconds:
+.B azure\-proxy\-agent \-\-status \-\-wait 30
+.TP
+Inspect the service through systemd:
+.B systemctl status azure\-proxy\-agent.service
+.SH SEE ALSO
+.BR systemctl (1),
+.BR journalctl (1),
+.BR systemd.service (5)
+.SH BUGS
+Report bugs at
+.UR https://github.com/Azure/GuestProxyAgent/issues
+.UE .
+.SH AUTHOR
+Microsoft Azure RT ProxyAgent V Team
+.RB < ARTProxyAgentVTeam@microsoft.com >.
+.SH COPYRIGHT
+Copyright (c) Microsoft Corporation. Licensed under the MIT License.

--- a/rpm-build/SPECS/azure-proxy-agent.spec
+++ b/rpm-build/SPECS/azure-proxy-agent.spec
@@ -22,10 +22,13 @@ mkdir -p %{buildroot}/usr/sbin/
 mkdir -p %{buildroot}/etc/azure/
 mkdir -p %{buildroot}/usr/lib/systemd/system/
 mkdir -p %{buildroot}/usr/lib/azure-proxy-agent/
+mkdir -p %{buildroot}/usr/share/man/man8/
 cp -f ./package/ProxyAgent/proxy-agent.json %{buildroot}/etc/azure/
 cp -f ./package/azure-proxy-agent.service %{buildroot}/usr/lib/systemd/system/
 cp -f ./package/ProxyAgent/ebpf_cgroup.o %{buildroot}/usr/lib/azure-proxy-agent/
 cp -f ./package/ProxyAgent/azure-proxy-agent %{buildroot}/usr/sbin/
+cp -f ./package/azure-proxy-agent.8 %{buildroot}/usr/share/man/man8/
+gzip -nf9 %{buildroot}/usr/share/man/man8/azure-proxy-agent.8
 
 %post
 %systemd_post azure-proxy-agent.service
@@ -40,6 +43,7 @@ cp -f ./package/ProxyAgent/azure-proxy-agent %{buildroot}/usr/sbin/
 /usr/sbin/azure-proxy-agent
 /etc/azure/proxy-agent.json
 /usr/lib/azure-proxy-agent/ebpf_cgroup.o
+/usr/share/man/man8/azure-proxy-agent.8.gz
 
 %changelog
 * Fri Sep 13 23:43:30 UTC 2024 - ARTProxyAgentVTeam@microsoft.com


### PR DESCRIPTION
**Quick macro cheat-sheet for azure-proxy-agent.8**
Macro | Meaning
-- | --
.TH | Title header (page metadata)
.SH | Section heading
.SS | Subsection heading
.PP / .LP | New paragraph
.TP | Tagged paragraph (hanging indent list)
.B / .I / .R | Whole-line bold / italic / roman
.BR .RB .IR .RI etc. | Alternate between two fonts word-by-word
\fB \fI \fR | Inline font switch (bold/italic/roman)
.br | Forced line break
.UR / .UE | URL start / end
\\- | Literal minus/hyphen
.\\" | Comment

The overall ordering here (NAME → SYNOPSIS → DESCRIPTION → OPTIONS → FILES → EXIT STATUS → EXAMPLES → SEE ALSO → BUGS → AUTHOR → COPYRIGHT) is the conventional man-page layout.

