### PR TITLE
Append failing eBPF dependency status to GPA service start failure error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -274,7 +274,23 @@ async fn setup_service(proxy_agent_target_folder: PathBuf, _service_config_folde
             logger::write(format!("Service {SERVICE_NAME} start successfully"));
         }
         Err(e) => {
-            logger::write_error(format!("Service {SERVICE_NAME} start failed, error: {e:?}"));
+            #[cfg(windows)]
+            {
+                let core_status = service::check_service_status("EbpfCore");
+                let ext_status = service::check_service_status("NetEbpfExt");
+                match failing_ebpf_deps_message(&core_status, &ext_status) {
+                    Some(deps) => logger::write_error(format!(
+                        "Service {SERVICE_NAME} start failed, error: {e:?}. {deps}"
+                    )),
+                    None => logger::write_error(format!(
+                        "Service {SERVICE_NAME} start failed, error: {e:?}"
+                    )),
+                }
+            }
+            #[cfg(not(windows))]
+            {
+                logger::write_error(format!("Service {SERVICE_NAME} start failed, error: {e:?}"));
+            }
             process::exit(1);
         }
     }
@@ -338,4 +354,90 @@ fn delete_folder(folder_to_be_delete: PathBuf) {
 fn delete_backup_folder() {
     let backup_folder = backup::proxy_agent_backup_folder();
     delete_folder(backup_folder);
+}
+
+/// Returns a message describing any EbpfCore/NetEbpfExt services that are not Running,
+/// or `None` when both are healthy. Extracted as a pure function for testability.
+#[cfg(windows)]
+fn failing_ebpf_deps_message(
+    core: &service::ServiceStatusInfo,
+    ext: &service::ServiceStatusInfo,
+) -> Option<String> {
+    let failing: Vec<String> = [core, ext]
+        .iter()
+        .filter(|s| {
+            s.state
+                .as_ref()
+                .is_none_or(|st| *st != service::ServiceState::Running)
+        })
+        .map(|s| s.message())
+        .collect();
+
+    if failing.is_empty() {
+        None
+    } else {
+        Some(format!("Failing eBPF dependencies: {}", failing.join("; ")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    mod windows {
+        use proxy_agent_shared::service::{ServiceState, ServiceStatusInfo};
+
+        fn make_status(name: &str, state: Option<ServiceState>) -> ServiceStatusInfo {
+            ServiceStatusInfo {
+                service_name: name.to_string(),
+                state,
+                start_type: "AutoStart".to_string(),
+            }
+        }
+
+        #[test]
+        fn both_running_returns_none() {
+            let core = make_status("EbpfCore", Some(ServiceState::Running));
+            let ext = make_status("NetEbpfExt", Some(ServiceState::Running));
+            assert!(super::super::failing_ebpf_deps_message(&core, &ext).is_none());
+        }
+
+        #[test]
+        fn both_not_installed_returns_both_names() {
+            let core = make_status("EbpfCore", None);
+            let ext = make_status("NetEbpfExt", None);
+            let msg = super::super::failing_ebpf_deps_message(&core, &ext).unwrap();
+            assert!(msg.contains("EbpfCore"), "expected EbpfCore in: {msg}");
+            assert!(msg.contains("NetEbpfExt"), "expected NetEbpfExt in: {msg}");
+        }
+
+        #[test]
+        fn core_not_installed_ext_running_returns_core_only() {
+            let core = make_status("EbpfCore", None);
+            let ext = make_status("NetEbpfExt", Some(ServiceState::Running));
+            let msg = super::super::failing_ebpf_deps_message(&core, &ext).unwrap();
+            assert!(msg.contains("EbpfCore"), "expected EbpfCore in: {msg}");
+            assert!(
+                !msg.contains("NetEbpfExt"),
+                "unexpected NetEbpfExt in: {msg}"
+            );
+        }
+
+        #[test]
+        fn core_running_ext_stopped_returns_ext_only() {
+            let core = make_status("EbpfCore", Some(ServiceState::Running));
+            let ext = make_status("NetEbpfExt", Some(ServiceState::Stopped));
+            let msg = super::super::failing_ebpf_deps_message(&core, &ext).unwrap();
+            assert!(!msg.contains("EbpfCore"), "unexpected EbpfCore in: {msg}");
+            assert!(msg.contains("NetEbpfExt"), "expected NetEbpfExt in: {msg}");
+        }
+
+        #[test]
+        fn both_stopped_returns_both_names() {
+            let core = make_status("EbpfCore", Some(ServiceState::Stopped));
+            let ext = make_status("NetEbpfExt", Some(ServiceState::Stopped));
+            let msg = super::super::failing_ebpf_deps_message(&core, &ext).unwrap();
+            assert!(msg.contains("EbpfCore"), "expected EbpfCore in: {msg}");
+            assert!(msg.contains("NetEbpfExt"), "expected NetEbpfExt in: {msg}");
+        }
+    }
 }


### PR DESCRIPTION
## Overview

When `GuestProxyAgent` fails to start due to missing or unhealthy eBPF dependencies (SCM errors 1068 / 1075), the error log previously only contained the raw SCM error with no actionable context:

```
Service 'GuestProxyAgent' failed to start after 4 attempts
```

This change queries `EbpfCore` and `NetEbpfExt` immediately after a start failure and appends any non-Running services to the error message, so on-call responders can identify the root cause without manual investigation.

## High Level Code Changes

#### `proxy_agent_setup/src/main.rs`

- Added a `failing_ebpf_deps_message` pure helper function (Windows-only) that takes two `ServiceStatusInfo` values and returns `None` when both are healthy, or `Some("Failing eBPF dependencies: ...")` listing only the non-Running ones.
- On start failure, the helper is called and its output appended inline to the single `write_error` call — no extra log lines when eBPF is healthy.
- Added 5 unit tests covering all meaningful state combinations: both running (None), both missing, each individually missing or stopped.

## Testing

Manually replaced `proxy_agent_setup.exe` in a VM, renamed the eBPF setup script to prevent auto-recovery, deleted both eBPF driver services, then ran `proxy_agent_setup.exe install`:

```
C:\Packages\Plugins\Microsoft.CPlat.ProxyAgent.ProxyAgentWindowsTest\1.0.41\ProxyAgent>sc delete EbpfCore
[SC] DeleteService SUCCESS

C:\Packages\Plugins\Microsoft.CPlat.ProxyAgent.ProxyAgentWindowsTest\1.0.41\ProxyAgent>sc delete NetEbpfExt
[SC] DeleteService SUCCESS

C:\Packages\Plugins\Microsoft.CPlat.ProxyAgent.ProxyAgentWindowsTest\1.0.41\ProxyAgent>proxy_agent_setup.exe install


============== ProxyAgent Setup Tool (9.9.9.0) is starting with args: install ==============
Stopped service GuestProxyAgent successfully
[... file copy output ...]
Install service GuestProxyAgent successfully
ebpf_setup: check_service_installed: service: eBPFSvc successfully queried.
Update service GuestProxyAgent with more service_dependency successfully
Service 'GuestProxyAgent' failed to start after 4 attempts
Service GuestProxyAgent start failed, error: WindowsService(Winapi(Os { code: 1068, kind: Uncategorized, message: "The dependency service or group failed to start." }), Os { code: 1068, kind: Uncategorized, message: "The dependency service or group failed to start." }). Failing eBPF dependencies: service: EbpfCore status query failed, service may not be installed; service: NetEbpfExt status query failed, service may not be installed
```

