### PR TITLE
Fix the rust-clippy and bloat issues for rust-1.97

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -124,7 +124,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.apt_packages }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -798,12 +798,12 @@ pub async fn get_status(host: &str, port: u16) -> Result<KeyStatus> {
     .await?;
 
     if !response.status().is_success() {
-        return Err(proxy_agent_shared::error::Error::Hyper(
+        return Err(Error::Hyper(
             proxy_agent_shared::error::HyperErrorType::ServerError(
                 endpoint.to_string(),
                 response.status(),
             ),
-        ))?;
+        ));
     }
 
     if proxy_agent_shared::misc_helpers::host_time_sync_is_stale(HOST_DATE_TIME_DRIFT_MAX_AGE) {

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -130,7 +130,7 @@ impl ProxyServer {
 
     pub async fn start(&self) {
         let addr = format!("{}:{}", std::net::Ipv4Addr::LOCALHOST, self.port);
-        logger::write_information(format!("Start proxy listener at '{}'.", &addr));
+        logger::write_information(format!("Start proxy listener at '{addr}'.",));
 
         let listener = match Self::start_listener_with_retry(
             &addr,

--- a/proxy_agent_setup/src/running.rs
+++ b/proxy_agent_setup/src/running.rs
@@ -44,7 +44,7 @@ pub fn proxy_agent_version_target_folder(proxy_agent_exe: &Path) -> PathBuf {
             panic!("Failed to get proxy agent version with error: {e}");
         }
     };
-    logger::write(format!("Proxy agent version: {}", &proxy_agent_version));
+    logger::write(format!("Proxy agent version: {proxy_agent_version}",));
     #[cfg(windows)]
     {
         let path = proxy_agent_parent_folder();


### PR DESCRIPTION
Fixing two new rust-clippy issues from 1.97
- https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
- https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#needless_return_with_question_mark
Pin the rustc version to 1.95 in bloat