### PR TITLE
Add mintdh.dll to cover the loaded modules test in WS2019

### DIFF
--- a/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
+++ b/e2etest/GuestProxyAgentTest/Resources/GuestProxyAgentLoadedModulesBaseline.txt
@@ -41,3 +41,4 @@ msvcp_win.dll
 symsrv.dll
 shlwapi.dll
 tdh.dll
+mintdh.dll


### PR DESCRIPTION
Why only WS2019 (OS-version specific)
mintdh.dll is a byproduct of how a particular Windows build factored the TDH component. On WS2019 (1809 / build 17763), tdh.dll is a thin forwarder whose real implementation lives in mintdh.dll, so when TDH is used you see both tdh.dll and mintdh.dll mapped.

On the other OS legs in your test matrix (WS2022, WS2025, client SKUs, etc.), that refactoring is different — tdh.dll is self-contained (or forwards to a differently-named module), so mintdh.dll simply doesn't exist there and can never appear. That's why the other OS runs pass unchanged and only the WS2019 leg flagged it.

